### PR TITLE
Experiment with personal site design refresh

### DIFF
--- a/docs/design-refresh-notes.md
+++ b/docs/design-refresh-notes.md
@@ -1,0 +1,28 @@
+# Personal Site Refresh Notes
+
+## Current Direction
+
+The refresh should make the site feel more intentionally designed without losing the clean, technical feel of the current portfolio.
+
+## Keep
+
+- The new "What I Do" direction is promising.
+- The numbered capability cards and overall style for that section are worth keeping.
+- The framed icon treatment works well, especially the card-like container around each icon.
+
+## Change
+
+- The hero section direction is not working yet.
+- The profile card treatment on the home page is not working yet.
+
+## Next Iteration
+
+- Rework the hero into something less card-like and less visually heavy.
+- Keep the icon-container language from "What I Do" and consider applying it selectively elsewhere.
+- Replace or simplify the home profile card so it feels less like another generic content block.
+
+## Open Questions
+
+- Should the hero return closer to the original simple layout, or move toward a more editorial layout without a surrounding card?
+- Should the profile content live directly on the page instead of inside a bordered card?
+- Should certifications stay in the compact showcase format from the refresh?

--- a/src/src/components/ArticleListSection.tsx
+++ b/src/src/components/ArticleListSection.tsx
@@ -30,15 +30,19 @@ const ArticleListSection: React.FC<ArticleListSectionProps> = ({
         <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
             {visibleArticles.length === 0 ? (
                 <Text className="text-text-secondary">{emptyMessage}</Text>
+            ) : featureFirst ? (
+                <div className="mt-8 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+                    <ArticleListCard article={visibleArticles[0]} featured showTags />
+                    <div className="grid gap-4">
+                        {visibleArticles.slice(1).map((article) => (
+                            <ArticleListCard key={article.slug} article={article} compact />
+                        ))}
+                    </div>
+                </div>
             ) : (
                 <ColumnContainer className="mt-8">
-                    {visibleArticles.map((article, index) => (
-                        <ArticleListCard
-                            key={article.slug}
-                            article={article}
-                            featured={featureFirst && index === 0}
-                            showTags={featureFirst && index === 0}
-                        />
+                    {visibleArticles.map((article) => (
+                        <ArticleListCard key={article.slug} article={article} />
                     ))}
                 </ColumnContainer>
             )}

--- a/src/src/components/ArticleListSection.tsx
+++ b/src/src/components/ArticleListSection.tsx
@@ -8,6 +8,7 @@ interface ArticleListSectionProps {
     heading: string;
     articles: Article[];
     limit?: number;
+    featureFirst?: boolean;
     redirectPath?: string;
     redirectLabel?: string;
     emptyMessage?: string;
@@ -18,6 +19,7 @@ const ArticleListSection: React.FC<ArticleListSectionProps> = ({
     heading,
     articles,
     limit,
+    featureFirst = false,
     redirectPath,
     redirectLabel,
     emptyMessage = "No articles found.",
@@ -30,8 +32,13 @@ const ArticleListSection: React.FC<ArticleListSectionProps> = ({
                 <Text className="text-text-secondary">{emptyMessage}</Text>
             ) : (
                 <ColumnContainer className="mt-8">
-                    {visibleArticles.map((article) => (
-                        <ArticleListCard key={article.slug} article={article} />
+                    {visibleArticles.map((article, index) => (
+                        <ArticleListCard
+                            key={article.slug}
+                            article={article}
+                            featured={featureFirst && index === 0}
+                            showTags={featureFirst && index === 0}
+                        />
                     ))}
                 </ColumnContainer>
             )}

--- a/src/src/components/CertificationShowcase.tsx
+++ b/src/src/components/CertificationShowcase.tsx
@@ -1,0 +1,46 @@
+import NewTabLink from "@/components/shared/NewTabLink";
+import Section from "@/components/shared/Section";
+import { Footnote, Heading3 } from "@/components/shared/typography";
+import type { Certification } from "@/types";
+
+interface CertificationShowcaseProps {
+    heading: string;
+    certifications: Certification[];
+    redirectPath?: string;
+    redirectLabel?: string;
+}
+
+const CertificationShowcase: React.FC<CertificationShowcaseProps> = ({
+    heading,
+    certifications,
+    redirectPath,
+    redirectLabel,
+}) => (
+    <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
+        <div className="overflow-hidden rounded-2xl border border-border-light bg-surface shadow-sm">
+            <div className="grid divide-y divide-border-light md:grid-cols-3 md:divide-x md:divide-y-0">
+                {certifications.map((certification) => (
+                    <NewTabLink key={certification.title} url={certification.url} className="h-full w-full">
+                        <article className="flex h-full items-center gap-4 p-5 transition-colors hover:bg-surface-hover/70 md:p-6">
+                            <div className="flex size-16 shrink-0 items-center justify-center rounded-xl bg-surface-elevated p-2 ring-1 ring-border-light">
+                                <img
+                                    src={certification.image.src}
+                                    alt={certification.image.alt}
+                                    width={certification.image.width}
+                                    height={certification.image.height}
+                                    className="max-h-12 object-contain"
+                                />
+                            </div>
+                            <div className="min-w-0">
+                                <Heading3 className="text-lg md:text-xl">{certification.title}</Heading3>
+                                <Footnote>{certification.issuer}</Footnote>
+                            </div>
+                        </article>
+                    </NewTabLink>
+                ))}
+            </div>
+        </div>
+    </Section>
+);
+
+export default CertificationShowcase;

--- a/src/src/components/ContactLinks.tsx
+++ b/src/src/components/ContactLinks.tsx
@@ -35,7 +35,7 @@ const ContactLinks: React.FC<ContactLinksProps> = ({ contacts, iconSize = 32, cl
         return null;
     }
 
-    const containerClassName = `flex flex-wrap gap-6 ${className}`.trim();
+    const containerClassName = `flex flex-wrap gap-3 ${className}`.trim();
 
     return (
         <div className={containerClassName}>
@@ -45,7 +45,11 @@ const ContactLinks: React.FC<ContactLinksProps> = ({ contacts, iconSize = 32, cl
 
                 return (
                     <ClientTooltip key={contact.name} content={contact.name} placement="bottom">
-                        <NewTabLink url={contact.url}>{content}</NewTabLink>
+                        <NewTabLink url={contact.url}>
+                            <span className="flex size-11 items-center justify-center rounded-xl border border-border-light bg-surface/80 transition-colors hover:border-primary/50 hover:bg-primary-light">
+                                {content}
+                            </span>
+                        </NewTabLink>
                     </ClientTooltip>
                 );
             })}

--- a/src/src/components/HeroSection.tsx
+++ b/src/src/components/HeroSection.tsx
@@ -4,41 +4,63 @@ import type { ImageProps } from "@/types";
 
 interface HeroSectionProps {
     heading: React.ReactNode | string;
+    eyebrow?: string;
     description?: React.ReactNode | string;
     image?: ImageProps;
     actions?: React.ReactNode;
 }
 
 // Generic hero layout pairing text with optional media and actions.
-const HeroSection: React.FC<HeroSectionProps> = ({ heading, description, image, actions }) => {
-    const renderHeading = () => (typeof heading === "string" ? <Heading1>{heading}</Heading1> : heading);
+const HeroSection: React.FC<HeroSectionProps> = ({ heading, eyebrow, description, image, actions }) => {
+    const renderHeading = () =>
+        typeof heading === "string" ? (
+            <Heading1 className="max-w-3xl text-balance">{heading}</Heading1>
+        ) : (
+            heading
+        );
     const renderDescription = () =>
-        typeof description === "string" ? <Text>{description}</Text> : description ?? null;
+        typeof description === "string" ? (
+            <Text className="max-w-2xl text-lg md:text-xl text-pretty">{description}</Text>
+        ) : (
+            description ?? null
+        );
 
     const buildImageClassName = () => {
-        const baseClassName = "rounded-xl w-full md:w-1/3 mt-6 md:mt-0";
+        const baseClassName = "aspect-square w-full rounded-2xl object-cover shadow-2xl";
         if (!image?.className) return baseClassName;
 
         return `${baseClassName} ${image.className}`;
     };
 
     return (
-        <div className="flex flex-col md:flex-row items-center pt-8">
-            <div className="md:mr-6 space-y-6 flex-1 flex flex-col justify-center">
-                {renderHeading()}
-                {renderDescription()}
-                {actions}
+        <section className="relative mt-6 overflow-hidden rounded-3xl border border-border-light bg-surface-elevated px-6 py-8 shadow-sm md:px-10 md:py-12">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,var(--color-primary-light),transparent_32%),radial-gradient(circle_at_85%_18%,oklch(92%_0.08_170),transparent_28%)] opacity-80 dark:opacity-20" />
+            <div className="absolute inset-x-0 bottom-0 h-px bg-linear-to-r from-transparent via-primary to-transparent opacity-60" />
+            <div className="relative flex flex-col items-start gap-8 md:flex-row md:items-center md:gap-12">
+                <div className="flex flex-1 flex-col justify-center space-y-6">
+                    {eyebrow && (
+                        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-primary text-font">
+                            {eyebrow}
+                        </p>
+                    )}
+                    {renderHeading()}
+                    {renderDescription()}
+                    {actions && <div className="pt-1">{actions}</div>}
+                </div>
+                {image && (
+                    <div className="w-full max-w-xs shrink-0 rounded-3xl border border-border-light bg-background/70 p-3 shadow-xl md:max-w-sm">
+                        <img
+                            src={image.src}
+                            alt={image.alt}
+                            width={image.width ?? 512}
+                            height={image.height ?? 512}
+                            fetchPriority="high"
+                            className={buildImageClassName()}
+                        />
+                    </div>
+                )}
             </div>
-            {image && (
-                <img
-                    src={image.src}
-                    alt={image.alt}
-                    width={image.width ?? 512}
-                    height={image.height ?? 512}
-                    className={buildImageClassName()}
-                />
-            )}
-        </div>
+        </section>
     );
 };
 

--- a/src/src/components/HomeCapabilitiesSection.tsx
+++ b/src/src/components/HomeCapabilitiesSection.tsx
@@ -1,0 +1,68 @@
+import { Link } from "react-router";
+import Section from "@/components/shared/Section";
+import { Heading3, Text } from "@/components/shared/typography";
+import type { ImageProps } from "@/types";
+
+interface CapabilityItem {
+    title: string;
+    description?: string;
+    image: ImageProps;
+    redirectPath?: string;
+}
+
+interface HomeCapabilitiesSectionProps {
+    heading: string;
+    items: CapabilityItem[];
+    redirectPath?: string;
+    redirectLabel?: string;
+}
+
+const HomeCapabilitiesSection: React.FC<HomeCapabilitiesSectionProps> = ({
+    heading,
+    items,
+    redirectPath,
+    redirectLabel,
+}) => (
+    <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
+        <div className="grid gap-4 md:grid-cols-2">
+            {items.map((item, index) => {
+                const content = (
+                    <article className="group relative flex h-full min-h-56 flex-col justify-between overflow-hidden rounded-2xl border border-border-light bg-surface p-6 shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-lg">
+                        <div className="absolute right-5 top-4 text-6xl font-bold leading-none text-primary/10 heading-font">
+                            {String(index + 1).padStart(2, "0")}
+                        </div>
+                        <div className="relative flex items-start justify-between gap-4">
+                            <div className="flex size-16 items-center justify-center rounded-2xl border border-border-light bg-surface-elevated">
+                                <img
+                                    src={item.image.src}
+                                    alt={item.image.alt}
+                                    width={item.image.width}
+                                    height={item.image.height}
+                                    className="size-10 object-contain"
+                                />
+                            </div>
+                        </div>
+                        <div className="relative mt-8 space-y-3">
+                            <Heading3 className="text-text-primary">{item.title}</Heading3>
+                            {item.description && <Text className="text-base md:text-base">{item.description}</Text>}
+                        </div>
+                    </article>
+                );
+
+                return item.redirectPath ? (
+                    <Link
+                        key={item.title}
+                        to={item.redirectPath}
+                        className="rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+                    >
+                        {content}
+                    </Link>
+                ) : (
+                    <div key={item.title}>{content}</div>
+                );
+            })}
+        </div>
+    </Section>
+);
+
+export default HomeCapabilitiesSection;

--- a/src/src/components/cards/ArticleListCard.tsx
+++ b/src/src/components/cards/ArticleListCard.tsx
@@ -8,15 +8,16 @@ import { Article } from "@/types/article";
 type ArticleListCardProps = {
     article: Article;
     showTags?: boolean;
+    featured?: boolean;
 };
 
-const ArticleListCard: React.FC<ArticleListCardProps> = ({ article, showTags = false }) => (
-    <Card as="article" className="flex flex-col gap-3">
+const ArticleListCard: React.FC<ArticleListCardProps> = ({ article, showTags = false, featured = false }) => (
+    <Card as="article" variant={featured ? "feature" : "default"} className="flex flex-col gap-3">
         <CardHeader className="gap-1.5">
             <CardTitle>
                 <Link
                     to={`/articles/${article.slug}`}
-                    className="hover:text-primary-hover transition-colors cursor-pointer"
+                    className="rounded-sm hover:text-primary-hover transition-colors cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
                 >
                     {article.title}
                 </Link>

--- a/src/src/components/cards/ArticleListCard.tsx
+++ b/src/src/components/cards/ArticleListCard.tsx
@@ -9,10 +9,11 @@ type ArticleListCardProps = {
     article: Article;
     showTags?: boolean;
     featured?: boolean;
+    compact?: boolean;
 };
 
-const ArticleListCard: React.FC<ArticleListCardProps> = ({ article, showTags = false, featured = false }) => (
-    <Card as="article" variant={featured ? "feature" : "default"} className="flex flex-col gap-3">
+const ArticleListCard: React.FC<ArticleListCardProps> = ({ article, showTags = false, featured = false, compact = false }) => (
+    <Card as="article" variant={featured ? "feature" : compact ? "compact" : "default"} className="flex flex-col gap-3">
         <CardHeader className="gap-1.5">
             <CardTitle>
                 <Link
@@ -26,7 +27,7 @@ const ArticleListCard: React.FC<ArticleListCardProps> = ({ article, showTags = f
                 {formatDate(article.publishedAt)}
             </CardSubtitle>
         </CardHeader>
-        {article.description && (
+        {article.description && !compact && (
             <CardBody className="pt-1">
                 <Text>{article.description}</Text>
             </CardBody>

--- a/src/src/components/cards/Card.tsx
+++ b/src/src/components/cards/Card.tsx
@@ -7,8 +7,9 @@ import GridContainer from "@/components/layout/GridContainer";
 type PolymorphicProps<E extends React.ElementType> = {
     as?: E;
     className?: string;
+    variant?: "default" | "quiet" | "feature" | "compact";
     children?: React.ReactNode;
-} & Omit<React.ComponentPropsWithoutRef<E>, "as" | "className" | "children">;
+} & Omit<React.ComponentPropsWithoutRef<E>, "as" | "className" | "variant" | "children">;
 
 type SimpleProps = {
     className?: string;
@@ -33,7 +34,18 @@ type CardLinkProps = {
 };
 
 const baseCardClass =
-    "p-6 bg-surface rounded-3xl border border-border-light shadow-md h-full transition-shadow duration-200 hover:shadow-xl active:shadow-xl";
+    "h-full border transition-[border-color,box-shadow,transform] duration-200 focus-within:border-primary";
+
+const cardVariants = {
+    default:
+        "rounded-2xl border-border-light bg-surface p-6 shadow-sm hover:-translate-y-0.5 hover:border-border hover:shadow-lg active:shadow-lg",
+    quiet:
+        "rounded-2xl border-border-light bg-surface/70 p-5 shadow-none hover:border-border hover:bg-surface-hover/60",
+    feature:
+        "rounded-3xl border-border-light bg-surface p-6 shadow-md hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-xl md:p-8",
+    compact:
+        "rounded-xl border-border-light bg-surface/80 p-4 shadow-none hover:border-border hover:bg-surface-hover/70",
+} satisfies Record<NonNullable<PolymorphicProps<"div">["variant"]>, string>;
 
 const mediaSizes: Record<NonNullable<CardMediaProps["size"]>, string> = {
     small: "w-1/3",
@@ -47,12 +59,13 @@ const cn = (...classes: Array<string | undefined | null | false>) => classes.fil
 const Card = <E extends React.ElementType = "div">({
     as,
     className,
+    variant = "default",
     children,
     ...props
 }: PolymorphicProps<E>) => {
     const Component = as ?? "div";
     return (
-        <Component className={cn(baseCardClass, className)} {...(props as React.ComponentPropsWithoutRef<E>)}>
+        <Component className={cn(baseCardClass, cardVariants[variant], className)} {...(props as React.ComponentPropsWithoutRef<E>)}>
             {children}
         </Component>
     );

--- a/src/src/components/cards/MediaTileCard.tsx
+++ b/src/src/components/cards/MediaTileCard.tsx
@@ -19,7 +19,7 @@ const sizeClasses: Record<MediaTileSize, string> = {
 };
 
 const MediaTileCard: React.FC<MediaTileCardProps> = ({ title, description, image, size = "medium" }) => (
-    <Card>
+    <Card variant="quiet">
         <div className="flex items-center flex-col h-full">
             {image && (
                 <CardMedia

--- a/src/src/components/layout/LayoutWrapper.tsx
+++ b/src/src/components/layout/LayoutWrapper.tsx
@@ -9,12 +9,12 @@ interface LayoutWrapperProps {
 
 const LayoutWrapper: React.FC<Readonly<LayoutWrapperProps>> = ({ children, githubRepositoryUrl, commitHash }) => {
     return (
-        <>
+        <div className="min-h-screen bg-[linear-gradient(180deg,var(--color-background)_0%,var(--color-surface-elevated)_52%,var(--color-background)_100%)]">
             <NavigationBar title="Logan Farci" />
-            <main className="max-w-(--breakpoint-lg) mx-auto px-6">{children}</main>
-            <hr className="border-t border-border my-8" />
+            <main className="max-w-(--breakpoint-lg) mx-auto px-5 pb-6 md:px-6">{children}</main>
+            <hr className="mx-auto my-8 max-w-(--breakpoint-lg) border-t border-border" />
             <Footer githubRepositoryUrl={githubRepositoryUrl} commitHash={commitHash} />
-        </>
+        </div>
     );
 };
 

--- a/src/src/components/layout/NavigationBar.tsx
+++ b/src/src/components/layout/NavigationBar.tsx
@@ -16,10 +16,18 @@ const NavigationBar: React.FC<NavigationBarProps> = ({ title }) => {
     };
 
     return (
-        <Navbar isBordered isMenuOpen={isMenuOpen} onMenuOpenChange={setIsMenuOpen}>
+        <Navbar
+            isBordered
+            isMenuOpen={isMenuOpen}
+            onMenuOpenChange={setIsMenuOpen}
+            className="bg-background/80 backdrop-blur-md"
+        >
             <NavbarContent className="flex justify-between items-center md:justify-between md:items-center text-center">
                 <NavbarBrand className="w-full md:w-auto">
-                    <Link to="/" className="text-xl md:text-2xl font-thin heading-font cursor-pointer">
+                    <Link
+                        to="/"
+                        className="rounded-lg text-xl font-bold heading-font cursor-pointer text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary md:text-2xl"
+                    >
                         {title}
                     </Link>
                 </NavbarBrand>
@@ -27,14 +35,14 @@ const NavigationBar: React.FC<NavigationBarProps> = ({ title }) => {
                     aria-label={isMenuOpen ? "Close menu" : "Open menu"}
                     className="md:hidden"
                 />
-                <div className="hidden md:flex items-center space-x-8">
-                    <NavBarEntry url="/" className="hover:text-primary-hover transition-colors">
+                <div className="hidden md:flex items-center gap-2">
+                    <NavBarEntry url="/" className="hover:text-primary-hover">
                         Home
                     </NavBarEntry>
-                    <NavBarEntry url="/about" className="hover:text-primary-hover transition-colors">
+                    <NavBarEntry url="/about" className="hover:text-primary-hover">
                         About
                     </NavBarEntry>
-                    <NavBarEntry url="/articles" className="hover:text-primary-hover transition-colors">
+                    <NavBarEntry url="/articles" className="hover:text-primary-hover">
                         Articles
                     </NavBarEntry>
                     <ThemeToggle />
@@ -42,17 +50,17 @@ const NavigationBar: React.FC<NavigationBarProps> = ({ title }) => {
             </NavbarContent>
             <NavbarMenu className="md:hidden text-center">
                 <NavbarMenuItem onClick={handleMenuItemClick}>
-                    <NavBarEntry url="/" className="hover:text-primary-hover transition-colors text-base py-2">
+                    <NavBarEntry url="/" className="hover:text-primary-hover text-base py-2">
                         Home
                     </NavBarEntry>
                 </NavbarMenuItem>
                 <NavbarMenuItem onClick={handleMenuItemClick}>
-                    <NavBarEntry url="/about" className="hover:text-primary-hover transition-colors text-base py-2">
+                    <NavBarEntry url="/about" className="hover:text-primary-hover text-base py-2">
                         About
                     </NavBarEntry>
                 </NavbarMenuItem>
                 <NavbarMenuItem onClick={handleMenuItemClick}>
-                    <NavBarEntry url="/articles" className="hover:text-primary-hover transition-colors text-base py-2">
+                    <NavBarEntry url="/articles" className="hover:text-primary-hover text-base py-2">
                         Articles
                     </NavBarEntry>
                 </NavbarMenuItem>

--- a/src/src/components/shared/NavBarEntry.tsx
+++ b/src/src/components/shared/NavBarEntry.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { NavLink } from "react-router";
 
 export interface NavBarEntryProps {
     children: React.ReactNode;
@@ -7,12 +7,19 @@ export interface NavBarEntryProps {
 }
 
 const NavBarEntry: React.FC<NavBarEntryProps> = ({ children, url, className = "" }) => {
-    const spacingClasses = "block md:inline-block mb-4 md:mb-0";
+    const spacingClasses = "block md:inline-flex mb-4 md:mb-0 min-h-11 items-center rounded-full px-3";
 
     return (
-        <Link to={url} className={`${spacingClasses} text-base md:text-lg text-font ${className}`}>
+        <NavLink
+            to={url}
+            className={({ isActive }) =>
+                `${spacingClasses} text-base md:text-lg text-font transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary ${
+                    isActive ? "bg-primary-light text-primary" : "text-text-secondary"
+                } ${className}`
+            }
+        >
             {children}
-        </Link>
+        </NavLink>
     );
 };
 

--- a/src/src/components/shared/NewTabLink.tsx
+++ b/src/src/components/shared/NewTabLink.tsx
@@ -2,9 +2,10 @@ export interface ExternalLinkProps {
     children: React.ReactNode;
     url: string;
     size?: "base" | "footnote";
+    className?: string;
 }
 
-const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base" }) => {
+const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base", className = "" }) => {
     const sizeClasses = size === "footnote" ? "text-sm md:text-base" : "text-base md:text-lg";
 
     return (
@@ -12,7 +13,7 @@ const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base" 
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${sizeClasses} inline-flex min-h-11 items-center rounded-md font-medium text-font text-primary transition-colors hover:text-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary`}
+            className={`${sizeClasses} inline-flex min-h-11 items-center rounded-md font-medium text-font text-primary transition-colors hover:text-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary ${className}`}
         >
             {children}
         </a>

--- a/src/src/components/shared/NewTabLink.tsx
+++ b/src/src/components/shared/NewTabLink.tsx
@@ -12,7 +12,7 @@ const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base" 
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${sizeClasses} font-medium text-font text-primary`}
+            className={`${sizeClasses} inline-flex min-h-11 items-center rounded-md font-medium text-font text-primary transition-colors hover:text-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary`}
         >
             {children}
         </a>

--- a/src/src/components/shared/Section.tsx
+++ b/src/src/components/shared/Section.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from "@heroui/react";
+import { Link } from "react-router";
 import ChevronRightIcon from "./icons/ChevronRightIcon";
-import { Heading1, Text } from "@/components/shared/typography";
+import { Heading2, Text } from "@/components/shared/typography";
 import { createId } from "@/core/string";
 
 interface SectionProps {
@@ -12,34 +13,35 @@ interface SectionProps {
 }
 
 const Section: React.FC<SectionProps> = ({ heading, redirectPath, redirectLabel, children, id }) => {
-    const handleNavigation = () => {
-        if (!redirectPath) return;
-
-        const url = redirectPath.startsWith("/") ? `${window.location.origin}${redirectPath}` : redirectPath;
-
-        window.location.assign(url);
-    };
-
     const toolTip = <Text>{redirectLabel}</Text>;
+    const headingContent = (
+        <>
+            <Heading2 className="mb-0 text-balance">{heading}</Heading2>
+            {redirectPath && (
+                <ChevronRightIcon
+                    className="size-7 shrink-0 self-center text-text-tertiary transition-transform duration-200 group-hover:translate-x-1 group-hover:text-primary md:size-8"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                />
+            )}
+        </>
+    );
 
     return (
-        <section id={id ?? createId(heading)} className="pt-8 scroll-mt-24">
-            <div
-                className={`flex items-center mb-4${redirectPath ? " cursor-pointer" : ""}`}
-                onClick={handleNavigation}
-            >
+        <section id={id ?? createId(heading)} className="py-8 scroll-mt-24 md:py-12">
+            <div className="mb-5 flex items-center">
                 {redirectPath ? (
                     <Tooltip content={toolTip} placement="right">
-                        <span className="flex items-center">
-                            <Heading1 className="mb-0">{heading}</Heading1>
-                            <ChevronRightIcon
-                                className="size-7 md:size-9 ml-2 shrink-0 self-center text-text-tertiary cursor-pointer"
-                                strokeWidth={2}
-                            />
-                        </span>
+                        <Link
+                            to={redirectPath}
+                            aria-label={redirectLabel ?? heading}
+                            className="group -ml-1 flex items-center gap-2 rounded-lg px-1 py-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+                        >
+                            {headingContent}
+                        </Link>
                     </Tooltip>
                 ) : (
-                    <Heading1 className="mb-0">{heading}</Heading1>
+                    headingContent
                 )}
             </div>
             {children}

--- a/src/src/components/shared/Tag.tsx
+++ b/src/src/components/shared/Tag.tsx
@@ -31,7 +31,13 @@ const Tag: React.FC<TagProps> = ({ children, imageSrc = "", imageAlt = "" }) => 
     }
 
     return (
-        <Chip variant="bordered" size="lg" radius="md" className="text-base" startContent={startContent}>
+        <Chip
+            variant="flat"
+            size="lg"
+            radius="md"
+            className="border border-border-light bg-surface-elevated text-base"
+            startContent={startContent}
+        >
             <Text>{children}</Text>
         </Chip>
     );

--- a/src/src/components/shared/TextSection.tsx
+++ b/src/src/components/shared/TextSection.tsx
@@ -10,7 +10,10 @@ interface TextSection {
 
 const TextSection: React.FC<TextSection> = ({ heading, text, redirectPath, redirectLabel }) => (
     <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
-        <Text>{text}</Text>
+        <div className="grid gap-6 rounded-2xl border border-border-light bg-surface p-6 shadow-sm md:grid-cols-[0.35fr_1fr] md:p-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-accent text-font">Profile</p>
+            <Text className="max-w-3xl text-pretty">{text}</Text>
+        </div>
     </Section>
 );
 

--- a/src/src/components/shared/ThemeToggle.tsx
+++ b/src/src/components/shared/ThemeToggle.tsx
@@ -26,7 +26,7 @@ const ThemeToggleInner: React.FC = () => {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg bg-surface-hover border border-border hover:bg-surface-elevated transition-colors duration-200 cursor-pointer"
+      className="size-11 rounded-xl bg-surface-hover border border-border hover:bg-surface-elevated transition-colors duration-200 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary inline-flex items-center justify-center"
       aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
       type="button"
     >

--- a/src/src/components/shared/icons/SvgIcon.tsx
+++ b/src/src/components/shared/icons/SvgIcon.tsx
@@ -1,19 +1,20 @@
 import React from "react";
 
-export type SvgIconProps = { 
-    className?: string; 
-    strokeWidth?: number; 
-    size?: number; 
+export type SvgIconProps = React.SVGAttributes<SVGSVGElement> & {
+    className?: string;
+    strokeWidth?: number;
+    size?: number;
     viewBox?: string;
-    children?: React.ReactNode 
+    children?: React.ReactNode;
 };
 
-const SvgIcon: React.FC<SvgIconProps> = ({ 
-    className, 
-    strokeWidth = 3, 
-    size = 24, 
+const SvgIcon: React.FC<SvgIconProps> = ({
+    className,
+    strokeWidth = 3,
+    size = 24,
     viewBox,
-    children 
+    children,
+    ...props
 }) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -23,7 +24,8 @@ const SvgIcon: React.FC<SvgIconProps> = ({
         stroke="currentColor"
         strokeWidth={strokeWidth}
         className={className}
-        style={{ aspectRatio: 'auto' }}
+        style={{ aspectRatio: "auto" }}
+        {...props}
     >
         {children}
     </svg>

--- a/src/src/components/shared/typography/core/styles.ts
+++ b/src/src/components/shared/typography/core/styles.ts
@@ -1,7 +1,7 @@
 export const typographyStyles = {
-    heading1: "text-3xl md:text-4xl font-bold heading-font text-text-primary",
-    heading2: "text-2xl md:text-3xl font-bold heading-font text-text-primary",
-    heading3: "text-xl md:text-2xl font-bold text-text-secondary heading-font",
+    heading1: "text-4xl md:text-6xl font-bold heading-font text-text-primary leading-tight text-balance",
+    heading2: "text-2xl md:text-3xl font-bold heading-font text-text-primary text-balance",
+    heading3: "text-xl md:text-2xl font-bold text-text-secondary heading-font text-pretty",
     heading4: "text-lg md:text-xl font-semibold heading-font text-text-tertiary",
     text: "text-base md:text-lg text-text-tertiary leading-relaxed! text-font",
     secondary: "text-base md:text-lg text-text-muted leading-relaxed! text-font",

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -22,6 +22,7 @@
   body {
     color: var(--color-foreground);
     background: var(--color-background);
+    -webkit-tap-highlight-color: transparent;
   }
 }
 
@@ -35,8 +36,8 @@
     --color-primary-light: oklch(97% 0.014 254.604); /* blue-50 */
     --color-secondary: oklch(55.1% 0.027 264.364); /* gray-500 */
     --color-secondary-hover: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-accent: oklch(62.3% 0.214 259.815); /* Same as primary */
-    --color-accent-hover: oklch(54.6% 0.245 262.881); /* Same as primary-hover */
+    --color-accent: oklch(69.6% 0.17 162.48); /* emerald-500 */
+    --color-accent-hover: oklch(59.6% 0.145 163.225); /* emerald-600 */
     
     /* Text semantic colors */
     --color-text-primary: oklch(27.8% 0.033 256.848); /* gray-800 */
@@ -65,6 +66,7 @@
 /* Dark mode styles when .dark class is applied */
 :root.dark,
 .dark {
+    color-scheme: dark;
     --color-background: oklch(10% 0.012 264.8); /* Very dark gray */
     --color-foreground: oklch(98% 0.003 264.542); /* Near white */
     
@@ -76,8 +78,8 @@
     --color-secondary: oklch(70.7% 0.022 261.325); /* gray-400 */
     --color-secondary-hover: oklch(87.2% 0.01 258.338); /* gray-300 */
     
-    --color-accent: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-accent-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-accent: oklch(84.5% 0.143 164.978); /* emerald-300 */
+    --color-accent-hover: oklch(76.5% 0.177 163.223); /* emerald-400 */
     
     /* Text colors for dark mode */
     --color-text-primary: oklch(98.5% 0.002 247.839); /* gray-50 */

--- a/src/src/pages/HomePage.tsx
+++ b/src/src/pages/HomePage.tsx
@@ -1,9 +1,10 @@
 import ArticleListSection from "@/components/ArticleListSection";
+import CertificationShowcase from "@/components/CertificationShowcase";
 import ContactLinks from "@/components/ContactLinks";
 import HeroSection from "@/components/HeroSection";
+import HomeCapabilitiesSection from "@/components/HomeCapabilitiesSection";
 import ColumnContainer from "@/components/layout/ColumnContainer";
 import TextSection from "@/components/shared/TextSection";
-import ThumbnailGridSection from "@/components/shared/ThumbnailGridSection";
 import { Heading1 } from "@/components/shared/typography";
 import { getFeaturedArticles } from "@/core/articles";
 import { getCertifications, getContacts, getInterests, getProfile } from "@/core/data";
@@ -37,19 +38,15 @@ export default function HomePage() {
                     redirectPath="/about#about-me"
                     redirectLabel="Read more about me"
                 />
-                <ThumbnailGridSection 
-                    heading="What I Do" 
-                    size="large" 
-                    columns={2} 
+                <HomeCapabilitiesSection
+                    heading="What I Do"
                     items={interests}
                     redirectPath="/about#skills"
                     redirectLabel="Explore my skills in detail"
                 />
-                <ThumbnailGridSection
+                <CertificationShowcase
                     heading="My Certifications"
-                    size="large"
-                    columns={3}
-                    items={featuredCertifications}
+                    certifications={featuredCertifications}
                     redirectPath="/about#certifications"
                     redirectLabel="Show all my certifications"
                 />

--- a/src/src/pages/HomePage.tsx
+++ b/src/src/pages/HomePage.tsx
@@ -1,10 +1,10 @@
 import ArticleListSection from "@/components/ArticleListSection";
 import ContactLinks from "@/components/ContactLinks";
-import GreetingHeading from "@/components/GreetingHeading";
 import HeroSection from "@/components/HeroSection";
 import ColumnContainer from "@/components/layout/ColumnContainer";
 import TextSection from "@/components/shared/TextSection";
 import ThumbnailGridSection from "@/components/shared/ThumbnailGridSection";
+import { Heading1 } from "@/components/shared/typography";
 import { getFeaturedArticles } from "@/core/articles";
 import { getCertifications, getContacts, getInterests, getProfile } from "@/core/data";
 
@@ -21,8 +21,13 @@ export default function HomePage() {
             <meta name="description" content="Logan Farci, Software Engineer" />
             <ColumnContainer>
                 <HeroSection
-                    heading={<GreetingHeading greeting="Hi" name="Logan" />}
-                    description={profile.role}
+                    eyebrow="Azure • GitHub • .NET • DevOps"
+                    heading={
+                        <Heading1 className="max-w-3xl text-balance">
+                            Building reliable cloud systems and developer workflows.
+                        </Heading1>
+                    }
+                    description={profile.introduction}
                     image={profile.avatar}
                     actions={<ContactLinks contacts={contacts} />}
                 />
@@ -52,6 +57,7 @@ export default function HomePage() {
                     heading="Featured Articles"
                     articles={featuredArticles}
                     limit={4}
+                    featureFirst
                     redirectPath="/articles"
                     redirectLabel="View all my articles"
                     emptyMessage="No featured articles found."


### PR DESCRIPTION
## Summary
- redesign the home hero with stronger positioning, layered surfaces, and a framed avatar treatment
- introduce card variants and a featured article state to reduce the same-card-everywhere feel
- improve section heading hierarchy, keyboard/focus affordances, and touch targets for shared links and controls

## Verification
- npm run lint
- npm test
- npm run build

Note: build passes but still emits existing prerender warnings about article title children and an existing large chunk warning.