### PR TITLE
Improve short article descriptions for SEO

### DIFF
--- a/content/articles/flouz-personal-finance-tool.md
+++ b/content/articles/flouz-personal-finance-tool.md
@@ -1,6 +1,6 @@
 ---
 title: "Flouz: A Small Personal Finance Tool"
-description: "A quick note on flouz, a local CLI tool I'm building to track bank transactions with SQLite and AI-powered categorization."
+description: "Learn how flouz tracks bank transactions in a local SQLite database and applies AI categorization without sending your financial data to the cloud."
 publishedAt: "2026-04-16"
 featured: false
 tags: ["Personal Finance", "TypeScript", "SQLite", "AI"]

--- a/content/articles/git-worktree-vscode.md
+++ b/content/articles/git-worktree-vscode.md
@@ -1,6 +1,6 @@
 ---
 title: "Efficient Git Worktree Usage in VS Code"
-description: "A focused guide on using Git worktrees within Visual Studio Code to streamline multi-branch workflows and boost productivity."
+description: "Learn how to use Git worktrees in Visual Studio Code to work across branches in parallel, stay organized, and avoid constant context switching."
 publishedAt: "2025-08-12"
 featured: false
 tags: ["Git", "Visual Studio Code"]

--- a/content/articles/github-mcp-server.md
+++ b/content/articles/github-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub MCP Server"
-description: "Short note about the GitHub MCP server and how it can be used to enhance your development workflow."
+description: "Learn which GitHub workflows the GitHub MCP Server can automate, which toolsets it exposes, and how to use it effectively with agents."
 publishedAt: "2025-07-18"
 featured: true
 tags: ["GitHub Copilot", "MCP"]

--- a/content/articles/mcp.md
+++ b/content/articles/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: "How MCP Tool Calls Work"
-description: "Learn how MCP turns a user request into a tool call through hosts, clients, servers, tool discovery, and JSON-RPC messages."
+description: "Understand how an MCP request becomes a tool call by tracing host, client, server, discovery, and JSON-RPC steps from prompt to result."
 publishedAt: "2025-07-02"
 featured: true
 tags: ["MCP", "AI"]

--- a/src/src/core/articles.test.ts
+++ b/src/src/core/articles.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getAllArticles, getArticleBySlug, getArticleSlugs, getFeaturedArticles } from "./articles";
 
 const stripFencedCodeBlocks = (content: string) => content.replace(/```[\s\S]*?```/g, "");
+const vagueDescriptionStarter = /^(short note about|a quick note on|a focused guide on)\b/i;
 
 describe("articles", () => {
     it("loads the available article slugs from content", () => {
@@ -34,6 +35,19 @@ describe("articles", () => {
 
         expect(featuredArticles.length).toBeGreaterThan(0);
         expect(featuredArticles.every((article) => article.featured)).toBe(true);
+    });
+
+    it("keeps SEO-focused descriptions for the affected articles", () => {
+        const affectedSlugs = ["mcp", "github-mcp-server", "git-worktree-vscode", "flouz-personal-finance-tool"];
+
+        for (const slug of affectedSlugs) {
+            const article = getArticleBySlug(slug);
+
+            expect(article).not.toBeNull();
+            expect(article!.description.length).toBeGreaterThanOrEqual(120);
+            expect(article!.description.length).toBeLessThanOrEqual(160);
+            expect(article!.description).not.toMatch(vagueDescriptionStarter);
+        }
     });
 
     it("does not allow duplicate top-level headings in the affected article bodies", () => {


### PR DESCRIPTION
## Summary
Issue #169 calls out four article descriptions that are too vague or too short for the site's SEO guidance. This updates the front matter copy so article cards and article page meta descriptions explain the value of each post more clearly.

- rewrites the affected article descriptions to stay within the 120-160 character guideline and use more specific, outcome-focused wording
- adds a focused regression test for those four slugs so vague starter phrasing and out-of-range descriptions do not slip back in

## Testing
- npm run test
- npm run lint

Fixes: #169