### PR TITLE
Group consecutive same-company experience roles into single cards

### DIFF
--- a/content/data/experiences.json
+++ b/content/data/experiences.json
@@ -3,6 +3,7 @@
     "name": "Consultant, Full-Stack Developer",
     "start": "2025-12-01",
     "type": "Full-Time",
+    "group": "avanade-fulltime",
     "company": {
       "name": "Avanade",
       "website": "https://www.avanade.com",
@@ -14,13 +15,16 @@
         "height": 128
       }
     },
-    "description": "A global leader in digital innovation and cloud services, created by Accenture and Microsoft to help organizations accelerate their digital transformation.\n\n- Led development of enterprise-grade solutions using Azure, .NET, and the Microsoft ecosystem for global clients.  \n- Architected and delivered scalable cloud applications using Azure, Infrastructure as Code, and clean architectural patterns.  \n- Championed code quality by applying clean code principles, resulting in maintainable, testable software.  \n- Mentored junior developers and interns across a variety of client and internal projects.  \n- Collaborated with clients to turn business requirements into secure, high-performance solutions.  \n- Promoted agile practices as a hands-on Scrum practitioner focused on continuous improvement and team effectiveness."
+    "companyDescription": "A global leader in digital innovation and cloud services, created by Accenture and Microsoft to help organizations accelerate their digital transformation.",
+    "description": "- Led development of enterprise-grade solutions using Azure, .NET, and the Microsoft ecosystem for global clients.\n- Architected and delivered scalable cloud applications using Azure, Infrastructure as Code, and clean architectural patterns.\n- Championed code quality by applying clean code principles, resulting in maintainable, testable software.\n- Mentored junior developers and interns across a variety of client and internal projects.\n- Collaborated with clients to turn business requirements into secure, high-performance solutions.\n- Promoted agile practices as a hands-on Scrum practitioner focused on continuous improvement and team effectiveness.",
+    "skills": ["Azure", ".NET", "TypeScript", "React", "Terraform", "DevOps", "Scrum"]
   },
   {
     "name": "Senior Analyst, Full-Stack Developer",
     "start": "2022-06-01",
     "end": "2025-12-01",
     "type": "Full-Time",
+    "group": "avanade-fulltime",
     "company": {
       "name": "Avanade",
       "website": "https://www.avanade.com",
@@ -32,7 +36,9 @@
         "height": 128
       }
     },
-    "description": "A global leader in digital innovation and cloud services, created by Accenture and Microsoft to help organizations accelerate their digital transformation.\n\n- Led development of enterprise-grade solutions using Azure, .NET, and the Microsoft ecosystem for global clients.  \n- Architected and delivered scalable cloud applications using Azure, Infrastructure as Code, and clean architectural patterns.  \n- Championed code quality by applying clean code principles, resulting in maintainable, testable software.  \n- Mentored junior developers and interns across a variety of client and internal projects.  \n- Collaborated with clients to turn business requirements into secure, high-performance solutions.  \n- Promoted agile practices as a hands-on Scrum practitioner focused on continuous improvement and team effectiveness."
+    "companyDescription": "A global leader in digital innovation and cloud services, created by Accenture and Microsoft to help organizations accelerate their digital transformation.",
+    "description": "- Led development of enterprise-grade solutions using Azure, .NET, and the Microsoft ecosystem for global clients.\n- Architected and delivered scalable cloud applications using Azure, Infrastructure as Code, and clean architectural patterns.\n- Championed code quality by applying clean code principles, resulting in maintainable, testable software.\n- Mentored junior developers and interns across a variety of client and internal projects.\n- Collaborated with clients to turn business requirements into secure, high-performance solutions.\n- Promoted agile practices as a hands-on Scrum practitioner focused on continuous improvement and team effectiveness.",
+    "skills": ["Azure", ".NET", "C#", "Angular", "Power Platform", "Azure DevOps"]
   },
   {
     "name": "Analyst Developer",
@@ -50,7 +56,9 @@
         "height": 128
       }
     },
-    "description": "A Belgian non-profit IT organization that partners with public sector institutions to design and deliver secure, innovative, and scalable digital services for citizens and government agencies. Worked at the Belgian National Employment Office (ONEM) through Smals.\n\n- Contributed to mainframe system migration to Linux and modernization of legacy systems.  \n- Maintained and debugged a C++ shared library on Linux and supported a custom mainframe emulator.  \n- Developed web applications using Angular, Spring Boot, Docker, and Kubernetes to support government workflows.  \n- Automated deployments using Atlassian Bamboo, improving release speed and reliability.  \n- Worked within agile teams, using Jira for sprint planning and Bitbucket for source control.  \n- Implemented testing strategies with Cypress, Cucumber, Jest, and JUnit to ensure code quality and coverage."
+    "companyDescription": "A Belgian non-profit IT organization that partners with public sector institutions to design and deliver secure, innovative, and scalable digital services for citizens and government agencies. Worked at the Belgian National Employment Office (ONEM) through Smals.",
+    "description": "- Contributed to mainframe system migration to Linux and modernization of legacy systems.\n- Maintained and debugged a C++ shared library on Linux and supported a custom mainframe emulator.\n- Developed web applications using Angular, Spring Boot, Docker, and Kubernetes to support government workflows.\n- Automated deployments using Atlassian Bamboo, improving release speed and reliability.\n- Worked within agile teams, using Jira for sprint planning and Bitbucket for source control.\n- Implemented testing strategies with Cypress, Cucumber, Jest, and JUnit to ensure code quality and coverage.",
+    "skills": ["Angular", "Spring Boot", "Docker", "Kubernetes", "C++", "Linux"]
   },
   {
     "name": "Software Engineer Intern",
@@ -68,7 +76,9 @@
         "height": 128
       }
     },
