### PR TITLE
docs: remove em dashes from existing articles

### DIFF
--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -14,7 +14,7 @@ When working with interns, a good chunk of pull request review time ends up goin
 
 The workflow validates that pull requests follow the team contract for pull request quality. It does not review code.
 
-I scoped it to title format, description structure, section coherence against actual changed files, assignee presence, and PR scope focus. Implementation review, correctness, test quality, and architecture are deliberately out of scope — that smaller contract is much easier to trust.
+I scoped it to title format, description structure, section coherence against actual changed files, assignee presence, and PR scope focus. Implementation review, correctness, test quality, and architecture are deliberately out of scope. That smaller contract is much easier to trust.
 
 ## How It Works
 
@@ -125,7 +125,7 @@ tools: [read/terminalSelection, read/terminalLastCommand, read/readFile, read/vi
 ---
 ```
 
-The validation rules themselves live in `.github/workflows/pull-request-quality-checks.md` (the workflow source). Both the agentic workflow and the VS Code agent point to the same contract — the workflow enforces it on every PR, the editor agent helps authors comply before pushing.
+The validation rules themselves live in `.github/workflows/pull-request-quality-checks.md` (the workflow source). Both the agentic workflow and the VS Code agent point to the same contract. The workflow enforces it on every PR, and the editor agent helps authors comply before pushing.
 
 ## Repository Structure
 
@@ -155,7 +155,7 @@ The validation rules themselves live in `.github/workflows/pull-request-quality-
 
 1. Copy the `.github/` folder from [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) into your repository.
 2. Add a `COPILOT_GITHUB_TOKEN` secret in **Settings → Secrets and variables → Actions**.
-3. The workflow triggers automatically on pull request events — no further configuration required.
+3. The workflow triggers automatically on pull request events. No further configuration is required.
 
 To modify the validation rules, edit the workflow source (`.github/workflows/pull-request-quality-checks.md`) and recompile:
 
@@ -173,8 +173,8 @@ gh aw compile
 
 ## References
 
-- [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) — full sample repository
+- [lfarci/pull-request-quality-checks](https://github.com/lfarci/pull-request-quality-checks) - full sample repository
 - [GitHub Agentic Workflows documentation](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-agentic-workflows)
-- [gh-aw CLI](https://github.com/github/gh-aw) — compile workflow sources to GitHub Actions YAML
+- [gh-aw CLI](https://github.com/github/gh-aw) - compile workflow sources to GitHub Actions YAML
 - [Customizing Copilot in VS Code](https://code.visualstudio.com/docs/copilot/copilot-customization)
 - [Conventional Commits specification](https://www.conventionalcommits.org/)

--- a/content/articles/flouz-personal-finance-tool.md
+++ b/content/articles/flouz-personal-finance-tool.md
@@ -8,11 +8,11 @@ author: "Logan Farci"
 coauthoredWithAgent: true
 ---
 
-I've been working on a small side project called [flouz](https://github.com/lfarci/flouz) — an AI-powered CLI tool for managing personal bank transactions. It's mostly an excuse to experiment with a few things I've been wanting to try.
+I've been working on a small side project called [flouz](https://github.com/lfarci/flouz), an AI-powered CLI tool for managing personal bank transactions. It's mostly an excuse to experiment with a few things I've been wanting to try.
 
 ## What It Does
 
-Flouz stores your transactions and bank account information in a local SQLite database. There's no server, no cloud sync, no account required — everything stays on your machine. The data is yours and only yours.
+Flouz stores your transactions and bank account information in a local SQLite database. There's no server, no cloud sync, no account required. Everything stays on your machine. The data is yours and only yours.
 
 The current focus is on using AI to automatically categorize transactions, which is the tedious part of any personal finance workflow. The goal is to make that process hands-off.
 

--- a/content/articles/git-worktree-vscode.md
+++ b/content/articles/git-worktree-vscode.md
@@ -87,7 +87,7 @@ git worktree remove ../features
 
 ## Conclusion
 
-Git worktrees dramatically improve productivity by letting you work on multiple features, bug fixes, or experiments in parallel—without the friction of constant branch switching. Instead of stashing changes or losing your place, you simply open a new VS Code window for each worktree and get straight to work. This approach keeps you focused and minimizes interruptions, especially when juggling urgent fixes or code reviews alongside ongoing development.
+Git worktrees dramatically improve productivity by letting you work on multiple features, bug fixes, or experiments in parallel, without the friction of constant branch switching. Instead of stashing changes or losing your place, you simply open a new VS Code window for each worktree and get straight to work. This approach keeps you focused and minimizes interruptions, especially when juggling urgent fixes or code reviews alongside ongoing development.
 
 ## References
 

--- a/content/articles/github-copilot-customizations.md
+++ b/content/articles/github-copilot-customizations.md
@@ -102,7 +102,7 @@ This prompt generates a Markdown file in `content/articles/` with the correct fr
 | **title** | No           | Optionally specify the article title. If omitted, Copilot generates a title based on the topic. |
 | **tags**  | No           | Optionally specify tags. If omitted, Copilot suggests tags based on the topic.                  |
 
-This prompt streamlines setup for me—I just provide a few details, and Copilot handles the rest. In the future, it could suggest outlines, generate draft sections, or pull in relevant references automatically. For now, it keeps things simple and leaves the content empty, but the foundation is ready for more advanced automation.
+This prompt streamlines setup for me. I just provide a few details, and Copilot handles the rest. In the future, it could suggest outlines, generate draft sections, or pull in relevant references automatically. For now, it keeps things simple and leaves the content empty, but the foundation is ready for more advanced automation.
 
 #### Enhance Article Prompt
 
@@ -126,7 +126,7 @@ Most often, I run this prompt to apply generic enhancements based on the Article
 
 `/article.enhance`
 
-This is the prompt I use most often. I jot down ideas quickly, then run this prompt to polish and refine the content. It helps me improve clarity, style, and structure—without getting bogged down in repetitive instructions.
+This is the prompt I use most often. I jot down ideas quickly, then run this prompt to polish and refine the content. It helps me improve clarity, style, and structure without getting bogged down in repetitive instructions.
 
 #### Review Article Prompt
 


### PR DESCRIPTION
The article guidelines already discourage em dashes, but a few published articles still used them. This keeps the existing content aligned with the writing rules by replacing those remaining cases with plain ASCII punctuation.

## What changed

- replaced 10 em-dash occurrences across 4 existing articles
- used commas, periods, or plain hyphens where they read most naturally
- kept the edits limited to sentence-level wording so the articles' meaning and tone stay the same

## Validation

- `rg "—" content/articles/*.md`
- `npm run build` from `src/`

## Notes

- The build still prints the existing React `<title>` prerender warning, which is unrelated to these article text edits.

Fixes: #168