### PR TITLE
docs(articles): revamp agentic workflow article with technical details

### DIFF
--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -1,18 +1,18 @@
 ---
-title: "My First Agentic Workflow: PR Quality Checks for Interns"
+title: "Pull Request Quality Checks with GitHub Agentic Workflows"
 description: "I built an agentic workflow that validates PR quality for interns using GitHub Agentic Workflows. The full sample is on GitHub."
 publishedAt: "2026-03-25"
 featured: true
-tags: ["GitHub Copilot", "GitHub Actions", "GitHub", "Agentic Workflows", "Visual Studio Code"]
+tags: ["GitHub Actions", "GitHub"]
 author: "Logan Farci"
 coauthoredWithAgent: true
 ---
 
-I started experimenting with agentic workflows by picking a narrow, high-signal problem: helping interns submit better pull requests. PR quality checks are repetitive, benefit from consistency, and are exactly the kind of thing new contributors struggle with first. The full sample is available at [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks).
+When working with interns, a good chunk of pull request review time ends up going to the same formalities: missing descriptions, vague titles, assignees left blank. These comments don't carry much technical weight, but they pile up and eat into the time I'd rather spend on actual guidance. So I built an agentic workflow to catch that stuff automatically. The full sample is available at [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks).
 
 # The Experiment
 
-The workflow validates that pull requests follow the team contract for PR quality. It does not review code.
+The workflow validates that pull requests follow the team contract for pull request quality. It does not review code.
 
 I scoped it to title format, description structure, section coherence against actual changed files, assignee presence, and PR scope focus. Implementation review, correctness, test quality, and architecture are deliberately out of scope — that smaller contract is much easier to trust.
 

--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -1,41 +1,24 @@
 ---
 title: "My First Agentic Workflow: PR Quality Checks for Interns"
-description: "I built an agentic workflow that validates pull request quality for interns, then reused the same skill in a VS Code agent to keep guidance consistent across automation and the editor."
+description: "I built an agentic workflow that validates PR quality for interns using GitHub Agentic Workflows. The full sample is on GitHub."
 publishedAt: "2026-03-25"
 featured: true
-tags: ["GitHub Copilot", "GitHub Actions", "GitHub", "Visual Studio Code"]
+tags: ["GitHub Copilot", "GitHub Actions", "GitHub", "Agentic Workflows", "Visual Studio Code"]
 author: "Logan Farci"
 coauthoredWithAgent: true
 ---
 
-I started experimenting with agentic workflows by picking a narrow, high-signal problem: helping interns submit better pull requests.
-
-PR quality checks are repetitive, benefit from consistency, and are exactly the kind of thing new contributors struggle with first. Instead of treating this as a documentation problem alone, I wanted to see what happened when I made it an agentic workflow problem.
-
-# Why Intern PRs?
-
-Interns learn several things at once: the codebase, the team workflow, the review culture, and the difference between "I changed code" and "I explained the change clearly."
-
-When the review loop starts with missing sections or vague explanations, reviewers spend time correcting process instead of helping with engineering. My goal was simple: build an agentic workflow that catches the boring-but-important PR quality issues early, gives actionable feedback, and stays consistent every time.
+I started experimenting with agentic workflows by picking a narrow, high-signal problem: helping interns submit better pull requests. PR quality checks are repetitive, benefit from consistency, and are exactly the kind of thing new contributors struggle with first. The full sample is available at [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks).
 
 # The Experiment
 
 The workflow validates that pull requests follow the team contract for PR quality. It does not review code.
 
-I scoped it to:
-- PR title format (Conventional Commits)
-- PR description structure (required sections)
-- Section coherence against actual changed files
-- Assignee presence
-- PR scope focus
-
-And I deliberately kept it away from implementation review, correctness, test quality, or architecture.
-
-That smaller scope made the experiment easier to reason about and trust.
+I scoped it to title format, description structure, section coherence against actual changed files, assignee presence, and PR scope focus. Implementation review, correctness, test quality, and architecture are deliberately out of scope — that smaller contract is much easier to trust.
 
 # How It Works
 
-The workflow runs on every PR event (opened, edited, synchronize, reopened). It reads the PR metadata and changed files, runs nine quality checks, and updates a single managed comment on the PR with only the failing items.
+The workflow runs on every PR event (opened, edited, synchronize, reopened). It reads PR metadata and changed files, runs six quality checks, and updates a single managed comment on the PR with only the failing items.
 
 ```mermaid
 flowchart LR
@@ -47,104 +30,149 @@ flowchart LR
     C -- Yes --> F[Mark workflow as pass]
 ```
 
-When everything passes, the workflow resolves cleanly without leaving extra noise. When something fails, the comment tells the author exactly what to fix:
+When everything passes, the workflow resolves cleanly without leaving extra noise. When something fails, the comment tells the author exactly what to fix. That precision matters for interns: "Improve your PR description" is not actionable. "The `Why` section restates what changed without explaining the motivation" is.
 
