### PR TITLE
Fix markdown code block rendering

### DIFF
--- a/src/src/components/shared/CodeSnippet.tsx
+++ b/src/src/components/shared/CodeSnippet.tsx
@@ -1,14 +1,28 @@
 import React from "react";
 import MermaidDiagram from "./MermaidDiagram";
-import { Code, Snippet } from "@heroui/react";
+import { Code } from "@heroui/react";
 
-interface CodeSnippetProps {
+export interface CodeSnippetProps {
     children: React.ReactNode;
     className?: string;
+    forceBlock?: boolean;
 }
 
-export default function CodeSnippet({ children, className }: CodeSnippetProps) {
-    const isInline = !className;
+function getTextContent(value: React.ReactNode): string {
+    if (typeof value === "string" || typeof value === "number") {
+        return String(value);
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(getTextContent).join("");
+    }
+
+    return "";
+}
+
+export default function CodeSnippet({ children, className, forceBlock = false }: CodeSnippetProps) {
+    const code = getTextContent(children);
+    const isInline = !forceBlock && !className && !code.includes("\n");
     const isMermaid = className?.includes("language-mermaid");
 
     if (isMermaid) {
@@ -20,14 +34,10 @@ export default function CodeSnippet({ children, className }: CodeSnippetProps) {
             {children}
         </Code>
     ) : (
-        <Snippet
-            size="md"
-            radius="md"
-            hideSymbol={true}
-            hideCopyButton={false}
-            className="w-full my-4 *:whitespace-pre-wrap"
+        <pre
+            className="my-4 w-full overflow-x-auto rounded-lg border border-border bg-surface-elevated p-4 text-sm leading-relaxed text-text-primary"
         >
-            {children}
-        </Snippet>
+            <code className={className}>{children}</code>
+        </pre>
     );
 }

--- a/src/src/components/shared/MarkdownContent.tsx
+++ b/src/src/components/shared/MarkdownContent.tsx
@@ -15,10 +15,27 @@ import {
     Emphasis,
 } from "@/components/shared/typography";
 import NewTabLink from "./NewTabLink";
-import CodeSnippet from "./CodeSnippet";
+import CodeSnippet, { CodeSnippetProps } from "./CodeSnippet";
 
 interface MarkdownContentProps {
     content: string;
+}
+
+function MarkdownCodeBlock({ children }: { children: React.ReactNode }) {
+    const codeSnippet = React.Children.toArray(children).find(
+        (child): child is React.ReactElement<CodeSnippetProps> =>
+            React.isValidElement<CodeSnippetProps>(child) && child.type === CodeSnippet,
+    );
+
+    if (codeSnippet) {
+        return (
+            <CodeSnippet className={codeSnippet.props.className} forceBlock>
+                {codeSnippet.props.children}
+            </CodeSnippet>
+        );
+    }
+
+    return <>{children}</>;
 }
 
 const markdownComponents: Components = {
@@ -36,6 +53,7 @@ const markdownComponents: Components = {
         </blockquote>
     ),
     code: ({ children, className }) => <CodeSnippet className={className}>{children}</CodeSnippet>,
+    pre: ({ children }) => <MarkdownCodeBlock>{children}</MarkdownCodeBlock>,
     a: ({ href, children }) => <NewTabLink url={href ?? ""}>{children}</NewTabLink>,
     strong: ({ children }) => <Strong>{children}</Strong>,
     em: ({ children }) => <Emphasis>{children}</Emphasis>,


### PR DESCRIPTION
Fenced Markdown code blocks in articles were rendering through the Heroui snippet component, which collapsed tree-style examples like the agentic workflow repository structure. This PR renders fenced blocks as semantic `<pre><code>` content so whitespace and line breaks are preserved, while keeping inline code on the existing Heroui `Code` styling.

## Summary
- Add block-aware code rendering for Markdown content.
- Preserve line breaks, indentation, and horizontal scrolling for fenced code samples.
- Avoid nested `<pre>` markup from React Markdown by owning the block wrapper in `MarkdownContent`.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`