### PR TITLE
fix: move workflow permissions to job level (least privilege)

### DIFF
--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -16,10 +16,6 @@ on:
           - Deploy
           - Destroy
 
-permissions:
-  id-token: write
-  contents: read
-
 env:
   IS_DEPLOY: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Deploy') }}
   IS_DESTROY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Destroy' }}
@@ -30,6 +26,8 @@ jobs:
   secrets:
     name: Read secrets from Azure Key Vault
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment: Production
     outputs:
       storage_account_name: ${{ steps.get-secrets.outputs.terraform_backend_storage_account }}
@@ -54,6 +52,9 @@ jobs:
   terraform:
     name: "Deploy Terraform module"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: Production
       url: "https://${{ env.SUBDOMAIN }}.${{ env.CUSTOM_DOMAIN }}"
@@ -144,6 +145,8 @@ jobs:
     name: "Set secrets in the Key Vaultr"
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Deploy') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment: Production
     needs: terraform
     steps:
@@ -172,6 +175,9 @@ jobs:
     name: "Configure custom domain"
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Deploy') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: Production
     needs: terraform
     steps:


### PR DESCRIPTION
The `azure-resources.yml` workflow declared `id-token: write` and `contents: read` permissions at the workflow level, granting them to all jobs regardless of need. This triggered a SonarCloud code scanning alert for violating the principle of least privilege.

This PR moves permissions to individual job declarations:

- **`id-token: write`** -- granted to all four jobs (each performs Azure OIDC login)
- **`contents: read`** -- granted only to `terraform` and `custom_domain` (the jobs that use `actions/checkout`)

Jobs that don't need repository content access (`secrets`, `environment`) no longer inherit it.

Fixes https://github.com/lfarci/loganfarci.com/security/code-scanning/1