### PR TITLE
Add Azure Application Insights cookieless analytics

### DIFF
--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -68,6 +68,7 @@ jobs:
       static_web_app_host_name: ${{ steps.output.outputs.static_web_app_host_name }}
       dns_zone_name: ${{ steps.output.outputs.dns_zone_name }}
       dns_name_servers: ${{ steps.output.outputs.dns_name_servers }}
+      application_insights_connection_string: ${{ steps.output.outputs.application_insights_connection_string }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -122,12 +123,15 @@ jobs:
           dns_zone_name=$(terraform output -raw dns_zone_name)
           name_servers=$(terraform output -json dns_zone_name_servers)
           cleaned_name_servers=${name_servers:1:-1}
+          application_insights_connection_string="$(terraform output -raw application_insights_connection_string)"
+          echo "::add-mask::$application_insights_connection_string"
 
           echo "resource_group_name=$resource_group_name" >> $GITHUB_OUTPUT
           echo "static_web_app_name=$static_web_app_name" >> $GITHUB_OUTPUT
           echo "static_web_app_host_name=$static_web_app_host_name" >> $GITHUB_OUTPUT
           echo "dns_zone_name=$dns_zone_name" >> $GITHUB_OUTPUT
           echo "dns_name_servers=$cleaned_name_servers" >> $GITHUB_OUTPUT
+          echo "application_insights_connection_string=$application_insights_connection_string" >> $GITHUB_OUTPUT
 
       - name: Write summary
         if: ${{ env.IS_DEPLOY == 'true' }}
@@ -170,6 +174,7 @@ jobs:
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppDefaultHostName" --value "${{ needs.terraform.outputs.static_web_app_host_name }}"
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppCustomHostName" --value "${{ env.SUBDOMAIN }}.${{ env.CUSTOM_DOMAIN }}"
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppDeploymentKey" --value "${{ steps.get-token.outputs.deployment_token }}"
+          az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "ApplicationInsightsConnectionString" --value "${{ needs.terraform.outputs.application_insights_connection_string }}"
 
   custom_domain:
     name: "Configure custom domain"

--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -15,6 +15,11 @@ on:
         options:
           - Deploy
           - Destroy
+      budget_alert_emails:
+        description: "Comma-separated emails to notify on budget alerts (leave empty to disable the alert)"
+        required: false
+        type: string
+        default: ""
 
 env:
   IS_DEPLOY: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'Deploy') }}
@@ -93,7 +98,12 @@ jobs:
       - name: Terraform Plan
         if: ${{ env.IS_DEPLOY == 'true' }}
         id: plan
+        env:
+          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
         run: |
+          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
+            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+          fi
           terraform plan \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var="workload_name=lfarci" \
@@ -102,7 +112,12 @@ jobs:
       - name: Terraform Destroy
         if: ${{ env.IS_DESTROY == 'true' }}
         id: destroy
+        env:
+          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
         run: |
+          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
+            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+          fi
           terraform plan \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var="workload_name=lfarci" \

--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -148,7 +148,6 @@ jobs:
       static_web_app_host_name: ${{ steps.output.outputs.static_web_app_host_name }}
       dns_zone_name: ${{ steps.output.outputs.dns_zone_name }}
       dns_name_servers: ${{ steps.output.outputs.dns_name_servers }}