-- Missing required sections
-- Weak explanation in `Why`
-- Vague validation notes
-- No assignee
-- Unrelated changes bundled together
+# The Workflow Source
 
-That precision matters for interns. "Improve your PR description" is not actionable. "The `Why` section restates what changed without explaining the motivation" is.
+GitHub Agentic Workflows are defined as Markdown files with a YAML front matter block. The workflow source lives at `.github/workflows/pull-request-quality-checks.md` and looks like this:
+
+```yaml
+---
+name: PR Quality Check
+description: Validates PR title, description completeness, assignee presence, and scope focus.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, assigned, unassigned]
+  skip-bots: [dependabot, renovate, github-actions]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+engine:
+  id: copilot
+  model: gpt-5-mini
+
+tools:
+  github:
+    toolsets: [default]
+
+safe-outputs:
+  jobs:
+    upsert-pr-quality-comment:
+      description: Create or update the singleton PR quality comment for the current PR.
+      runs-on: ubuntu-latest
+      output: Upserted PR quality comment.
+      permissions:
+        contents: read
+        issues: write
+        pull-requests: write
+      inputs:
+        body:
+          description: The full PR quality comment body.
+          required: true
+          type: string
+        item_number:
+          description: The pull request number to comment on.
+          required: false
+          type: string
+        create_if_missing:
+          description: Whether to create the comment when none already exists.
+          required: false
+          type: boolean
+      steps:
+        - name: Upsert managed PR quality comment
+          uses: ./.github/actions/upsert-pr-quality-comment
+          with:
+            github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+            marker: "<!-- pr-quality-check-bot -->"
+---
+```
+
+The `safe-outputs` block defines a callable action the Copilot agent can invoke to post or update the managed PR comment. The agent instructions (the Markdown body below the front matter) tell it exactly when to call this output and with what content.
+
+You compile this source into a standard GitHub Actions YAML using the [`gh aw`](https://github.com/github/gh-aw) CLI:
+
+```bash
+gh aw compile
+```
+
+This regenerates `.github/workflows/pull-request-quality-checks.lock.yml`. Never edit the `.lock.yml` directly — it is auto-generated and will be overwritten on the next compile.
 
 # The Core Pattern: Shared Skill
 
 The most interesting part of this experiment is how the PR quality rules are defined once and consumed in two places.
 
-```mermaid
-flowchart TD
-    A[Shared PR Quality Skill] --> B[contract.md]
-    A --> C[template.md]
+The VS Code agent at `.github/agents/pr-quality-validator.agent.md` uses the same rules to coach authors locally before they push. Its YAML front matter wires it into Copilot Chat:
 
-    B --> D[Agentic Workflow]
-    C --> D
+```yaml
+---
+description: "Use this agent when the user asks to validate or improve pull requests
+  for team convention compliance.
 
-    B --> E[VS Code Agent]
-    C --> E
-
-    D --> F[Enforces checks on every PR]
-    E --> G[Helps author improve PR locally]
-
-    style D fill:#dff3e4,stroke:#2b6f3e,stroke-width:2px
-    style E fill:#eef4ff,stroke:#2c4f8f,stroke-width:1px
-    style A fill:#fff4d6,stroke:#8b6b1f,stroke-width:1px
+  Trigger phrases include:
+  - 'check if my PR meets team conventions'
+  - 'validate my PR description'
+  - 'does this PR follow our standards?'
+  - 'help me write a better PR description'
+  "
+name: Pull Request Quality Validator
+tools: [read/terminalSelection, read/terminalLastCommand, read/readFile, read/viewImage, search]
+---
 ```
 
-The shared skill lives in `.github/skills/pr-quality-checks/` and contains:
-- **`contract.md`**: the nine validation checks with pass/fail criteria
-- **`template.md`**: the expected PR description format
+The validation rules themselves live in `.github/workflows/pull-request-quality-checks.md` (the workflow source). Both the agentic workflow and the VS Code agent point to the same contract — the workflow enforces it on every PR, the editor agent helps authors comply before pushing.
 
-The **agentic workflow** imports the contract at compile time using `{{#runtime-import}}` and enforces it automatically on every PR. The **VS Code agent** points to the same files and helps authors understand and apply the rules before pushing.
+# Repository Structure
 
-The workflow is the enforcement layer. The VS Code agent is the coaching layer. Both stay aligned because they read from the same source of truth.
+```
+.github/
+├── actions/
+│   └── upsert-pr-quality-comment/   # Posts or updates the managed PR comment
+├── agents/
+│   └── pr-quality-validator.agent.md # VS Code Copilot Chat agent definition
+└── workflows/
+    ├── pull-request-quality-checks.md      # Workflow source (edit this)
+    └── pull-request-quality-checks.lock.yml # Compiled output (auto-generated)
+```
 
 # What The Workflow Checks
 
 | Check | What It Validates |
 |-------|-------------------|
-| A | Title follows Conventional Commits |
-| B | Required PR sections are present |
-| C | `Why` section explains motivation clearly |
-| D | `What Changed` section matches actual diff |
-| E | `Validation / Tests` section provides concrete evidence |
-| F | `Screenshots` section is coherent (if present) |
-| G | `Linked Issue` section is coherent (if present) |
-| H | At least one assignee is set |
-| I | PR is focused on a single concern |
+| A | Title follows Conventional Commits format |
+| B | Description explains why the change is needed |
+| C | Description summarizes what was changed |
+| D | Description explains how the change was validated |
+| E | At least one assignee is set |
+| F | PR is focused on a single concern |
 
-# Why The Workflow Matters More Than The Editor
+# Setup
 
-The VS Code agent is useful, but it depends on whether someone used it at the right time. The workflow enforces the standard the same way for everyone.
+1. Copy the `.github/` folder from [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) into your repository.
+2. Add a `COPILOT_GITHUB_TOKEN` secret in **Settings → Secrets and variables → Actions**.
+3. The workflow triggers automatically on pull request events — no further configuration required.
 
-That is the split I wanted to explore:
-- **Workflow** for enforcement
-- **Editor agent** for coaching
+To modify the validation rules, edit the workflow source (`.github/workflows/pull-request-quality-checks.md`) and recompile:
 
-If the policy only exists in an editor assistant, compliance is optional. In the workflow, it is guaranteed.
-
-# Why Shared Skills Matter
-
-Without a shared skill, I would maintain two separate definitions of PR quality. That means drift becomes the default.
-
-With one source of truth:
-- Tighten the title rules and both surfaces stay aligned
-- Change the required sections and both surfaces stay aligned
-- Improve the remediation wording and both surfaces stay aligned
-
-That reuse matters more as the number of agents grows.
+```bash
+gh aw compile
+```
 
 # What I Learned
 
-**Start with a narrow contract.** My first instinct could have been "build an AI PR reviewer." That would have been too broad. A small contract with clear pass/fail boundaries is much easier to evaluate.
+**Start with a narrow contract.** A small contract with clear pass/fail boundaries is much easier to evaluate than "build an AI PR reviewer."
 
-**Interns need precise feedback.** The workflow is useful because it says exactly what is wrong, not "improve your description." New contributors need specific guidance.
+**Shared skills prevent drift.** Without one source of truth, the workflow and the editor agent would define PR quality independently. Change a rule in one place and the other falls out of sync.
 
-**Shared skills bridge automation and local guidance.** The workflow and the VS Code agent have different roles but share the same policy. That reduces maintenance and makes the system feel coherent.
-
-**Scope control builds trust.** The workflow does not pretend to do everything. It validates one thing clearly and that makes it easier to trust.
-
-# What's Next
-
-If I keep pushing this experiment, I would explore:
-- A GitHub PR template file that mirrors the shared contract
-- Automated detection of workflow drift between source and compiled output
-- Extending the same pattern to documentation or issue quality checks
-- Measuring whether this reduces reviewer back-and-forth for new contributors
-
-But even in its current form, the main lesson is already clear: the workflow should own enforcement, shared skills should own the policy, and local agents should help people comply before automation steps in.
+**Scope control builds trust.** The workflow does not pretend to do everything. It validates one thing clearly and that makes it easier to trust and extend.
 
 # References
 
+- [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) — full sample repository
 - [GitHub Agentic Workflows documentation](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-agentic-workflows)
+- [gh-aw CLI](https://github.com/github/gh-aw) — compile workflow sources to GitHub Actions YAML
 - [Customizing Copilot in VS Code](https://code.visualstudio.com/docs/copilot/copilot-customization)
 - [Conventional Commits specification](https://www.conventionalcommits.org/)


### PR DESCRIPTION
## Summary

Revamps the agentic workflow PR quality checks article to be more technical and concise. Adds real code samples from the companion repo [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks).

## What Changed

- Trimmed verbose prose: merged intro, removed redundant "Why Intern PRs?", "Why The Workflow Matters", and "Why Shared Skills Matter" sections
- Added real workflow source YAML front matter snippet (`engine:`, `tools:`, `safe-outputs:`)
- Added VS Code agent YAML front matter snippet showing trigger phrases
- Added repository structure tree (`.github/` layout)
- Added 3-step setup section with `gh aw compile` command
- Updated checks table from 9 items (A-I) to the actual 6 (A-F) matching the real workflow
- Linked companion repo in intro and references
- Added `gh-aw` CLI reference
- Updated front matter description and tags

## Validation / Tests

Article renders correctly — no build changes required, content-only update.