### PR TITLE
Tighten MCP article scope

### DIFF
--- a/content/articles/github-copilot-customizations.md
+++ b/content/articles/github-copilot-customizations.md
@@ -10,7 +10,7 @@ coauthoredWithAgent: true
 
 This website is my technical workspace, a place to document findings, experiments, and lessons learned for myself and other developers. I use it to publish focused articles about current projects or topics I’m exploring, knowing the content will evolve over time. My goal is to keep these notes clear and actionable, whether for my own reference or for anyone else who finds them.
 
-While writing my first two articles ([MCP fundamentals](https://www.loganfarci.com/articles/mcp) and [GitHub MCP Server](https://www.loganfarci.com/articles/github-mcp-server)), I found GitHub Copilot surprisingly effective as a collaborator. It helped me:
+While writing my first two articles ([How MCP Tool Calls Work](https://www.loganfarci.com/articles/mcp) and [GitHub MCP Server](https://www.loganfarci.com/articles/github-mcp-server)), I found GitHub Copilot surprisingly effective as a collaborator. It helped me:
 
 -   Scaffold new articles and enforce the required front matter format
 -   Catch spelling and grammar issues

--- a/content/articles/github-mcp-server.md
+++ b/content/articles/github-mcp-server.md
@@ -10,7 +10,7 @@ coauthoredWithAgent: true
 
 The GitHub MCP server is a powerful tool that transforms your AI agent into a GitHub powerhouse. This server provides comprehensive integration with GitHub, allowing you to manage repositories, issues, pull requests, and GitHub Actions through natural language conversations.
 
-If you want a refresher on MCP itself, start with my [Model Context Protocol](/articles/mcp) article or the [official introduction](https://modelcontextprotocol.io/introduction). This article stays focused on what the GitHub MCP Server exposes and how to use it effectively.
+If you want a refresher on how MCP tool calls work, start with my [How MCP Tool Calls Work](/articles/mcp) article or the [official introduction](https://modelcontextprotocol.io/introduction). This article stays focused on what the GitHub MCP Server exposes and how to use it effectively.
 
 ## The GitHub MCP Server
 

--- a/content/articles/mcp.md
+++ b/content/articles/mcp.md
@@ -1,6 +1,6 @@
 ---
-title: "Model Context Protocol"
-description: "Exploring the Model Context Protocol (MCP): A New Standard for AI Tool Integration"
+title: "How MCP Tool Calls Work"
+description: "Learn how MCP turns a user request into a tool call through hosts, clients, servers, tool discovery, and JSON-RPC messages."
 publishedAt: "2025-07-02"
 featured: true
 tags: ["MCP", "AI"]
@@ -8,93 +8,90 @@ author: "Logan Farci"
 coauthoredWithAgent: true
 ---
 
-The Model Context Protocol (MCP) has been gaining significant attention across the AI development community. Major companies like GitHub, Microsoft, and Notion are rapidly releasing MCP servers, and the [official server list](https://github.com/modelcontextprotocol/servers) continues to expand.
+The Model Context Protocol (MCP) is easiest to understand when you follow one request from chat prompt to tool result.
 
-This article explores what MCP is, how it works, and whether it represents a lasting solution to AI tool integration challenges. We'll examine the current ecosystem, discover available servers and clients, and understand how this protocol might shape the future of AI development.
+This article focuses on that path: how an AI application discovers MCP tools, asks a server to run one, and turns the result into an answer. It does not try to catalog the whole MCP ecosystem.
 
-## What is MCP?
+## The three parts of MCP
 
-Anthropic introduced the Model Context Protocol (MCP) in November 2024 through their [original announcement](https://www.anthropic.com/news/model-context-protocol). As of July 2025, MCP is still relatively new but gaining traction. Other influential companies are adopting it, including Microsoft, GitHub, OpenAI.
+Anthropic introduced MCP in November 2024 through its [launch announcement](https://www.anthropic.com/news/model-context-protocol). The current [official introduction](https://modelcontextprotocol.io/introduction) describes MCP as a standard way for AI applications to connect to tools and data sources.
 
-To understand MCP, the [official introduction](https://modelcontextprotocol.io/introduction) is an excellent starting point. It provides a detailed overview of the protocol, its architecture, and core concepts.
+The most useful mental model is the [official architecture](https://modelcontextprotocol.io/docs/concepts/architecture):
 
-In essence, MCP is described as:
+- **Host:** The AI application the user interacts with, such as Visual Studio Code, Claude Desktop, Cursor, or Claude Code.
+- **Client:** The connector inside the host that manages one MCP server connection.
+- **Server:** The program that exposes tools, resources, or prompts to the client.
 
-> _MCP is an open protocol that standardizes how applications provide context to LLMs. Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools._
+The distinction between host and client matters. Visual Studio Code is the host. If it connects to a GitHub MCP server and a filesystem MCP server, it creates separate MCP client connections for each server.
 
-Before MCP, integrating tools often relied on custom APIs or proprietary connectors, which were difficult to maintain and lacked standardization. This fragmented approach made seamless interactions between applications and AI models challenging.
+## What the server actually exposes
 
-## How agents invoke MCP tools
+MCP servers can expose several primitives, but tools are the important one for this article. The [server concepts documentation](https://modelcontextprotocol.io/docs/learn/server-concepts) describes tools as **model-controlled** actions. That means the language model decides whether a tool is relevant based on the tool name, description, and input schema made available by the host.
 
-LLMs invoking external tools might seem magical, but it's all about clever orchestration. These models, at their core, are text generators. So, how do they interact with external tools?
+For example, a server might expose a weather tool like this:
 
-To grasp how this works, it helps to understand the three core components described in the [Anthropic documentation](https://modelcontextprotocol.io/docs/concepts/architecture):
+```json
+{
+  "name": "get_weather",
+  "description": "Get current weather information for a location",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "string"
+      }
+    },
+    "required": ["location"]
+  }
+}
+```
 
-- **Host**: The application containing the LLM (like GitHub Copilot Agent Mode)
-- **Client**: The component that implements the MCP protocol within the host
-- **Server**: The process that provides tools, resources, or prompts to the client
+The schema is not just documentation. It is the contract the model uses to decide what arguments to provide when the host asks the server to call the tool.
 
-The [protocol documentation](https://modelcontextprotocol.io/docs/concepts/architecture) explains this interaction flow in detail, and the [message flow diagram](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#message-flow) provides a helpful visual understanding.
+## From prompt to tool call
 
-Let's trace through what happens when I ask GitHub Copilot "What are the recent issues in my repository?" using the [GitHub MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/github):
+Imagine asking an MCP-enabled editor: "What are the recent issues in my repository?"
 
-1. **The host** (Visual Studio Code) receives my natural language request
-2. **The client** within Visual Studio Code translates this into an MCP tool call
-3. **The server** processes the MCP tool call and calls the GitHub API with the appropriate parameters
-4. **The server** returns structured data back to the client
-5. **The host** formats this into a readable response
+The flow looks like this:
 
-What's compelling about this architecture is that the same GitHub server can work with any MCP-compatible host. Whether I'm using Claude Desktop, Visual Studio Code, or building a custom application, the server implementation remains unchanged.
+1. **The host receives the prompt.** The user asks the question in the AI application.
+2. **The client has already discovered tools.** During setup, the MCP client asks connected servers what tools they provide.
+3. **The model chooses a tool.** The host gives the model the prompt and available tool schemas. The model decides whether one of those tools fits the request.
+4. **The client sends a tool call.** If a tool is selected, the client sends a JSON-RPC `tools/call` request to the server.
+5. **The server runs the action.** The server calls the underlying API or local capability and returns structured content.
+6. **The host answers the user.** The result goes back into the model context so the host can produce a readable answer.
 
-[Kiran Prakash](https://www.linkedin.com/in/kiran-prakash)'s article on [function calling using LLMs](https://martinfowler.com/articles/function-call-LLM.html) provides deeper insight into this process. It covers how agents invoke functions and [connects this concept to MCP](https://martinfowler.com/articles/function-call-LLM.html#HowFunctionCallingRelatesToMcpModelContextProtocol)'s tool invocation model, explaining how function calling integrates with the MCP architecture.
+The [tools documentation](https://modelcontextprotocol.io/docs/concepts/tools) shows the JSON-RPC shape. A call can be as simple as:
 
-I also recommend reading [What Is MCP, and Why Is Everyone Talking About It?](https://huggingface.co/blog/Kseniase/mcp) from [Ksenia Se](https://www.linkedin.com/in/ksenia-se/). This article is honestly very complete.
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "Brussels"
+    }
+  }
+}
+```
 
-## Discovering MCP servers
+That is the core of MCP tool invocation. The model does not directly call the external service. It proposes a structured tool call, the MCP client sends it to the server, and the server performs the work.
 
-The MCP ecosystem is rapidly expanding, with servers appearing across different domains and use cases. Rather than attempting to maintain a comprehensive catalog (which would quickly become outdated), I'll focus on the primary discovery sources.
+## Where transport fits
 
-### Anthropic
+MCP separates the protocol messages from the way they are transported. The [transport documentation](https://modelcontextprotocol.io/docs/concepts/transports) currently highlights two common options:
 
-The [Model Context Protocol GitHub organization](https://github.com/modelcontextprotocol) serves as the central hub for development and discovery. The [`servers` repository](https://github.com/modelcontextprotocol/servers) provides the most curated collection of implementations, from reference examples to production-ready solutions.
+- **stdio:** The host launches a local server process and communicates over standard input and output.
+- **Streamable HTTP:** The host connects to a remote server over HTTP, with optional streaming.
 
-### Microsoft
+This separation is why the same server concept can work in local developer tooling and remote hosted integrations. The host/client/server roles stay the same even when the transport changes.
 
-Microsoft is already providing MCP servers for some of their products. They are maintaining a list of MCP servers in the [`microsoft/mcp`](https://github.com/microsoft/mcp) repository.
+## Why this architecture is useful
 
-I work daily with Visual Studio Code, so I was particularly interested in how MCP integrates with GitHub Copilot. The VS Code documentation provides an updated list of [MCP servers for agent mode](https://code.visualstudio.com/mcp), which serves as a good entry point.
+Before MCP, each AI application needed custom integrations for each external tool. MCP reduces that integration work by standardizing the contract between AI hosts and tool servers.
 
-### Community
+The practical takeaway is simple: when you add an MCP server, you are not teaching the model a new API from scratch. You are giving the host a standard way to discover tool schemas, request tool execution, and return results to the model.
 
-Besides the official sources, many community-driven MCP servers are emerging. I'm currently using [`punkpeye/awesome-mcp-servers`](https://github.com/punkpeye/awesome-mcp-servers), which includes a curated server list available in English, Japanese, Thai, and Portuguese. They've also set up a [web portal](https://glama.ai/mcp/servers) for easier browsing.
-
-### Future of server discovery
-
-The [MCP development roadmap](https://modelcontextprotocol.io/development/roadmap#registry) identifies server distribution and discoverability as key priorities. An [active community discussion](https://github.com/orgs/modelcontextprotocol/discussions/159) explores various approaches to improving server discovery, with several community-driven indexing initiatives already emerging.
-
-## MCP clients
-
-While exploring MCP servers, I discovered the client ecosystem is more diverse than I initially expected. Understanding this landscape helps identify where MCP fits into different development workflows.
-
-The [official client directory](https://modelcontextprotocol.io/clients) reveals surprising breadth beyond Anthropic's applications. While Claude Desktop, Claude.ai, and Claude Code represent mature implementations, the community has developed clients for platforms I didn't anticipate. [`mcp.el`](https://github.com/lizqwerscott/mcp.el) is a good example as it offers MCP support for Emacs. Some new AI powered IDEs are also gaining a lot of traction, such as [Cursor](https://docs.cursor.com/context/model-context-protocol) and [Windsurf](https://windsurf.com/editor).
-
-### Feature support
-
-The [feature support matrix](https://modelcontextprotocol.io/clients#feature-support-matrix) shows that complete MCP specification support remains limited. Currently, only [`fast-agent`](https://llmindset.co.uk/resources/fast-agent/) and GitHub Copilot Agent Mode support the full specification. This fragmentation suggests opportunities for developers. You can contribute more complete implementations or identify which features matter most for specific use cases.
-
-### Building custom clients
-
-The protocol's openness enables custom development using multi-language SDKs. For .NET developers, Microsoft provides excellent resources:
-
-- [Create a minimal MCP client using .NET](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/build-mcp-client)
-- [Integrating MCP Tools with Semantic Kernel](https://devblogs.microsoft.com/semantic-kernel/integrating-model-context-protocol-tools-with-semantic-kernel-a-step-by-step-guide/)
-
-These resources open possibilities for custom AI applications that leverage the growing server ecosystem.
-
-## Final thoughts
-
-MCP represents a significant step toward standardizing AI tool integration. While still young, the protocol shows promise thanks to its breadth of support and the active community building around it.
-
-The rapid adoption by major players like Microsoft, combined with strong community engagement, suggests MCP is likely here to stay. For developers, this presents an opportunity to build tools that work across multiple AI platforms rather than being locked into proprietary ecosystems.
-
-As the protocol matures and more clients support the full specification, we can expect MCP to become as fundamental to AI development as REST APIs are to web development today.
+If you want to go deeper, start with the official [architecture](https://modelcontextprotocol.io/docs/concepts/architecture), [tools](https://modelcontextprotocol.io/docs/concepts/tools), and [transport](https://modelcontextprotocol.io/docs/concepts/transports) documentation. Those three pages explain the parts that matter most when you are debugging or building MCP integrations.


### PR DESCRIPTION
This narrows the MCP article so it matches the site's article guidelines: one focused takeaway instead of a broad survey of the ecosystem.

The existing `/articles/mcp` route stays stable, but the article is reframed as "How MCP Tool Calls Work" and now focuses on the host/client/server model, tool discovery, JSON-RPC `tools/call`, and transport basics. Related article links were updated to use the new title and framing.

Validation: `npm run build` completed successfully from `src/`. The build still emits the existing React `<title>` prerender warning on article routes.

Fixes: #162