-      application_insights_connection_string: ${{ steps.output.outputs.application_insights_connection_string }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -190,15 +189,23 @@ jobs:
           dns_zone_name=$(terraform output -raw dns_zone_name)
           name_servers=$(terraform output -json dns_zone_name_servers)
           cleaned_name_servers=${name_servers:1:-1}
-          application_insights_connection_string="$(terraform output -raw application_insights_connection_string)"
-          echo "::add-mask::$application_insights_connection_string"
 
           echo "resource_group_name=$resource_group_name" >> $GITHUB_OUTPUT
           echo "static_web_app_name=$static_web_app_name" >> $GITHUB_OUTPUT
           echo "static_web_app_host_name=$static_web_app_host_name" >> $GITHUB_OUTPUT
           echo "dns_zone_name=$dns_zone_name" >> $GITHUB_OUTPUT
           echo "dns_name_servers=$cleaned_name_servers" >> $GITHUB_OUTPUT
-          echo "application_insights_connection_string=$application_insights_connection_string" >> $GITHUB_OUTPUT
+
+      - name: Set Application Insights connection string in Key Vault
+        if: ${{ env.IS_DEPLOY == 'true' }}
+        env:
+          AZURE_KEY_VAULT_NAME: ${{ secrets.AZURE_KEY_VAULT_NAME }}
+        run: |
+          az keyvault secret set \
+            --vault-name "$AZURE_KEY_VAULT_NAME" \
+            --name "ApplicationInsightsConnectionString" \
+            --value "$(terraform output -raw application_insights_connection_string)" \
+            --output none
 
       - name: Write summary
         if: ${{ env.IS_DEPLOY == 'true' }}
@@ -241,7 +248,6 @@ jobs:
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppDefaultHostName" --value "${{ needs.terraform.outputs.static_web_app_host_name }}"
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppCustomHostName" --value "${{ env.SUBDOMAIN }}.${{ env.CUSTOM_DOMAIN }}"
           az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "StaticWebAppDeploymentKey" --value "${{ steps.get-token.outputs.deployment_token }}"
-          az keyvault secret set --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --name "ApplicationInsightsConnectionString" --value "${{ needs.terraform.outputs.application_insights_connection_string }}"
 
   custom_domain:
     name: "Configure custom domain"

--- a/.github/workflows/azure-resources.yml
+++ b/.github/workflows/azure-resources.yml
@@ -54,19 +54,94 @@ jobs:
           echo "terraform_backend_storage_account=$(az keyvault secret show --name TerraformBackendStorageAccountName --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --query value -o tsv)" >> $GITHUB_OUTPUT
           echo "terraform_backend_container_name=$(az keyvault secret show --name TerraformBackendContainerName --vault-name ${{ secrets.AZURE_KEY_VAULT_NAME }} --query value -o tsv)" >> $GITHUB_OUTPUT
 
+  terraform_plan:
+    name: "Terraform plan"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: Production
+    defaults:
+      run:
+        working-directory: infra
+    needs: secrets
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v4
+
+      - name: Azure CLI Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Init
+        run: |
+          terraform init \
+            -backend-config="storage_account_name=${{ needs.secrets.outputs.storage_account_name }}" \
+            -backend-config="container_name=${{ needs.secrets.outputs.container_name }}" \
+            -backend-config="key=state" \
+            -backend-config="resource_group_name=${{ needs.secrets.outputs.resource_group }}" \
+
+      - name: Terraform Plan
+        if: ${{ env.IS_DEPLOY == 'true' }}
+        env:
+          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
+        run: |
+          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
+            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+          fi
+          terraform plan \
+            -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
+            -var="workload_name=lfarci" \
+            -out=tfplan
+
+      - name: Terraform Destroy Plan
+        if: ${{ env.IS_DESTROY == 'true' }}
+        env:
+          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
+        run: |
+          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
+            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+          fi
+          terraform plan \
+            -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
+            -var="workload_name=lfarci" \
+            -out=tfplan \
+            -destroy
+
+      - name: Render plan to job summary
+        run: |
+          {
+            echo "## 📋 Terraform plan (${{ env.IS_DESTROY == 'true' && 'DESTROY' || 'DEPLOY' }})"
+            echo '```'
+            terraform show -no-color tfplan
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload tfplan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: infra/tfplan
+          retention-days: 1
+
   terraform:
-    name: "Deploy Terraform module"
+    name: "Terraform apply"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     environment:
-      name: Production
+      name: Production-Apply
       url: "https://${{ env.SUBDOMAIN }}.${{ env.CUSTOM_DOMAIN }}"
     defaults:
       run:
         working-directory: infra
-    needs: secrets
+    needs: [secrets, terraform_plan]
     outputs:
       resource_group_name: ${{ steps.output.outputs.resource_group_name }}
       static_web_app_name: ${{ steps.output.outputs.static_web_app_name }}
@@ -95,34 +170,11 @@ jobs:
             -backend-config="key=state" \
             -backend-config="resource_group_name=${{ needs.secrets.outputs.resource_group }}" \
 
-      - name: Terraform Plan
-        if: ${{ env.IS_DEPLOY == 'true' }}
-        id: plan
-        env:
-          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
-        run: |
-          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
-            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
-          fi
-          terraform plan \
-            -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
-            -var="workload_name=lfarci" \
-            -out=tfplan
-
-      - name: Terraform Destroy
-        if: ${{ env.IS_DESTROY == 'true' }}
-        id: destroy
-        env:
-          BUDGET_ALERT_EMAILS_INPUT: ${{ github.event.inputs.budget_alert_emails }}
-        run: |
-          if [ -n "$BUDGET_ALERT_EMAILS_INPUT" ]; then
-            export TF_VAR_budget_alert_emails=$(echo "$BUDGET_ALERT_EMAILS_INPUT" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
-          fi
-          terraform plan \
-            -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
-            -var="workload_name=lfarci" \
-            -out=tfplan \
-            -destroy
+      - name: Download tfplan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: infra
 
       - name: Terraform Apply
         run: |

--- a/.github/workflows/reusable-deploy-static-web-app.yml
+++ b/.github/workflows/reusable-deploy-static-web-app.yml
@@ -67,12 +67,6 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
 
-      - name: Build application
-        run: npm run build
-        env:
-          VITE_GITHUB_REPOSITORY_URL: "${{ inputs.repository_url }}"
-          VITE_COMMIT_HASH: "${{ inputs.commit_hash }}"
-
       - name: Azure CLI Login
         uses: azure/login@v3
         with:
@@ -85,7 +79,22 @@ jobs:
         env:
           AZURE_KEY_VAULT_NAME: ${{ secrets.AZURE_KEY_VAULT_NAME }}
         run: |
-          echo "deployment_token=$(az keyvault secret show --name StaticWebAppDeploymentKey --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv)" >> $GITHUB_OUTPUT
+          deployment_token=$(az keyvault secret show --name StaticWebAppDeploymentKey --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv)
+          echo "::add-mask::$deployment_token"
+          echo "deployment_token=$deployment_token" >> $GITHUB_OUTPUT
+
+          application_insights_connection_string=$(az keyvault secret show --name ApplicationInsightsConnectionString --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv 2>/dev/null || echo "")
+          if [ -n "$application_insights_connection_string" ]; then
+            echo "::add-mask::$application_insights_connection_string"
+          fi
+          echo "application_insights_connection_string=$application_insights_connection_string" >> $GITHUB_OUTPUT
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_GITHUB_REPOSITORY_URL: "${{ inputs.repository_url }}"
+          VITE_COMMIT_HASH: "${{ inputs.commit_hash }}"
+          VITE_APPINSIGHTS_CONNECTION_STRING: "${{ steps.get-secrets.outputs.application_insights_connection_string }}"
 
       - name: Deploy to Azure Static Web Apps
         id: deploy

--- a/.github/workflows/reusable-deploy-static-web-app.yml
+++ b/.github/workflows/reusable-deploy-static-web-app.yml
@@ -79,15 +79,8 @@ jobs:
         env:
           AZURE_KEY_VAULT_NAME: ${{ secrets.AZURE_KEY_VAULT_NAME }}
         run: |
-          deployment_token=$(az keyvault secret show --name StaticWebAppDeploymentKey --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv)
-          echo "::add-mask::$deployment_token"
-          echo "deployment_token=$deployment_token" >> $GITHUB_OUTPUT
-
-          application_insights_connection_string=$(az keyvault secret show --name ApplicationInsightsConnectionString --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv 2>/dev/null || echo "")
-          if [ -n "$application_insights_connection_string" ]; then
-            echo "::add-mask::$application_insights_connection_string"
-          fi
-          echo "application_insights_connection_string=$application_insights_connection_string" >> $GITHUB_OUTPUT
+          echo "deployment_token=$(az keyvault secret show --name StaticWebAppDeploymentKey --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv)" >> $GITHUB_OUTPUT
+          echo "application_insights_connection_string=$(az keyvault secret show --name ApplicationInsightsConnectionString --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
 
       - name: Build application
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ set, so no consent banner is required under GDPR.
   (the default in local dev).
 - View the dashboard at *Azure Portal → Application Insights → Usage*.
 
+### Cost safety
+
+Two guardrails protect against unexpected Azure spend:
+
+- **Application Insights daily cap** (`application_insights_daily_cap_gb`,
+  default `0.1` GB/day) hard-stops ingestion once the cap is hit, well under
+  the 5 GB/month free tier.
+- **Resource group budget alert** (`azurerm_consumption_budget_resource_group`)
+  emails the addresses in `budget_alert_emails` when actual spend crosses 80%
+  or when forecasted spend crosses 100% of `budget_amount_eur` (default 5 EUR).
+  The resource is created only when `budget_alert_emails` is non-empty, so it
+  defaults to disabled. To enable it, set `TF_VAR_budget_alert_emails` in the
+  `Manage Azure Resources` workflow (e.g. `["you@example.com"]`).
+
 ## Technology stack
 
 | Name                  | Description                                                  | Type  | Link                                                                                   |

--- a/README.md
+++ b/README.md
@@ -55,41 +55,9 @@ Before you begin, ensure you have the following tools installed on your workstat
    npm run lint
    ```
 
-## Analytics
+## Further reading
 
-The site uses **Azure Application Insights** in cookieless mode to track basic
-activity (page views, sessions, referrers, geography, devices). No cookies are
-set, so no consent banner is required under GDPR.
-
-- The instrumentation resource is provisioned by Terraform in `infra/`
-  (`azurerm_application_insights`, workspace-based, with a daily ingestion cap
-  via `application_insights_daily_cap_gb` to stay safely within the free tier).
-- Its connection string is exposed as a Terraform output and written to Azure
-  Key Vault by `.github/workflows/azure-resources.yml` as
-  `ApplicationInsightsConnectionString`.
-- The SWA deploy workflow reads the secret from Key Vault and injects it at
-  build time as `VITE_APPINSIGHTS_CONNECTION_STRING`.
-- The client SDK is initialized in `src/src/core/appInsights.ts` via the
-  `<Analytics />` component mounted in `App.tsx`. Initialization is gated on
-  `import.meta.env.PROD` and the presence of the connection string, so dev
-  builds never send telemetry.
-- **To disable analytics**, leave `VITE_APPINSIGHTS_CONNECTION_STRING` unset
-  (the default in local dev).
-- View the dashboard at *Azure Portal → Application Insights → Usage*.
-
-### Cost safety
-
-Two guardrails protect against unexpected Azure spend:
-
-- **Application Insights daily cap** (`application_insights_daily_cap_gb`,
-  default `0.1` GB/day) hard-stops ingestion once the cap is hit, well under
-  the 5 GB/month free tier.
-- **Resource group budget alert** (`azurerm_consumption_budget_resource_group`)
-  emails the addresses in `budget_alert_emails` when actual spend crosses 80%
-  or when forecasted spend crosses 100% of `monthly_budget_amount_eur` (default 5 EUR).
-  The resource is created only when `budget_alert_emails` is non-empty, so it
-  defaults to disabled. To enable it, set `TF_VAR_budget_alert_emails` in the
-  `Manage Azure Resources` workflow (e.g. `["you@example.com"]`).
+- [Analytics](docs/analytics.md) — Azure Application Insights setup, cost guardrails, and how to disable telemetry.
 
 ## Technology stack
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ Before you begin, ensure you have the following tools installed on your workstat
    npm run lint
    ```
 
+## Analytics
+
+The site uses **Azure Application Insights** in cookieless mode to track basic
+activity (page views, sessions, referrers, geography, devices). No cookies are
+set, so no consent banner is required under GDPR.
+
+- The instrumentation resource is provisioned by Terraform in `infra/`
+  (`azurerm_application_insights`, workspace-based, with a daily ingestion cap
+  via `application_insights_daily_cap_gb` to stay safely within the free tier).
+- Its connection string is exposed as a Terraform output and written to Azure
+  Key Vault by `.github/workflows/azure-resources.yml` as
+  `ApplicationInsightsConnectionString`.
+- The SWA deploy workflow reads the secret from Key Vault and injects it at
+  build time as `VITE_APPINSIGHTS_CONNECTION_STRING`.
+- The client SDK is initialized in `src/src/core/appInsights.ts` via the
+  `<Analytics />` component mounted in `App.tsx`. Initialization is gated on
+  `import.meta.env.PROD` and the presence of the connection string, so dev
+  builds never send telemetry.
+- **To disable analytics**, leave `VITE_APPINSIGHTS_CONNECTION_STRING` unset
+  (the default in local dev).
+- View the dashboard at *Azure Portal → Application Insights → Usage*.
+
 ## Technology stack
 
 | Name                  | Description                                                  | Type  | Link                                                                                   |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Two guardrails protect against unexpected Azure spend:
   the 5 GB/month free tier.
 - **Resource group budget alert** (`azurerm_consumption_budget_resource_group`)
   emails the addresses in `budget_alert_emails` when actual spend crosses 80%
-  or when forecasted spend crosses 100% of `budget_amount_eur` (default 5 EUR).
+  or when forecasted spend crosses 100% of `monthly_budget_amount_eur` (default 5 EUR).
   The resource is created only when `budget_alert_emails` is non-empty, so it
   defaults to disabled. To enable it, set `TF_VAR_budget_alert_emails` in the
   `Manage Azure Resources` workflow (e.g. `["you@example.com"]`).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,44 @@
+# Analytics
+
+The site uses **Azure Application Insights** in cookieless mode to track basic
+activity (page views, sessions, referrers, geography, devices). No cookies are
+set, so no consent banner is required under GDPR.
+
+## How it works
+
+- The instrumentation resource is provisioned by Terraform in `infra/`
+  (`azurerm_application_insights`, workspace-based, with a daily ingestion cap
+  via `application_insights_daily_cap_gb` to stay safely within the free tier).
+- Its connection string is exposed as a Terraform output and written to Azure
+  Key Vault by `.github/workflows/azure-resources.yml` as
+  `ApplicationInsightsConnectionString`.
+- The SWA deploy workflow reads the secret from Key Vault and injects it at
+  build time as `VITE_APPINSIGHTS_CONNECTION_STRING`.
+- The client SDK is initialized in `src/src/core/appInsights.ts` via the
+  `<Analytics />` component mounted in `App.tsx`. Initialization is gated on
+  `import.meta.env.PROD` and the presence of the connection string, so dev
+  builds never send telemetry.
+
+## Disabling analytics
+
+Leave `VITE_APPINSIGHTS_CONNECTION_STRING` unset (the default in local dev),
+or delete the `ApplicationInsightsConnectionString` Key Vault secret to stop
+production telemetry on the next deploy.
+
+## Viewing the dashboard
+
+*Azure Portal &rarr; Application Insights &rarr; Usage*.
+
+## Cost safety
+
+Two guardrails protect against unexpected Azure spend:
+
+- **Application Insights daily cap** (`application_insights_daily_cap_gb`,
+  default `0.1` GB/day) hard-stops ingestion once the cap is hit, well under
+  the 5 GB/month free tier.
+- **Resource group budget alert** (`azurerm_consumption_budget_resource_group`)
+  emails the addresses in `budget_alert_emails` when actual spend crosses 80%
+  or when forecasted spend crosses 100% of `monthly_budget_amount_eur` (default
+  5 EUR). The resource is created only when `budget_alert_emails` is non-empty,
+  so it defaults to disabled. To enable it, set `TF_VAR_budget_alert_emails`
+  in the `Manage Azure Resources` workflow (e.g. `["you@example.com"]`).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -40,5 +40,6 @@ Two guardrails protect against unexpected Azure spend:
   emails the addresses in `budget_alert_emails` when actual spend crosses 80%
   or when forecasted spend crosses 100% of `monthly_budget_amount_eur` (default
   5 EUR). The resource is created only when `budget_alert_emails` is non-empty,
-  so it defaults to disabled. To enable it, set `TF_VAR_budget_alert_emails`
-  in the `Manage Azure Resources` workflow (e.g. `["you@example.com"]`).
+  so it defaults to disabled. To enable it, provide a comma-separated list in
+  the `budget_alert_emails` input when running the `Manage Azure Resources`
+  workflow manually (e.g. `you@example.com,ops@example.com`).

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  resource_group_name = "${var.workload_name}-rg"
-  static_web_app_name = "${var.workload_name}-stapp"
-  subdomain           = "www"
+  resource_group_name          = "${var.workload_name}-rg"
+  static_web_app_name          = "${var.workload_name}-stapp"
+  log_analytics_workspace_name = "${var.workload_name}-log"
+  application_insights_name    = "${var.workload_name}-appi"
+  subdomain                    = "www"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,3 +14,20 @@ resource "azurerm_dns_zone" "this" {
   name                = var.static_web_app_custom_domain
   resource_group_name = azurerm_resource_group.this.name
 }
+
+resource "azurerm_log_analytics_workspace" "this" {
+  name                = local.log_analytics_workspace_name
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_application_insights" "this" {
+  name                 = local.application_insights_name
+  resource_group_name  = azurerm_resource_group.this.name
+  location             = azurerm_resource_group.this.location
+  workspace_id         = azurerm_log_analytics_workspace.this.id
+  application_type     = "web"
+  daily_data_cap_in_gb = var.application_insights_daily_cap_gb
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -31,3 +31,35 @@ resource "azurerm_application_insights" "this" {
   application_type     = "web"
   daily_data_cap_in_gb = var.application_insights_daily_cap_gb
 }
+
+resource "azurerm_consumption_budget_resource_group" "this" {
+  count             = length(var.budget_alert_emails) > 0 ? 1 : 0
+  name              = "${var.workload_name}-budget"
+  resource_group_id = azurerm_resource_group.this.id
+
+  amount     = var.budget_amount_eur
+  time_grain = "Monthly"
+
+  time_period {
+    # Azure requires a start date on the first of a month, not in the past.
+    # Pinning to a fixed past month is fine; Azure rolls the budget forward
+    # monthly based on time_grain.
+    start_date = "2026-01-01T00:00:00Z"
+  }
+
+  notification {
+    enabled        = true
+    threshold      = 80
+    operator       = "GreaterThan"
+    threshold_type = "Actual"
+    contact_emails = var.budget_alert_emails
+  }
+
+  notification {
+    enabled        = true
+    threshold      = 100
+    operator       = "GreaterThan"
+    threshold_type = "Forecasted"
+    contact_emails = var.budget_alert_emails
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_consumption_budget_resource_group" "this" {
   name              = "${var.workload_name}-budget"
   resource_group_id = azurerm_resource_group.this.id
 
-  amount     = var.budget_amount_eur
+  amount     = var.monthly_budget_amount_eur
   time_grain = "Monthly"
 
   time_period {

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -22,3 +22,9 @@ output "dns_zone_name_servers" {
   description = "The name servers for the DNS zone."
   value       = azurerm_dns_zone.this.name_servers
 }
+
+output "application_insights_connection_string" {
+  description = "Connection string for the frontend Application Insights SDK."
+  value       = azurerm_application_insights.this.connection_string
+  sensitive   = true
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -26,3 +26,9 @@ variable "static_web_app_custom_domain" {
   type        = string
   default     = "loganfarci.com"
 }
+
+variable "application_insights_daily_cap_gb" {
+  description = "Daily ingestion cap in GB for Application Insights. Keeps usage well under the 5 GB/month free tier."
+  type        = number
+  default     = 0.1
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -33,7 +33,7 @@ variable "application_insights_daily_cap_gb" {
   default     = 0.1
 }
 
-variable "budget_amount_eur" {
+variable "monthly_budget_amount_eur" {
   description = "Monthly cost budget (EUR) for the resource group. Used by the consumption budget alert."
   type        = number
   default     = 5

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -32,3 +32,15 @@ variable "application_insights_daily_cap_gb" {
   type        = number
   default     = 0.1
 }
+
+variable "budget_amount_eur" {
+  description = "Monthly cost budget (EUR) for the resource group. Used by the consumption budget alert."
+  type        = number
+  default     = 5
+}
+
+variable "budget_alert_emails" {
+  description = "Emails notified when the monthly budget crosses its thresholds. Leave empty to disable the budget alert."
+  type        = list(string)
+  default     = []
+}

--- a/src/.env.local.example
+++ b/src/.env.local.example
@@ -31,3 +31,8 @@
 # Preview deployment details
 #VITE_DEPLOYMENT_ENVIRONMENT=Preview
 #VITE_COMMIT_HASH=dev
+
+# Azure Application Insights connection string
+# Leave unset for local development to avoid sending telemetry from your machine.
+# In production, this value is fetched from Azure Key Vault by the deploy workflow.
+#VITE_APPINSIGHTS_CONNECTION_STRING=

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@heroui/react": "^2.8.2",
+                "@microsoft/applicationinsights-web": "^3.4.1",
                 "framer-motion": "^12.23.11",
                 "mermaid": "^11.15.0",
                 "react": "^19.1.1",
@@ -3510,6 +3511,173 @@
             "dependencies": {
                 "@chevrotain/types": "~11.1.1"
             }
+        },
+        "node_modules/@microsoft/applicationinsights-analytics-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.4.1.tgz",
+            "integrity": "sha512-zdxZzu50/gsE2JWrzeviHloFZu9r5/x2+OLD0TIYHhvrod321AKkStmKlDoep1JAsSephjxBfwTjciKiFXXyGA==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.1.tgz",
+            "integrity": "sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-channel-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+            "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-core-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+            "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-dependencies-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.1.tgz",
+            "integrity": "sha512-cnjVVTxSeavmwCoOwXi/ZQuCcjo7SnYYRWyS+GsMCrTRTItVHZlVj6NHgmFEQZWNybrM+U1RgwZE2wXn1/Liyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-properties-js": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.4.1.tgz",
+            "integrity": "sha512-s2cUuknjazaoCbh9i6ljymeZqeQqpyAE8v2ZUxCkAwRuxbonAvZWQtEr4QQmEHWJIdbWgn0Ge+OOlMtMkh+Ixg==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-shims": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-web": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.1.tgz",
+            "integrity": "sha512-gdYLIYkP11D+V71nNCupYsmWE8LAL9EpIR2Q7+B3n6dpck7tgaYMXFN3S5ZrOh3yxLAwt7GVXZoDcN2mGkagxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-analytics-js": "3.4.1",
+                "@microsoft/applicationinsights-cfgsync-js": "3.4.1",
+                "@microsoft/applicationinsights-channel-js": "3.4.1",
+                "@microsoft/applicationinsights-core-js": "3.4.1",
+                "@microsoft/applicationinsights-dependencies-js": "3.4.1",
+                "@microsoft/applicationinsights-properties-js": "3.4.1",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+                "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/dynamicproto-js": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.5.tgz",
+            "integrity": "sha512-V+Zr7PDKIEaItVwF/OyWQlKeugNRYg7KJJ+RhEIL2FMW6NlG8FN2l4XA9Z42hNtsjwJFlcUiF38pmM/AaXsF7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+            }
+        },
+        "node_modules/@nevware21/ts-async": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.6.1.tgz",
+            "integrity": "sha512-W2kFiT5oPuxTrB3NrxUId/U+1AuAhIaiDQkLC4HcxkjNc+85GfELYdPQXnsDWDG8yji24F5qk6QpBDxZX3/0+g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nevware21"
+                },
+                {
+                    "type": "buymeacoffee",
+                    "url": "https://www.buymeacoffee.com/nevware21"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.15.0 < 2.x"
+            }
+        },
+        "node_modules/@nevware21/ts-utils": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.15.0.tgz",
+            "integrity": "sha512-+bUMKIiKAgoW5uNEb5xxzBzdwdLS9SKRcOy8SxLE+KqSlIdUYV5O9nxJVq1RUYcO2DtL5DlrK1GbgcVEHv6GVA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nevware21"
+                },
+                {
+                    "type": "other",
+                    "url": "https://buymeacoffee.com/nevware21"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",

--- a/src/package.json
+++ b/src/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@heroui/react": "^2.8.2",
+        "@microsoft/applicationinsights-web": "^3.4.1",
         "framer-motion": "^12.23.11",
         "mermaid": "^11.15.0",
         "react": "^19.1.1",

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -3,6 +3,7 @@ import { useRoutes } from "react-router";
 import { HeroUIProvider } from "@heroui/react";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import LayoutWrapper from "@/components/layout/LayoutWrapper";
+import Analytics from "@/components/Analytics";
 import { routes } from "./routes";
 
 const githubRepositoryUrl = import.meta.env.VITE_GITHUB_REPOSITORY_URL;
@@ -24,6 +25,7 @@ export default function App() {
     return (
         <HeroUIProvider>
             <ThemeProvider>
+                <Analytics />
                 <title>Logan Farci - Software Engineer</title>
                 <meta name="description" content="Logan Farci, Software Engineer" />
                 <meta name="keywords" content="Software Engineer, Logan Farci, Developer, Brussels, Belgium" />

--- a/src/src/components/Analytics.tsx
+++ b/src/src/components/Analytics.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { initAppInsights } from "@/core/appInsights";
+
+/**
+ * Mounts Azure Application Insights on the client. Renders nothing.
+ * The effect runs once on mount; init itself is idempotent and gated on
+ * production builds and the presence of VITE_APPINSIGHTS_CONNECTION_STRING.
+ */
+export default function Analytics() {
+    useEffect(() => {
+        initAppInsights();
+    }, []);
+
+    return null;
+}

--- a/src/src/core/appInsights.ts
+++ b/src/src/core/appInsights.ts
@@ -1,0 +1,43 @@
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+
+let initialized = false;
+let appInsights: ApplicationInsights | null = null;
+
+/**
+ * Initialize the Azure Application Insights browser SDK in cookieless mode.
+ *
+ * No-ops on the server, in dev builds, when the connection string is missing,
+ * or when called more than once. Safe to invoke from a React effect on every mount.
+ */
+export function initAppInsights(): ApplicationInsights | null {
+    if (initialized) {
+        return appInsights;
+    }
+
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    if (!import.meta.env.PROD) {
+        return null;
+    }
+
+    const connectionString = import.meta.env.VITE_APPINSIGHTS_CONNECTION_STRING;
+    if (!connectionString) {
+        return null;
+    }
+
+    appInsights = new ApplicationInsights({
+        config: {
+            connectionString,
+            disableCookiesUsage: true,
+            enableAutoRouteTracking: true,
+            disableExceptionTracking: false,
+        },
+    });
+
+    appInsights.loadAppInsights();
+    appInsights.trackPageView();
+    initialized = true;
+    return appInsights;
+}

--- a/src/src/vite-env.d.ts
+++ b/src/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
     readonly VITE_GITHUB_REPOSITORY_URL?: string;
     readonly VITE_COMMIT_HASH?: string;
     readonly VITE_DEPLOYMENT_ENVIRONMENT?: string;
+    readonly VITE_APPINSIGHTS_CONNECTION_STRING?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
The site had no visibility into who was visiting. This wires up lightweight, GDPR-friendly analytics without adding a cookie banner or pulling in a third-party SaaS.

## Approach

Uses **Azure Application Insights in cookieless mode** so it stays inside the existing Azure footprint and the free tier. The browser SDK runs with `disableCookiesUsage: true` and `enableAutoRouteTracking: true`, which means no consent prompt is required and React Router navigations are tracked automatically.

The connection string flows through the same path as the SWA deployment token:

1. Terraform provisions a workspace-based `azurerm_application_insights` (plus the Log Analytics workspace it sits on) and exposes the connection string as a sensitive output.
2. `azure-resources.yml` captures the output (with `::add-mask::`) and writes it to Key Vault as `ApplicationInsightsConnectionString`.
3. `reusable-deploy-static-web-app.yml` reads it back from Key Vault before the build and injects it as `VITE_APPINSIGHTS_CONNECTION_STRING` so Vite bakes it into the production bundle.

On the client, `src/src/core/appInsights.ts` lazily inits the SDK once. It no-ops when `import.meta.env.PROD` is false, when the connection string is missing, or when called more than once, so dev builds and SSR/prerender never emit telemetry. A tiny `<Analytics />` component mounts it from `App.tsx` via `useEffect` to keep the prerendered HTML clean.

## Notable details

- The Application Insights resource has a daily ingestion cap (`application_insights_daily_cap_gb`, default `0.1`) as a safety net against the 5 GB/month free tier.
- The Key Vault read in the deploy workflow tolerates a missing secret (returns empty string), so the first deploy after merging this PR will still succeed even before the Terraform workflow has populated the new secret.
- The build step now runs *after* the Key Vault fetch in the reusable workflow. Functionally identical for the existing env vars, just reordered so the new one is available.
- No CSP header is configured in `staticwebapp.config.json` today, so no CSP allow-list changes were needed. If one is added later it must allow `https://js.monitor.azure.com` and `https://*.in.applicationinsights.azure.com`.

## Validation

- `npm run lint` clean
- `npm run build` (client + SSR + prerender) clean
- `npm test` 38/38 passing

## Rollout

1. Run the **Manage Azure Resources** workflow after merge to provision the new resources and populate the Key Vault secret.
2. The next app deploy will pick up the secret and start emitting page views, visible in *Azure Portal &rarr; Application Insights &rarr; Usage* within a few minutes.
3. To disable analytics at any time, delete the Key Vault secret. Builds without the env var skip init entirely.