### PR TITLE
Clarify agentic workflow YAML extensions in PR quality article

### DIFF
--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -36,6 +36,8 @@ When everything passes, the workflow resolves cleanly without leaving extra nois
 
 GitHub Agentic Workflows are defined as Markdown files with a YAML front matter block. The workflow source lives at `.github/workflows/pull-request-quality-checks.md` and looks like this:
 
+This front matter is workflow source syntax, not plain GitHub Actions YAML. Keys like `engine`, `tools`, and `safe-outputs` are GitHub Agentic Workflows extensions that `gh aw` understands before compilation.
+
 ```yaml
 ---
 name: PR Quality Check
@@ -91,15 +93,15 @@ safe-outputs:
 ---
 ```
 
-The `safe-outputs` block defines a callable action the Copilot agent can invoke to post or update the managed PR comment. The agent instructions (the Markdown body below the front matter) tell it exactly when to call this output and with what content.
+The `safe-outputs` block defines a callable action the Copilot agent can invoke to post or update the managed PR comment. The agent instructions, in the Markdown body below the front matter, tell it exactly when to call this output and with what content.
 
-You compile this source into a standard GitHub Actions YAML using the [`gh aw`](https://github.com/github/gh-aw) CLI:
+You compile this Markdown source into a generated GitHub Actions lock file with the [`gh aw`](https://github.com/github/gh-aw) CLI:
 
 ```bash
 gh aw compile
 ```
 
-This regenerates `.github/workflows/pull-request-quality-checks.lock.yml`. Never edit the `.lock.yml` directly — it is auto-generated and will be overwritten on the next compile.
+This turns `.github/workflows/pull-request-quality-checks.md` into `.github/workflows/pull-request-quality-checks.lock.yml`. Never edit the `.lock.yml` directly, it is auto-generated and will be overwritten on the next compile.
 
 # The Core Pattern: Shared Skill
 


### PR DESCRIPTION
This article shows a workflow source example that includes `safe-outputs.jobs`. Without clarification, readers familiar with standard GitHub Actions may assume the snippet is plain Actions YAML. This PR makes that distinction explicit and explains what `gh aw compile` produces.

- adds a short note before the example explaining that `engine`, `tools`, and `safe-outputs` are GitHub Agentic Workflows source extensions
- updates the compile explanation so it clearly maps the `.md` source file to the generated `.lock.yml` workflow
- keeps the article narrowly focused on the specific ambiguity called out in the issue

Build note: `npm run build` still reports the existing prerender warning about `<title>` children being rendered as an array, but the build succeeds and this PR does not change that area.

Fixes: #170