-    "description": "A global leader in digital and cloud services, founded by Accenture and Microsoft to help organizations accelerate innovation through the Microsoft ecosystem.\n\n- Designed and developed a cloud-native proof-of-concept application using React, TypeScript, Azure Functions (.NET), Azure Storage Tables, and Azure Key Vault.  \n- Created Azure DevOps web extensions to support agile teams with mood tracking and reporting tools.  \n- Implemented automated DevOps workflows for builds and deployments within the Azure ecosystem.  \n- Applied clean code and security best practices with focus on scalability and maintainability.  \n- Delivered technical demos to both technical and non-technical stakeholders."
+    "companyDescription": "A global leader in digital and cloud services, founded by Accenture and Microsoft to help organizations accelerate innovation through the Microsoft ecosystem.",
+    "description": "- Designed and developed a cloud-native proof-of-concept application using React, TypeScript, Azure Functions (.NET), Azure Storage Tables, and Azure Key Vault.\n- Created Azure DevOps web extensions to support agile teams with mood tracking and reporting tools.\n- Implemented automated DevOps workflows for builds and deployments within the Azure ecosystem.\n- Applied clean code and security best practices with focus on scalability and maintainability.\n- Delivered technical demos to both technical and non-technical stakeholders.",
+    "skills": ["React", "TypeScript", "Azure Functions", ".NET", "Azure DevOps"]
   },
   {
     "name": "Software Engineer Intern",
@@ -86,6 +96,8 @@
         "height": 128
       }
     },
-    "description": "A specialized prototyping internship program bridging innovation and industry experience through partnerships with leading technology companies.\n\n- Selected for competitive prototyping internship program after rigorous selection sessions.  \n- Worked on Avanade-sponsored project while receiving training and mentorship at Microsoft.  \n- Received training on Scrum, Python, Node.js, Angular, React, Big Data, and IoT.  \n- Developed technical and soft skills through expert-led workshops and mentorship sessions.  \n- Adapted to remote collaboration during coronavirus outbreak, maintaining productivity through online supervision.  \n- Contributed to innovation projects supporting startups and entrepreneurs in the local tech ecosystem."
+    "companyDescription": "A specialized prototyping internship program bridging innovation and industry experience through partnerships with leading technology companies.",
+    "description": "- Selected for competitive prototyping internship program after rigorous selection sessions.\n- Worked on Avanade-sponsored project while receiving training and mentorship at Microsoft.\n- Received training on Scrum, Python, Node.js, Angular, React, Big Data, and IoT.\n- Developed technical and soft skills through expert-led workshops and mentorship sessions.\n- Adapted to remote collaboration during coronavirus outbreak, maintaining productivity through online supervision.\n- Contributed to innovation projects supporting startups and entrepreneurs in the local tech ecosystem.",
+    "skills": ["Python", "Node.js", "Angular", "React", "Scrum"]
   }
 ]

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Card, { CardBody, CardHeader, CardMedia, CardSubtitle } from "./Card";
+import Card, { CardHeader, CardMedia, CardSubtitle } from "./Card";
 import InfoCard from "./InfoCard";
 import { Secondary } from "@/components/shared/typography";
 import IconTag from "@/components/shared/IconTag";
@@ -34,15 +34,9 @@ const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ rol
             {!isLast && <div className="w-0.5 flex-1 bg-border-light mt-1" />}
         </div>
 
-        <div className="pb-6">
+        <div className={isLast ? "" : "pb-4"}>
             <CardTitleWithTooltip>{role.name}</CardTitleWithTooltip>
             <Secondary>{role.type} · {formatPeriod(role.start, role.end)}</Secondary>
-            {role.description && (
-                <div className="mt-2">
-                    <MarkdownPreview>{role.description}</MarkdownPreview>
-                </div>
-            )}
-            <RoleSkills skills={role.skills} />
         </div>
     </div>
 );
@@ -72,9 +66,10 @@ const SingleExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "
 };
 
 const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "grouped" }> }> = ({ entry }) => {
-    const { company, companyDescription, roles } = entry;
+    const { company, roles } = entry;
     const earliestStart = roles[roles.length - 1]?.start;
     const latestEnd = roles[0]?.end;
+    const allSkills = [...new Set(roles.flatMap((r) => r.skills ?? []))];
 
     return (
         <Card className="scroll-mt-24">
@@ -91,17 +86,15 @@ const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: 
                 <div className="flex flex-col flex-1 min-w-0 items-start">
                     <CardHeader className="gap-1.5 w-full items-start">
                         <CardSubtitle className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                            {company.name} · {company.location}
+                            {company.name} ({roles[0]?.type})
                         </CardSubtitle>
+                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                            {company.location}
+                        </Secondary>
                         <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
                             {formatPeriod(earliestStart, latestEnd)}
                         </Secondary>
                     </CardHeader>
-                    {companyDescription && (
-                        <CardBody className="pt-1 gap-2 w-full items-start">
-                            <MarkdownPreview>{companyDescription}</MarkdownPreview>
-                        </CardBody>
-                    )}
                 </div>
             </div>
 
@@ -114,6 +107,8 @@ const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: 
                     />
                 ))}
             </div>
