### PR TITLE
Skip Dependabot preview deployments

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -39,7 +39,7 @@ jobs:
       AZURE_KEY_VAULT_NAME: ${{ secrets.AZURE_KEY_VAULT_NAME }}
 
   deploy_preview:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
     name: "Deploy App to Preview"
     uses: ./.github/workflows/reusable-deploy-static-web-app.yml
     permissions:
@@ -57,7 +57,7 @@ jobs:
       AZURE_KEY_VAULT_NAME: ${{ secrets.AZURE_KEY_VAULT_NAME }}
 
   close_pull_request:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
     name: "Close Pull Request"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -6,18 +6,14 @@ on:
       - main
     paths:
       - "src/**"
-      - "content/**"
-      - ".github/workflows/deploy-app.yml"
-      - ".github/workflows/reusable-deploy-static-web-app.yml"
+      - "content/articles/**"
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
     paths:
       - "src/**"
-      - "content/**"
-      - ".github/workflows/deploy-app.yml"
-      - ".github/workflows/reusable-deploy-static-web-app.yml"
+      - "content/articles/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "src/**"
       - "content/articles/**"
+      - "content/data/**"
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - "src/**"
       - "content/articles/**"
+      - "content/data/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Dependabot PRs should not create Azure Static Web Apps preview environments, and deployment runs should stay focused on changes that affect the web app or articles.

This updates the app deployment workflow to skip preview deploy and close jobs for PRs authored by `dependabot[bot]`. It also narrows automatic deployment triggers to web app changes under `src/**` and article changes under `content/articles/**`, while keeping manual dispatch available.