### PR TITLE
design: sharp editorial refresh with a11y and performance fixes

### DIFF
--- a/src/src/components/ArticleListSection.tsx
+++ b/src/src/components/ArticleListSection.tsx
@@ -6,6 +6,7 @@ import type { Article } from "@/types";
 
 interface ArticleListSectionProps {
     heading: string;
+    label?: string;
     articles: Article[];
     limit?: number;
     redirectPath?: string;
@@ -16,6 +17,7 @@ interface ArticleListSectionProps {
 // Generic article list section usable across pages.
 const ArticleListSection: React.FC<ArticleListSectionProps> = ({
     heading,
+    label,
     articles,
     limit,
     redirectPath,
@@ -25,7 +27,7 @@ const ArticleListSection: React.FC<ArticleListSectionProps> = ({
     const visibleArticles = typeof limit === "number" ? articles.slice(0, limit) : articles;
 
     return (
-        <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
+        <Section heading={heading} label={label} redirectPath={redirectPath} redirectLabel={redirectLabel}>
             {visibleArticles.length === 0 ? (
                 <Text className="text-text-secondary">{emptyMessage}</Text>
             ) : (

--- a/src/src/components/ContactLinks.tsx
+++ b/src/src/components/ContactLinks.tsx
@@ -45,7 +45,7 @@ const ContactLinks: React.FC<ContactLinksProps> = ({ contacts, iconSize = 32, cl
 
                 return (
                     <ClientTooltip key={contact.name} content={contact.name} placement="bottom">
-                        <NewTabLink url={contact.url}>{content}</NewTabLink>
+                        <NewTabLink url={contact.url} aria-label={contact.name}>{content}</NewTabLink>
                     </ClientTooltip>
                 );
             })}

--- a/src/src/components/HeroSection.tsx
+++ b/src/src/components/HeroSection.tsx
@@ -35,6 +35,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ heading, description, image, 
                     alt={image.alt}
                     width={image.width ?? 512}
                     height={image.height ?? 512}
+                    fetchPriority="high"
                     className={buildImageClassName()}
                 />
             )}

--- a/src/src/components/cards/Card.tsx
+++ b/src/src/components/cards/Card.tsx
@@ -33,7 +33,7 @@ type CardLinkProps = {
 };
 
 const baseCardClass =
-    "p-6 bg-surface rounded-3xl border border-border-light shadow-md h-full transition-shadow duration-200 hover:shadow-xl active:shadow-xl";
+    "p-6 bg-surface rounded-xl border border-border-light shadow-sm h-full transition-shadow duration-200 hover:shadow-md active:shadow-md";
 
 const mediaSizes: Record<NonNullable<CardMediaProps["size"]>, string> = {
     small: "w-1/3",

--- a/src/src/components/shared/NewTabLink.tsx
+++ b/src/src/components/shared/NewTabLink.tsx
@@ -2,9 +2,10 @@ export interface ExternalLinkProps {
     children: React.ReactNode;
     url: string;
     size?: "base" | "footnote";
+    "aria-label"?: string;
 }
 
-const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base" }) => {
+const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base", "aria-label": ariaLabel }) => {
     const sizeClasses = size === "footnote" ? "text-sm md:text-base" : "text-base md:text-lg";
 
     return (
@@ -12,7 +13,8 @@ const NewTabLink: React.FC<ExternalLinkProps> = ({ children, url, size = "base" 
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${sizeClasses} font-medium text-font text-primary`}
+            aria-label={ariaLabel}
+            className={`${sizeClasses} font-medium text-font text-primary hover:text-primary-hover transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm`}
         >
             {children}
         </a>

--- a/src/src/components/shared/Section.tsx
+++ b/src/src/components/shared/Section.tsx
@@ -1,46 +1,47 @@
 import { Tooltip } from "@heroui/react";
+import { Link } from "react-router";
 import ChevronRightIcon from "./icons/ChevronRightIcon";
-import { Heading1, Text } from "@/components/shared/typography";
+import { Heading2, Text } from "@/components/shared/typography";
 import { createId } from "@/core/string";
 
 interface SectionProps {
     heading: string;
+    label?: string;
     redirectPath?: string;
     redirectLabel?: string;
     id?: string;
     children?: React.ReactNode;
 }
 
-const Section: React.FC<SectionProps> = ({ heading, redirectPath, redirectLabel, children, id }) => {
-    const handleNavigation = () => {
-        if (!redirectPath) return;
-
-        const url = redirectPath.startsWith("/") ? `${window.location.origin}${redirectPath}` : redirectPath;
-
-        window.location.assign(url);
-    };
-
+const Section: React.FC<SectionProps> = ({ heading, label, redirectPath, redirectLabel, children, id }) => {
     const toolTip = <Text>{redirectLabel}</Text>;
 
     return (
         <section id={id ?? createId(heading)} className="pt-8 scroll-mt-24">
-            <div
-                className={`flex items-center mb-4${redirectPath ? " cursor-pointer" : ""}`}
-                onClick={handleNavigation}
-            >
-                {redirectPath ? (
-                    <Tooltip content={toolTip} placement="right">
-                        <span className="flex items-center">
-                            <Heading1 className="mb-0">{heading}</Heading1>
-                            <ChevronRightIcon
-                                className="size-7 md:size-9 ml-2 shrink-0 self-center text-text-tertiary cursor-pointer"
-                                strokeWidth={2}
-                            />
-                        </span>
-                    </Tooltip>
-                ) : (
-                    <Heading1 className="mb-0">{heading}</Heading1>
+            <div className="flex flex-col mb-4">
+                {label && (
+                    <span className="text-xs font-semibold tracking-widest uppercase text-text-muted mb-1">
+                        {label}
+                    </span>
                 )}
+                <div className="flex items-center">
+                    {redirectPath ? (
+                        <Tooltip content={toolTip} placement="right">
+                            <Link
+                                to={redirectPath}
+                                className="flex items-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
+                            >
+                                <Heading2 className="mb-0">{heading}</Heading2>
+                                <ChevronRightIcon
+                                    className="size-7 md:size-9 ml-2 shrink-0 self-center text-text-tertiary"
+                                    strokeWidth={2}
+                                />
+                            </Link>
+                        </Tooltip>
+                    ) : (
+                        <Heading2 className="mb-0">{heading}</Heading2>
+                    )}
+                </div>
             </div>
             {children}
         </section>

--- a/src/src/components/shared/TextSection.tsx
+++ b/src/src/components/shared/TextSection.tsx
@@ -3,13 +3,14 @@ import { Text } from "@/components/shared/typography";
 
 interface TextSection {
     heading: string;
+    label?: string;
     text: string;
     redirectPath?: string;
     redirectLabel?: string;
 }
 
-const TextSection: React.FC<TextSection> = ({ heading, text, redirectPath, redirectLabel }) => (
-    <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
+const TextSection: React.FC<TextSection> = ({ heading, label, text, redirectPath, redirectLabel }) => (
+    <Section heading={heading} label={label} redirectPath={redirectPath} redirectLabel={redirectLabel}>
         <Text>{text}</Text>
     </Section>
 );

--- a/src/src/components/shared/ThumbnailGridSection.tsx
+++ b/src/src/components/shared/ThumbnailGridSection.tsx
@@ -15,6 +15,7 @@ interface ThumbnailItem {
 
 interface ThumbnailGridSectionProps {
     heading: string;
+    label?: string;
     items: ThumbnailItem[];
     columns?: number;
     size?: MediaTileSize;
@@ -24,13 +25,14 @@ interface ThumbnailGridSectionProps {
 
 const ThumbnailGridSection: React.FC<ThumbnailGridSectionProps> = ({
     heading,
+    label,
     items,
     columns = 3,
     size: thumbnailSize = "medium",
     redirectPath,
     redirectLabel,
 }) => (
-    <Section heading={heading} redirectPath={redirectPath} redirectLabel={redirectLabel}>
+    <Section heading={heading} label={label} redirectPath={redirectPath} redirectLabel={redirectLabel}>
         <CardGrid columns={columns} className="mt-8">
             {items.map((item, index) => {
                 const card = (

--- a/src/src/components/shared/icons/SvgIcon.tsx
+++ b/src/src/components/shared/icons/SvgIcon.tsx
@@ -8,12 +8,12 @@ export type SvgIconProps = {
     children?: React.ReactNode 
 };
 
-const SvgIcon: React.FC<SvgIconProps> = ({ 
-    className, 
-    strokeWidth = 3, 
-    size = 24, 
+const SvgIcon: React.FC<SvgIconProps> = ({
+    className,
+    strokeWidth = 3,
+    size = 24,
     viewBox,
-    children 
+    children
 }) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -24,6 +24,8 @@ const SvgIcon: React.FC<SvgIconProps> = ({
         strokeWidth={strokeWidth}
         className={className}
         style={{ aspectRatio: 'auto' }}
+        aria-hidden="true"
+        focusable="false"
     >
         {children}
     </svg>

--- a/src/src/components/shared/typography/core/styles.ts
+++ b/src/src/components/shared/typography/core/styles.ts
@@ -1,8 +1,8 @@
 export const typographyStyles = {
-    heading1: "text-3xl md:text-4xl font-bold heading-font text-text-primary",
-    heading2: "text-2xl md:text-3xl font-bold heading-font text-text-primary",
-    heading3: "text-xl md:text-2xl font-bold text-text-secondary heading-font",
-    heading4: "text-lg md:text-xl font-semibold heading-font text-text-tertiary",
+    heading1: "text-4xl md:text-6xl font-bold heading-font text-text-primary text-balance",
+    heading2: "text-2xl md:text-3xl font-bold heading-font text-text-primary text-balance",
+    heading3: "text-xl md:text-2xl font-bold text-text-secondary heading-font text-balance",
+    heading4: "text-lg md:text-xl font-semibold heading-font text-text-tertiary text-balance",
     text: "text-base md:text-lg text-text-tertiary leading-relaxed! text-font",
     secondary: "text-base md:text-lg text-text-muted leading-relaxed! text-font",
     strong: "font-semibold text-text-tertiary text-font",

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -65,6 +65,7 @@
 /* Dark mode styles when .dark class is applied */
 :root.dark,
 .dark {
+    color-scheme: dark;
     --color-background: oklch(10% 0.012 264.8); /* Very dark gray */
     --color-foreground: oklch(98% 0.003 264.542); /* Near white */
     
@@ -118,4 +119,11 @@
 .dark {
     --background: var(--color-background);
     --foreground: var(--color-foreground);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, ::before, ::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+    }
 }

--- a/src/src/pages/HomePage.tsx
+++ b/src/src/pages/HomePage.tsx
@@ -26,22 +26,25 @@ export default function HomePage() {
                     image={profile.avatar}
                     actions={<ContactLinks contacts={contacts} />}
                 />
-                <TextSection 
-                    heading="About Me" 
-                    text={profile.introduction} 
+                <TextSection
+                    heading="About Me"
+                    label="Background"
+                    text={profile.introduction}
                     redirectPath="/about#about-me"
                     redirectLabel="Read more about me"
                 />
-                <ThumbnailGridSection 
-                    heading="What I Do" 
-                    size="large" 
-                    columns={2} 
+                <ThumbnailGridSection
+                    heading="What I Do"
+                    label="Expertise"
+                    size="large"
+                    columns={2}
                     items={interests}
                     redirectPath="/about#skills"
                     redirectLabel="Explore my skills in detail"
                 />
                 <ThumbnailGridSection
                     heading="My Certifications"
+                    label="Credentials"
                     size="large"
                     columns={3}
                     items={featuredCertifications}
@@ -50,6 +53,7 @@ export default function HomePage() {
                 />
                 <ArticleListSection
                     heading="Featured Articles"
+                    label="Writing"
                     articles={featuredArticles}
                     limit={4}
                     redirectPath="/articles"


### PR DESCRIPTION
## Summary

- **Typography**: Hero H1 scaled up to `text-4xl/text-6xl` for editorial impact; all section headings corrected from `<h1>` to `<h2>` (heading hierarchy was broken); `text-balance` added to all heading levels to prevent awkward line breaks
- **Section overline labels**: New optional `label` prop on `Section` and all section wrapper components; homepage now shows uppercase category labels (Background, Expertise, Credentials, Writing) above each section heading for a more designed, intentional feel
- **Section navigation**: Replaced `<div onClick>` + `window.location.assign()` with a proper React Router `<Link>` — restores Cmd/Ctrl+click, middle-click, and keyboard navigation
- **Cards**: Radius reduced `rounded-3xl` → `rounded-xl`; default shadow reduced `shadow-md` → `shadow-sm`; hover shadow reduced `shadow-xl` → `shadow-md` (flat at rest, elevates on hover)
- **Accessibility**: `aria-hidden` + `focusable="false"` on all SVG icons; `aria-label` added to icon-only contact links; `focus-visible` ring added to `NewTabLink`; hover state added to external links
- **Performance**: `fetchPriority="high"` on above-fold hero image
- **Dark mode**: `color-scheme: dark` added to `.dark` block (fixes scrollbar and native input styling on Windows/Chrome)
- **Motion**: `@media (prefers-reduced-motion: reduce)` disables all transitions for users who prefer it

## Test plan

- [ ] Homepage renders correctly in light and dark mode
- [ ] Hero heading is visibly larger than section headings
- [ ] Each section shows its overline label (Background, Expertise, Credentials, Writing)
- [ ] Section headings with chevron navigate correctly; Cmd+click opens in new tab
- [ ] Contact icon links are keyboard-focusable and have visible focus ring
- [ ] Hero avatar loads with high priority (check DevTools Network tab)
- [ ] Dark mode scrollbar matches page background on Windows/Chrome
- [ ] Cards are slightly flatter at rest, shadow appears on hover
- [ ] All 65 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)