### PR TITLE
Align greeting hand icon

### DIFF
--- a/src/src/components/GreetingHeading.tsx
+++ b/src/src/components/GreetingHeading.tsx
@@ -15,7 +15,7 @@ const GreetingHeading: React.FC<GreetingHeadingProps> = ({
     name,
     iconSrc = "/images/icons/waving_hand.avif",
     iconAlt = "Waving hand",
-    iconSize = 40,
+    iconSize = 64,
 }) => (
     <Heading1 className="flex items-center">
         <span className="pr-1">{greeting}</span>
@@ -24,7 +24,7 @@ const GreetingHeading: React.FC<GreetingHeadingProps> = ({
             alt={iconAlt}
             width={iconSize}
             height={iconSize}
-            className="inline-block w-10 h-10"
+            className="inline-block size-[1em] shrink-0"
         />
         <span>, I&apos;m {name}</span>
     </Heading1>


### PR DESCRIPTION
The home hero greeting used a fixed-size hand icon while the `Hi` heading scales between mobile and desktop sizes. This keeps the icon aligned with the heading typography so the greeting stays visually balanced at each breakpoint.

## Changes
- Size the waving hand image with `1em` so it follows the `Heading1` font size.
- Keep intrinsic width and height metadata aligned with the desktop heading size and prevent flex shrink.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`

Note: the build still emits existing React `<title>` child warnings during article prerendering; this change does not touch those pages.