### PR TITLE
Remove homepage section labels

### DIFF
--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -23,6 +23,15 @@
     color: var(--color-foreground);
     background: var(--color-background);
   }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-manrope);
+  }
 }
 
 /* Base theme configuration using Tailwind v4 @theme directive */

--- a/src/src/pages/HomePage.tsx
+++ b/src/src/pages/HomePage.tsx
@@ -28,14 +28,12 @@ export default function HomePage() {
                 />
                 <TextSection
                     heading="About Me"
-                    label="Background"
                     text={profile.introduction}
                     redirectPath="/about#about-me"
                     redirectLabel="Read more about me"
                 />
                 <ThumbnailGridSection
                     heading="What I Do"
-                    label="Expertise"
                     size="large"
                     columns={2}
                     items={interests}
@@ -44,7 +42,6 @@ export default function HomePage() {
                 />
                 <ThumbnailGridSection
                     heading="My Certifications"
-                    label="Credentials"
                     size="large"
                     columns={3}
                     items={featuredCertifications}
@@ -53,7 +50,6 @@ export default function HomePage() {
                 />
                 <ArticleListSection
                     heading="Featured Articles"
-                    label="Writing"
                     articles={featuredArticles}
                     limit={4}
                     redirectPath="/articles"


### PR DESCRIPTION
The homepage section headings were visually crowded by small overline labels that duplicated the section meaning. This removes those labels so the headings stand on their own and better match the requested design.

This also reinforces typography consistency by applying Manrope to all semantic heading elements (`h1` through `h6`) at the global CSS base layer, while preserving the existing shared typography components and body font setup.