### PR TITLE
Hide technical deployment details

### DIFF
--- a/src/.env.local.example
+++ b/src/.env.local.example
@@ -26,7 +26,8 @@
 
 # Public Environment Variables
 # GitHub Repository URL
-#NEXT_PUBLIC_GITHUB_REPOSITORY_URL=https://github.com/lfarci/loganfarci.com
+#VITE_GITHUB_REPOSITORY_URL=https://github.com/lfarci/loganfarci.com
 
-# Commit Hash
-#NEXT_PUBLIC_COMMIT_HASH=dev
+# Preview deployment details
+#VITE_DEPLOYMENT_ENVIRONMENT=Preview
+#VITE_COMMIT_HASH=dev

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useRoutes } from "react-router";
 import { HeroUIProvider } from "@heroui/react";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -6,9 +7,19 @@ import { routes } from "./routes";
 
 const githubRepositoryUrl = import.meta.env.VITE_GITHUB_REPOSITORY_URL;
 const latestCommitHash = import.meta.env.VITE_COMMIT_HASH;
+const deploymentEnvironment = import.meta.env.VITE_DEPLOYMENT_ENVIRONMENT;
+const isConfiguredPreviewEnvironment = deploymentEnvironment?.toLowerCase() === "preview";
+const previewHostnamePattern = /(^|-)pr-\d+([.-]|$)/i;
 
 export default function App() {
     const element = useRoutes(routes);
+    const [isPreviewEnvironment, setIsPreviewEnvironment] = useState(isConfiguredPreviewEnvironment);
+
+    useEffect(() => {
+        if (!isConfiguredPreviewEnvironment) {
+            setIsPreviewEnvironment(previewHostnamePattern.test(window.location.hostname));
+        }
+    }, []);
 
     return (
         <HeroUIProvider>
@@ -18,7 +29,7 @@ export default function App() {
                 <meta name="keywords" content="Software Engineer, Logan Farci, Developer, Brussels, Belgium" />
                 <LayoutWrapper
                     githubRepositoryUrl={githubRepositoryUrl}
-                    commitHash={latestCommitHash}
+                    commitHash={isPreviewEnvironment ? latestCommitHash : undefined}
                 >
                     {element}
                 </LayoutWrapper>

--- a/src/src/components/layout/Footer.tsx
+++ b/src/src/components/layout/Footer.tsx
@@ -15,16 +15,7 @@ const Footer: React.FC<FooterProps> = ({ githubRepositoryUrl, commitHash, commit
     return (
         <footer className="max-w-(--breakpoint-lg) mx-auto px-4 flex flex-wrap justify-between items-center pb-8 gap-y-2">
             <div className="flex flex-wrap items-center gap-1 min-w-0">
-                <Footnote>© Logan Farci. Powered by </Footnote>
-                <NewTabLink url="https://vite.dev/" size="footnote">
-                    {" "}
-                    Vite{" "}
-                </NewTabLink>
-                <Footnote> and </Footnote>
-                <NewTabLink url="https://azure.microsoft.com/en-us/products/app-service/static" size="footnote">
-                    {" "}
-                    Azure Static Web App.{" "}
-                </NewTabLink>
+                <Footnote>© Logan Farci.</Footnote>
             </div>
             {showCommitHash && (
                 <div className="flex flex-wrap items-center gap-1 min-w-0">

--- a/src/src/vite-env.d.ts
+++ b/src/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
     readonly VITE_GITHUB_REPOSITORY_URL?: string;
     readonly VITE_COMMIT_HASH?: string;
+    readonly VITE_DEPLOYMENT_ENVIRONMENT?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Removes implementation and hosting details from the public footer so the site presents a cleaner, less technical surface to visitors.

The footer now keeps only the copyright line, and the build commit link is only passed through in preview contexts. Preview detection supports an explicit `VITE_DEPLOYMENT_ENVIRONMENT=Preview` value and falls back to Azure preview hostnames that include `pr-<number>`, so production and other non-preview environments no longer show the hash.

Validation: `npm run lint && npm run test && npm run build`