### PR TITLE
Fix article body heading hierarchy

### DIFF
--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -10,13 +10,13 @@ coauthoredWithAgent: true
 
 When working with interns, a good chunk of pull request review time ends up going to the same formalities: missing descriptions, vague titles, assignees left blank. These comments don't carry much technical weight, but they pile up and eat into the time I'd rather spend on actual guidance. So I built an agentic workflow to catch that stuff automatically. The full sample is available at [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks).
 
-# The Experiment
+## The Experiment
 
 The workflow validates that pull requests follow the team contract for pull request quality. It does not review code.
 
 I scoped it to title format, description structure, section coherence against actual changed files, assignee presence, and PR scope focus. Implementation review, correctness, test quality, and architecture are deliberately out of scope — that smaller contract is much easier to trust.
 
-# How It Works
+## How It Works
 
 The workflow runs on every PR event (opened, edited, synchronize, reopened). It reads PR metadata and changed files, runs six quality checks, and updates a single managed comment on the PR with only the failing items.
 
@@ -32,7 +32,7 @@ flowchart LR
 
 When everything passes, the workflow resolves cleanly without leaving extra noise. When something fails, the comment tells the author exactly what to fix. That precision matters for interns: "Improve your PR description" is not actionable. "The `Why` section restates what changed without explaining the motivation" is.
 
-# The Workflow Source
+## The Workflow Source
 
 GitHub Agentic Workflows are defined as Markdown files with a YAML front matter block. The workflow source lives at `.github/workflows/pull-request-quality-checks.md` and looks like this:
 
@@ -101,7 +101,7 @@ gh aw compile
 
 This regenerates `.github/workflows/pull-request-quality-checks.lock.yml`. Never edit the `.lock.yml` directly — it is auto-generated and will be overwritten on the next compile.
 
-# The Core Pattern: Shared Skill
+## The Core Pattern: Shared Skill
 
 The most interesting part of this experiment is how the PR quality rules are defined once and consumed in two places.
 
@@ -125,7 +125,7 @@ tools: [read/terminalSelection, read/terminalLastCommand, read/readFile, read/vi
 
 The validation rules themselves live in `.github/workflows/pull-request-quality-checks.md` (the workflow source). Both the agentic workflow and the VS Code agent point to the same contract — the workflow enforces it on every PR, the editor agent helps authors comply before pushing.
 
-# Repository Structure
+## Repository Structure
 
 ```
 .github/
@@ -138,7 +138,7 @@ The validation rules themselves live in `.github/workflows/pull-request-quality-
     └── pull-request-quality-checks.lock.yml # Compiled output (auto-generated)
 ```
 
-# What The Workflow Checks
+## What The Workflow Checks
 
 | Check | What It Validates |
 |-------|-------------------|
@@ -149,7 +149,7 @@ The validation rules themselves live in `.github/workflows/pull-request-quality-
 | E | At least one assignee is set |
 | F | PR is focused on a single concern |
 
-# Setup
+## Setup
 
 1. Copy the `.github/` folder from [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) into your repository.
 2. Add a `COPILOT_GITHUB_TOKEN` secret in **Settings → Secrets and variables → Actions**.
@@ -161,7 +161,7 @@ To modify the validation rules, edit the workflow source (`.github/workflows/pul
 gh aw compile
 ```
 
-# What I Learned
+## What I Learned
 
 **Start with a narrow contract.** A small contract with clear pass/fail boundaries is much easier to evaluate than "build an AI PR reviewer."
 
@@ -169,7 +169,7 @@ gh aw compile
 
 **Scope control builds trust.** The workflow does not pretend to do everything. It validates one thing clearly and that makes it easier to trust and extend.
 
-# References
+## References
 
 - [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) — full sample repository
 - [GitHub Agentic Workflows documentation](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-agentic-workflows)

--- a/content/articles/github-copilot-customizations.md
+++ b/content/articles/github-copilot-customizations.md
@@ -19,7 +19,7 @@ While writing my first two articles ([MCP fundamentals](https://www.loganfarci.c
 
 However, I quickly noticed a recurring problem: I was repeating the same instructions to Copilot in every session. My most common prompts were things like `Enhance this specific section and make it smoother`, `Update the article description and title`, or `Remove duplication across the article`. These requests were short and lacked context, making it impractical to provide full background each time. Copilot works best when it has the complete picture.
 
-# Customizing GitHub Copilot
+## Customizing GitHub Copilot
 
 GitHub Copilot now supports powerful customization features in Visual Studio Code. I decided to leverage these capabilities to streamline my writing workflow and eliminate repetitive instructions. By customizing Copilot, I can automate common tasks like article reviews, edits, and scaffolding, ensuring every article remains consistent and follows established guidelines.
 
@@ -33,7 +33,7 @@ Key customization features in VS Code include:
 
 These features standardize Copilot’s behavior and ensure consistency across writing and development workflows. This article shows how I use them to set up an effective technical writing assistant.
 
-# Create a technical writing assistant
+## Create a technical writing assistant
 
 This section explains how to use Copilot customization to build an efficient technical writing assistant. By integrating these features into my workflow, I’ve streamlined article creation and editing for this website. The goal is to improve quality and consistency without repeating instructions in every session.
 
@@ -138,7 +138,7 @@ I use the Review Article Prompt as the final gatekeeper before publication, ensu
 
 to trigger a comprehensive review of my draft. This process helps me catch overlooked issues and enforces consistency across my content, so every article published is polished and reliable.
 
-# Workflow
+## Workflow
 
 ```mermaid
 flowchart TB
@@ -161,7 +161,7 @@ flowchart TB
     review -- "Needs Revisions" --> write
 ```
 
-# References
+## References
 
 You can also enforce technology-specific best practices for your stack. The open-source community maintains lists of reusable instructions, such as [Awesome Copilot Instructions](https://github.com/Code-and-Sorts/awesome-copilot-instructions), which you can adapt for your projects.
 

--- a/src/src/core/articles.test.ts
+++ b/src/src/core/articles.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { getAllArticles, getArticleBySlug, getArticleSlugs, getFeaturedArticles } from "./articles";
 
+const stripFencedCodeBlocks = (content: string) => content.replace(/```[\s\S]*?```/g, "");
+
 describe("articles", () => {
     it("loads the available article slugs from content", () => {
         const articles = getAllArticles();
@@ -32,5 +34,16 @@ describe("articles", () => {
 
         expect(featuredArticles.length).toBeGreaterThan(0);
         expect(featuredArticles.every((article) => article.featured)).toBe(true);
+    });
+
+    it("does not allow duplicate top-level headings in the affected article bodies", () => {
+        const affectedSlugs = ["github-copilot-customizations", "agentic-workflow-pr-quality-checks"];
+
+        for (const slug of affectedSlugs) {
+            const article = getArticleBySlug(slug);
+
+            expect(article).not.toBeNull();
+            expect(stripFencedCodeBlocks(article!.content)).not.toMatch(/^#\s/m);
+        }
     });
 });


### PR DESCRIPTION
Fixes: #167

## Summary
Article pages already render the front matter title as the page h1, but two markdown article bodies still started with `#` headings. That produced duplicate top-level headings in the rendered article content.

This change fixes the hierarchy at the source by demoting the affected article body headings so sections start at h2 and nested headings stay consistent. It also adds a targeted regression test for those two article slugs that strips fenced code blocks before asserting no body-level `#` headings remain.

## Notes
The markdown renderer is unchanged. This issue came from article source content, so fixing the markdown files keeps the semantic intent explicit instead of hiding it in global heading remapping.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`