+
+            <RoleSkills skills={allSkills} />
         </Card>
     );
 };

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -17,7 +17,7 @@ const formatPeriod = (start: Date, end?: Date) => {
 const RoleSkills: React.FC<{ skills?: string[] }> = ({ skills }) => {
     if (!skills?.length) return null;
     return (
-        <div className="flex flex-wrap gap-1.5 mt-2">
+        <div className="flex flex-wrap gap-2 mt-4">
             {skills.map((skill) => (
                 <IconTag key={skill}>{skill}</IconTag>
             ))}
@@ -28,12 +28,12 @@ const RoleSkills: React.FC<{ skills?: string[] }> = ({ skills }) => {
 const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ role, isLast = false }) => (
     <div className="relative pl-6">
         <div className="absolute left-0 top-0 bottom-0 flex flex-col items-center">
-            <div className="w-2.5 h-2.5 rounded-full bg-accent border-2 border-accent shrink-0 mt-1.5" />
+            <div className="w-2.5 h-2.5 rounded-full bg-surface border-2 border-accent shrink-0 mt-1.5" />
             {!isLast && <div className="w-0.5 flex-1 bg-border-light mt-1" />}
         </div>
 
         <div className="pb-6">
-            <Heading4>{role.name}</Heading4>
+            <Heading4 className="text-text-secondary!">{role.name}</Heading4>
             <Secondary>{role.type} · {formatPeriod(role.start, role.end)}</Secondary>
             {role.description && (
                 <div className="mt-2">
@@ -86,7 +86,7 @@ const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: 
             mediaAlign="start"
             align="start"
             footer={
-                <div className="w-full">
+                <div className="w-full border-t border-border-light pt-4">
                     {roles.map((role, index) => (
                         <RoleSection
                             key={`${role.name}-${String(role.start)}`}

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import Card, { CardBody, CardHeader, CardMedia, CardSubtitle } from "./Card";
 import InfoCard from "./InfoCard";
-import { Heading4, Secondary } from "@/components/shared/typography";
+import { Secondary } from "@/components/shared/typography";
 import IconTag from "@/components/shared/IconTag";
 import { MarkdownPreview } from "@/components/shared/preview";
+import CardTitleWithTooltip from "./CardTitleWithTooltip";
 import type { ExperienceEntry, ExperienceRole } from "@/core/experiences";
 
 const formatMonthYear = (date: Date | string) => {
@@ -33,7 +35,7 @@ const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ rol
         </div>
 
         <div className="pb-6">
-            <Heading4 className="text-text-secondary!">{role.name}</Heading4>
+            <CardTitleWithTooltip>{role.name}</CardTitleWithTooltip>
             <Secondary>{role.type} · {formatPeriod(role.start, role.end)}</Secondary>
             {role.description && (
                 <div className="mt-2">
@@ -75,30 +77,44 @@ const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: 
     const latestEnd = roles[0]?.end;
 
     return (
-        <InfoCard
-            title={company.name}
-            details={[
-                company.location,
-                formatPeriod(earliestStart, latestEnd),
-            ]}
-            media={company.logo}
-            mediaSize="small"
-            mediaAlign="start"
-            align="start"
-            footer={
-                <div className="w-full border-t border-border-light pt-4">
-                    {roles.map((role, index) => (
-                        <RoleSection
-                            key={`${role.name}-${String(role.start)}`}
-                            role={role}
-                            isLast={index === roles.length - 1}
-                        />
-                    ))}
+        <Card className="scroll-mt-24">
+            <div className="flex w-full items-start gap-4">
+                {company.logo && (
+                    <CardMedia
+                        media={company.logo}
+                        size="medium"
+                        align="start"
+                        containerClassName="flex shrink-0 justify-center items-start mt-1"
+                        className="w-12 h-12 md:w-16 md:h-16"
+                    />
+                )}
+                <div className="flex flex-col flex-1 min-w-0 items-start">
+                    <CardHeader className="gap-1.5 w-full items-start">
+                        <CardSubtitle className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                            {company.name} · {company.location}
+                        </CardSubtitle>
+                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                            {formatPeriod(earliestStart, latestEnd)}
+                        </Secondary>
+                    </CardHeader>
+                    {companyDescription && (
+                        <CardBody className="pt-1 gap-2 w-full items-start">
+                            <MarkdownPreview>{companyDescription}</MarkdownPreview>
+                        </CardBody>
+                    )}
                 </div>
-            }
-        >
-            {companyDescription && <MarkdownPreview>{companyDescription}</MarkdownPreview>}
-        </InfoCard>
+            </div>
+
+            <div className="mt-4 border-t border-border-light pt-4">
+                {roles.map((role, index) => (
+                    <RoleSection
+                        key={`${role.name}-${String(role.start)}`}
+                        role={role}
+                        isLast={index === roles.length - 1}
+                    />
+                ))}
+            </div>
+        </Card>
     );
 };
 

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -47,6 +47,7 @@ const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ rol
 
 const SingleExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "single" }> }> = ({ entry }) => {
     const { company, companyDescription, role } = entry;
+    const combinedMarkdown = [companyDescription, role.description].filter(Boolean).join("\n\n");
 
     return (
         <InfoCard
@@ -62,8 +63,7 @@ const SingleExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "
             align="start"
             showTitleTooltip
         >
-            {companyDescription && <MarkdownPreview>{companyDescription}</MarkdownPreview>}
-            {role.description && <MarkdownPreview>{role.description}</MarkdownPreview>}
+            {combinedMarkdown && <MarkdownPreview>{combinedMarkdown}</MarkdownPreview>}
             <RoleSkills skills={role.skills} />
         </InfoCard>
     );

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import Card, { CardBody, CardHeader, CardMedia, CardSubtitle, CardTitle } from "./Card";
+import CardTitleWithTooltip from "./CardTitleWithTooltip";
+import { Secondary, Text } from "@/components/shared/typography";
+import IconTag from "@/components/shared/IconTag";
+import { MarkdownPreview } from "@/components/shared/preview";
+import type { ExperienceEntry, ExperienceRole } from "@/core/experiences";
+
+const formatMonthYear = (date: Date | string) => {
+    const d = typeof date === "string" ? new Date(date) : date;
+    return d.toLocaleDateString(undefined, { year: "numeric", month: "long" });
+};
+
+const formatPeriod = (start: Date, end?: Date) => {
+    return `${formatMonthYear(start)} - ${end ? formatMonthYear(end) : "Present"}`;
+};
+
+const RoleSkills: React.FC<{ skills?: string[] }> = ({ skills }) => {
+    if (!skills?.length) return null;
+    return (
+        <div className="flex flex-wrap gap-1.5 mt-2">
+            {skills.map((skill) => (
+                <IconTag key={skill}>{skill}</IconTag>
+            ))}
+        </div>
+    );
+};
+
+const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ role, isLast = false }) => (
+    <div className="relative pl-6">
+        {/* Timeline connector */}
+        <div className="absolute left-0 top-0 bottom-0 flex flex-col items-center">
+            <div className="w-2.5 h-2.5 rounded-full bg-accent border-2 border-accent shrink-0 mt-1.5" />
+            {!isLast && <div className="w-0.5 flex-1 bg-border-light mt-1" />}
+        </div>
+
+        <div className="pb-6">
+            <p className="text-base font-semibold text-text leading-tight">{role.name}</p>
+            <Secondary>{role.type} · {formatPeriod(role.start, role.end)}</Secondary>
+            {role.description && (
+                <div className="mt-2">
+                    <MarkdownPreview>{role.description}</MarkdownPreview>
+                </div>
+            )}
+            <RoleSkills skills={role.skills} />
+        </div>
+    </div>
+);
+
+const ExperienceCard: React.FC<{ entry: ExperienceEntry }> = ({ entry }) => {
+    const { company, companyDescription } = entry;
+    const mediaProps = company.logo;
+
+    if (entry.kind === "single") {
+        const { role } = entry;
+        return (
+            <Card className="scroll-mt-24">
+                <div className="flex w-full items-start gap-4">
+                    {mediaProps && (
+                        <CardMedia
+                            media={mediaProps}
+                            size="medium"
+                            align="start"
+                            containerClassName="flex shrink-0 justify-center items-start mt-1"
+                            className="w-12 h-12 md:w-16 md:h-16"
+                        />
+                    )}
+                    <div className="flex flex-col flex-1 min-w-0 items-start">
+                        <CardHeader className="gap-1.5 w-full items-start">
+                            <CardTitleWithTooltip>{role.name}</CardTitleWithTooltip>
+                            <CardSubtitle className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                                {company.name} ({role.type})
+                            </CardSubtitle>
+                            <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                                {company.location}
+                            </Secondary>
+                            <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                                {formatPeriod(role.start, role.end)}
+                            </Secondary>
+                        </CardHeader>
+                        <CardBody className="pt-1 gap-2 w-full items-start">
+                            {companyDescription && <Text>{companyDescription}</Text>}
+                            {role.description && <MarkdownPreview>{role.description}</MarkdownPreview>}
+                            <RoleSkills skills={role.skills} />
+                        </CardBody>
+                    </div>
+                </div>
+            </Card>
+        );
+    }
+
+    const { roles } = entry;
+    const earliestStart = roles[roles.length - 1]?.start;
+    const latestEnd = roles[0]?.end;
+
+    return (
+        <Card className="scroll-mt-24">
+            <div className="flex w-full items-start gap-4">
+                {mediaProps && (
+                    <CardMedia
+                        media={mediaProps}
+                        size="medium"
+                        align="start"
+                        containerClassName="flex shrink-0 justify-center items-start mt-1"
+                        className="w-12 h-12 md:w-16 md:h-16"
+                    />
+                )}
+                <div className="flex flex-col flex-1 min-w-0 items-start">
+                    <CardHeader className="gap-1.5 w-full items-start">
+                        <CardTitle className="leading-tight">{company.name}</CardTitle>
+                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                            {company.location}
+                        </Secondary>
+                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
+                            {formatPeriod(earliestStart, latestEnd)}
+                        </Secondary>
+                    </CardHeader>
+                    {companyDescription && (
+                        <CardBody className="pt-1 gap-2 w-full items-start">
+                            <Text>{companyDescription}</Text>
+                        </CardBody>
+                    )}
+                </div>
+            </div>
+
+            {/* Role timeline */}
+            <div className="mt-6">
+                {roles.map((role, index) => (
+                    <RoleSection
+                        key={`${role.name}-${String(role.start)}`}
+                        role={role}
+                        isLast={index === roles.length - 1}
+                    />
+                ))}
+            </div>
+        </Card>
+    );
+};
+
+export default ExperienceCard;

--- a/src/src/components/cards/ExperienceCard.tsx
+++ b/src/src/components/cards/ExperienceCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import Card, { CardBody, CardHeader, CardMedia, CardSubtitle, CardTitle } from "./Card";
-import CardTitleWithTooltip from "./CardTitleWithTooltip";
-import { Secondary, Text } from "@/components/shared/typography";
+import InfoCard from "./InfoCard";
+import { Heading4, Secondary } from "@/components/shared/typography";
 import IconTag from "@/components/shared/IconTag";
 import { MarkdownPreview } from "@/components/shared/preview";
 import type { ExperienceEntry, ExperienceRole } from "@/core/experiences";
@@ -28,14 +27,13 @@ const RoleSkills: React.FC<{ skills?: string[] }> = ({ skills }) => {
 
 const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ role, isLast = false }) => (
     <div className="relative pl-6">
-        {/* Timeline connector */}
         <div className="absolute left-0 top-0 bottom-0 flex flex-col items-center">
             <div className="w-2.5 h-2.5 rounded-full bg-accent border-2 border-accent shrink-0 mt-1.5" />
             {!isLast && <div className="w-0.5 flex-1 bg-border-light mt-1" />}
         </div>
 
         <div className="pb-6">
-            <p className="text-base font-semibold text-text leading-tight">{role.name}</p>
+            <Heading4>{role.name}</Heading4>
             <Secondary>{role.type} · {formatPeriod(role.start, role.end)}</Secondary>
             {role.description && (
                 <div className="mt-2">
@@ -47,94 +45,68 @@ const RoleSection: React.FC<{ role: ExperienceRole; isLast?: boolean }> = ({ rol
     </div>
 );
 
-const ExperienceCard: React.FC<{ entry: ExperienceEntry }> = ({ entry }) => {
-    const { company, companyDescription } = entry;
-    const mediaProps = company.logo;
+const SingleExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "single" }> }> = ({ entry }) => {
+    const { company, companyDescription, role } = entry;
 
-    if (entry.kind === "single") {
-        const { role } = entry;
-        return (
-            <Card className="scroll-mt-24">
-                <div className="flex w-full items-start gap-4">
-                    {mediaProps && (
-                        <CardMedia
-                            media={mediaProps}
-                            size="medium"
-                            align="start"
-                            containerClassName="flex shrink-0 justify-center items-start mt-1"
-                            className="w-12 h-12 md:w-16 md:h-16"
-                        />
-                    )}
-                    <div className="flex flex-col flex-1 min-w-0 items-start">
-                        <CardHeader className="gap-1.5 w-full items-start">
-                            <CardTitleWithTooltip>{role.name}</CardTitleWithTooltip>
-                            <CardSubtitle className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                                {company.name} ({role.type})
-                            </CardSubtitle>
-                            <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                                {company.location}
-                            </Secondary>
-                            <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                                {formatPeriod(role.start, role.end)}
-                            </Secondary>
-                        </CardHeader>
-                        <CardBody className="pt-1 gap-2 w-full items-start">
-                            {companyDescription && <Text>{companyDescription}</Text>}
-                            {role.description && <MarkdownPreview>{role.description}</MarkdownPreview>}
-                            <RoleSkills skills={role.skills} />
-                        </CardBody>
-                    </div>
-                </div>
-            </Card>
-        );
-    }
+    return (
+        <InfoCard
+            title={role.name}
+            subtitle={`${company.name} (${role.type})`}
+            details={[
+                company.location,
+                formatPeriod(role.start, role.end),
+            ]}
+            media={company.logo}
+            mediaSize="small"
+            mediaAlign="start"
+            align="start"
+            showTitleTooltip
+        >
+            {companyDescription && <MarkdownPreview>{companyDescription}</MarkdownPreview>}
+            {role.description && <MarkdownPreview>{role.description}</MarkdownPreview>}
+            <RoleSkills skills={role.skills} />
+        </InfoCard>
+    );
+};
 
-    const { roles } = entry;
+const GroupedExperienceCard: React.FC<{ entry: Extract<ExperienceEntry, { kind: "grouped" }> }> = ({ entry }) => {
+    const { company, companyDescription, roles } = entry;
     const earliestStart = roles[roles.length - 1]?.start;
     const latestEnd = roles[0]?.end;
 
     return (
-        <Card className="scroll-mt-24">
-            <div className="flex w-full items-start gap-4">
-                {mediaProps && (
-                    <CardMedia
-                        media={mediaProps}
-                        size="medium"
-                        align="start"
-                        containerClassName="flex shrink-0 justify-center items-start mt-1"
-                        className="w-12 h-12 md:w-16 md:h-16"
-                    />
-                )}
-                <div className="flex flex-col flex-1 min-w-0 items-start">
-                    <CardHeader className="gap-1.5 w-full items-start">
-                        <CardTitle className="leading-tight">{company.name}</CardTitle>
-                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                            {company.location}
-                        </Secondary>
-                        <Secondary className="w-full whitespace-nowrap overflow-hidden text-ellipsis">
-                            {formatPeriod(earliestStart, latestEnd)}
-                        </Secondary>
-                    </CardHeader>
-                    {companyDescription && (
-                        <CardBody className="pt-1 gap-2 w-full items-start">
-                            <Text>{companyDescription}</Text>
-                        </CardBody>
-                    )}
+        <InfoCard
+            title={company.name}
+            details={[
+                company.location,
+                formatPeriod(earliestStart, latestEnd),
+            ]}
+            media={company.logo}
+            mediaSize="small"
+            mediaAlign="start"
+            align="start"
+            footer={
+                <div className="w-full">
+                    {roles.map((role, index) => (
+                        <RoleSection
+                            key={`${role.name}-${String(role.start)}`}
+                            role={role}
+                            isLast={index === roles.length - 1}
+                        />
+                    ))}
                 </div>
-            </div>
-
-            {/* Role timeline */}
-            <div className="mt-6">
-                {roles.map((role, index) => (
-                    <RoleSection
-                        key={`${role.name}-${String(role.start)}`}
-                        role={role}
-                        isLast={index === roles.length - 1}
-                    />
-                ))}
-            </div>
-        </Card>
+            }
+        >
+            {companyDescription && <MarkdownPreview>{companyDescription}</MarkdownPreview>}
+        </InfoCard>
     );
+};
+
+const ExperienceCard: React.FC<{ entry: ExperienceEntry }> = ({ entry }) => {
+    if (entry.kind === "single") {
+        return <SingleExperienceCard entry={entry} />;
+    }
+    return <GroupedExperienceCard entry={entry} />;
 };
 
 export default ExperienceCard;

--- a/src/src/core/experiences.ts
+++ b/src/src/core/experiences.ts
@@ -1,0 +1,89 @@
+import { Experience } from "@/types";
+import { Company } from "@/types/company";
+
+export interface ExperienceRole {
+    name: string;
+    start: Date;
+    end?: Date;
+    type?: Experience["type"];
+    description?: string;
+    skills?: string[];
+}
+
+export interface SingleExperienceEntry {
+    kind: "single";
+    company: Company;
+    companyDescription?: string;
+    role: ExperienceRole;
+}
+
+export interface GroupedExperienceEntry {
+    kind: "grouped";
+    company: Company;
+    companyDescription?: string;
+    roles: ExperienceRole[];
+}
+
+export type ExperienceEntry = SingleExperienceEntry | GroupedExperienceEntry;
+
+function toRole(experience: Experience): ExperienceRole {
+    return {
+        name: experience.name,
+        start: experience.start,
+        end: experience.end,
+        type: experience.type,
+        description: experience.description,
+        skills: experience.skills,
+    };
+}
+
+/**
+ * Groups experiences that share a `group` identifier into a single entry
+ * with multiple roles. Ungrouped experiences become single entries.
+ * Roles within a group are sorted by start date (most recent first).
+ */
+export function groupExperiences(experiences: Experience[]): ExperienceEntry[] {
+    const grouped = new Map<string, Experience[]>();
+    const singles: Experience[] = [];
+
+    for (const exp of experiences) {
+        if (exp.group) {
+            const existing = grouped.get(exp.group) ?? [];
+            existing.push(exp);
+            grouped.set(exp.group, existing);
+        } else {
+            singles.push(exp);
+        }
+    }
+
+    const entries: ExperienceEntry[] = [];
+    const seen = new Set<string>();
+
+    for (const exp of experiences) {
+        if (exp.group) {
+            if (seen.has(exp.group)) continue;
+            seen.add(exp.group);
+
+            const groupExps = grouped.get(exp.group)!;
+            const roles = groupExps
+                .map(toRole)
+                .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
+
+            entries.push({
+                kind: "grouped",
+                company: groupExps[0].company,
+                companyDescription: groupExps[0].companyDescription,
+                roles,
+            });
+        } else {
+            entries.push({
+                kind: "single",
+                company: exp.company,
+                companyDescription: exp.companyDescription,
+                role: toRole(exp),
+            });
+        }
+    }
+
+    return entries;
+}

--- a/src/src/pages/AboutPage.tsx
+++ b/src/src/pages/AboutPage.tsx
@@ -2,26 +2,17 @@ import Section from "@/components/shared/Section";
 import React from "react";
 import MarkdownSection from "@/components/shared/MarkdownSection";
 import { Card, CardBody, CardHeader, CardSubtitle, CardTitle } from "@/components/cards";
-import InfoCard from "@/components/cards/InfoCard";
 import { Certification, SkillCategory } from "@/types";
-import { MarkdownPreview } from "@/components/shared/preview";
 import { getCertifications, getDiploma, getExperiences, getProfile, getSkillCategories } from "@/core/data";
 import IconTag from "@/components/shared/IconTag";
 import { Text } from "@/components/shared/typography";
 import { createId } from "@/core/string";
 import ColumnContainer from "@/components/layout/ColumnContainer";
 import ThumbnailGridSection from "@/components/shared/ThumbnailGridSection";
-
-const formatMonthYear = (date: Date | string) => {
-    const d = typeof date === "string" ? new Date(date) : date;
-    return d.toLocaleDateString(undefined, { year: "numeric", month: "long" });
-};
-
-const formatExperiencePeriod = (start: Date, end?: Date) => {
-    const startDate = formatMonthYear(start);
-    const endDate = end ? formatMonthYear(end) : "Present";
-    return `${startDate} - ${endDate}`;
-};
+import ExperienceCard from "@/components/cards/ExperienceCard";
+import { groupExperiences } from "@/core/experiences";
+import InfoCard from "@/components/cards/InfoCard";
+import { MarkdownPreview } from "@/components/shared/preview";
 
 const certifications = getCertifications()
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
@@ -32,7 +23,7 @@ const certifications = getCertifications()
         url: certification.url,
     }));
 
-const experiences = getExperiences();
+const experiences = groupExperiences(getExperiences());
 const skillCategories = getSkillCategories();
 const diploma = getDiploma();
 const profile = getProfile();
@@ -51,24 +42,12 @@ export default function AboutPage() {
                 />
                 <Section heading="Experience">
                     <ColumnContainer>
-                        {experiences.map((experience) => (
-                            <InfoCard
-                                key={`${experience.name}-${experience.company.name}`}
-                                title={experience.name}
-                                subtitle={`${experience.company.name} (${experience.type})`}
-                                details={[
-                                    experience.company.location,
-                                    formatExperiencePeriod(experience.start, experience.end),
-                                ]}
-                                media={experience.company.logo}
-                                mediaSize="small"
-                                mediaAlign="start"
-                                align="start"
-                                showTitleTooltip
-                            >
-                                <MarkdownPreview>{experience.description}</MarkdownPreview>
-                            </InfoCard>
-                        ))}
+                        {experiences.map((entry) => {
+                            const key = entry.kind === "grouped"
+                                ? `group-${entry.company.name}`
+                                : `${entry.role.name}-${entry.company.name}`;
+                            return <ExperienceCard key={key} entry={entry} />;
+                        })}
                     </ColumnContainer>
                 </Section>
                 <Section heading="Education">

--- a/src/src/types/experience.ts
+++ b/src/src/types/experience.ts
@@ -6,5 +6,8 @@ export interface Experience {
   start: Date;
   end?: Date;
   type?: "Full-Time" | "Part-Time" | "Internship" | "Freelance";
+  companyDescription?: string;
   description?: string;
+  skills?: string[];
+  group?: string;
 }

--- a/src/tests/unit/core/experiences.test.ts
+++ b/src/tests/unit/core/experiences.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { groupExperiences, ExperienceEntry } from "@/core/experiences";
+import { Experience } from "@/types";
+
+const makeExperience = (overrides: Partial<Experience> = {}): Experience => ({
+    name: "Developer",
+    company: {
+        name: "Acme",
+        website: "https://acme.com",
+        location: "Brussels, Belgium",
+    },
+    start: new Date("2022-01-01"),
+    type: "Full-Time",
+    ...overrides,
+});
+
+describe("groupExperiences", () => {
+    it("returns empty array for empty input", () => {
+        expect(groupExperiences([])).toEqual([]);
+    });
+
+    it("returns a single entry for one ungrouped experience", () => {
+        const experiences = [makeExperience()];
+        const result = groupExperiences(experiences);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].kind).toBe("single");
+    });
+
+    it("preserves all fields in a single entry", () => {
+        const exp = makeExperience({
+            name: "Senior Dev",
+            description: "Did stuff",
+            skills: ["React", "TypeScript"],
+            companyDescription: "A great company",
+        });
+        const result = groupExperiences([exp]);
+        const entry = result[0] as Extract<ExperienceEntry, { kind: "single" }>;
+
+        expect(entry.role.name).toBe("Senior Dev");
+        expect(entry.role.description).toBe("Did stuff");
+        expect(entry.role.skills).toEqual(["React", "TypeScript"]);
+        expect(entry.companyDescription).toBe("A great company");
+    });
+
+    it("groups experiences with the same group identifier", () => {
+        const experiences = [
+            makeExperience({ name: "Senior Dev", group: "acme-ft", start: new Date("2024-01-01") }),
+            makeExperience({ name: "Junior Dev", group: "acme-ft", start: new Date("2022-01-01") }),
+        ];
+        const result = groupExperiences(experiences);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].kind).toBe("grouped");
+    });
+
+    it("sorts roles within a group by start date descending (most recent first)", () => {
+        const experiences = [
+            makeExperience({ name: "Junior", group: "acme-ft", start: new Date("2020-01-01") }),
+            makeExperience({ name: "Senior", group: "acme-ft", start: new Date("2023-01-01") }),
+            makeExperience({ name: "Mid", group: "acme-ft", start: new Date("2021-06-01") }),
+        ];
+        const result = groupExperiences(experiences);
+        const grouped = result[0] as Extract<ExperienceEntry, { kind: "grouped" }>;
+
+        expect(grouped.roles.map((r) => r.name)).toEqual(["Senior", "Mid", "Junior"]);
+    });
+
+    it("keeps ungrouped experiences separate from grouped ones", () => {
+        const experiences = [
+            makeExperience({ name: "Consultant", group: "acme-ft", start: new Date("2024-01-01") }),
+            makeExperience({ name: "Analyst", group: "acme-ft", start: new Date("2022-01-01") }),
+            makeExperience({ name: "Intern", company: { name: "Acme", website: "https://acme.com", location: "Brussels" } }),
+        ];
+        const result = groupExperiences(experiences);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].kind).toBe("grouped");
+        expect(result[1].kind).toBe("single");
+    });
+
+    it("preserves original order (grouped entry appears at position of first member)", () => {
+        const experiences = [
+            makeExperience({ name: "Consultant", group: "acme-ft", start: new Date("2024-01-01") }),
+            makeExperience({
+                name: "Other Company Dev",
+                company: { name: "Other", website: "https://other.com", location: "Ghent" },
+            }),
+            makeExperience({ name: "Analyst", group: "acme-ft", start: new Date("2022-01-01") }),
+        ];
+        const result = groupExperiences(experiences);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].kind).toBe("grouped");
+        expect(result[1].kind).toBe("single");
+        expect(result[1].company.name).toBe("Other");
+    });
+
+    it("handles multiple different groups", () => {
+        const experiences = [
+            makeExperience({ name: "Senior at A", group: "company-a", start: new Date("2024-01-01") }),
+            makeExperience({ name: "Junior at A", group: "company-a", start: new Date("2022-01-01") }),
+            makeExperience({
+                name: "Lead at B",
+                group: "company-b",
+                company: { name: "B Corp", website: "https://b.com", location: "Antwerp" },
+                start: new Date("2023-01-01"),
+            }),
+            makeExperience({
+                name: "Dev at B",
+                group: "company-b",
+                company: { name: "B Corp", website: "https://b.com", location: "Antwerp" },
+                start: new Date("2021-01-01"),
+            }),
+        ];
+        const result = groupExperiences(experiences);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].kind).toBe("grouped");
+        expect(result[0].company.name).toBe("Acme");
+        expect(result[1].kind).toBe("grouped");
+        expect(result[1].company.name).toBe("B Corp");
+    });
+
+    it("uses company info from the first experience in the group", () => {
+        const experiences = [
+            makeExperience({
+                name: "Senior",
+                group: "g1",
+                companyDescription: "First description",
+                start: new Date("2024-01-01"),
+            }),
+            makeExperience({
+                name: "Junior",
+                group: "g1",
+                companyDescription: "Second description",
+                start: new Date("2022-01-01"),
+            }),
+        ];
+        const result = groupExperiences(experiences);
+        const grouped = result[0] as Extract<ExperienceEntry, { kind: "grouped" }>;
+
+        expect(grouped.companyDescription).toBe("First description");
+    });
+});


### PR DESCRIPTION
## Motivation

When someone gets promoted within the same company, the About page currently shows each role as a separate card -- duplicating the company logo, description, and making it hard to see that the roles are related. This PR groups consecutive same-company roles into a single card with a clear career progression timeline.

## Approach

Rather than auto-grouping by company name (which would incorrectly merge unrelated stints like a past internship), this uses an explicit `group` field in the experience data. Experiences sharing the same `group` identifier are merged into one card.

**Data model changes:**
- Added `group`, `companyDescription`, and `skills` (string tags) fields to the `Experience` type
- Split the existing `description` field into a shared `companyDescription` (displayed once) and per-role `description` (bullet points specific to each role)
- Each role now has its own `skills` array rendered as tag labels

**Grouping logic** (`core/experiences.ts`):
- `groupExperiences()` takes a flat `Experience[]` and returns `ExperienceEntry[]` -- each entry is either a `SingleExperienceEntry` or a `GroupedExperienceEntry` with multiple roles
- Grouped roles are sorted by start date (most recent first)
- Original array order is preserved (grouped entry appears at the position of its first member)

**ExperienceCard component:**
- Single roles render similarly to the previous InfoCard layout
- Grouped roles show company info at the top, followed by a vertical timeline where each role displays its title, period, description, and skill tags

## What to look for

- The Avanade Consultant + Senior Analyst roles are grouped; the Avanade Intern stays separate
- Skill tags per role -- currently placeholder values, easy to refine later
- The timeline visual uses a simple dot-and-line pattern via Tailwind

## Testing

- 9 new unit tests for `groupExperiences()` covering: empty input, single entries, grouping, sort order, mixed grouped/ungrouped, multi-group, and company info resolution
- All 74 tests pass, build succeeds, lint clean