### PR TITLE
Define Tailwind design tokens

### DIFF
--- a/src/src/components/shared/primitives/Button.tsx
+++ b/src/src/components/shared/primitives/Button.tsx
@@ -4,11 +4,11 @@ import type { ComponentProps, Ref } from "react";
 import { mergeClassNames } from "@/core/mergeClassNames";
 
 const buttonVariants = cva(
-    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-control text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
     {
         variants: {
             variant: {
-                default: "bg-primary text-text-inverse hover:bg-primary-hover",
+                default: "bg-brand text-brand-foreground hover:bg-brand-hover",
                 secondary: "border border-border bg-surface-hover text-text-primary hover:bg-surface-elevated",
                 ghost: "text-text-primary hover:bg-surface-hover",
                 icon: "border border-border bg-surface-hover text-text-primary hover:bg-surface-elevated",

--- a/src/src/components/shared/primitives/CardPrimitives.tsx
+++ b/src/src/components/shared/primitives/CardPrimitives.tsx
@@ -8,7 +8,7 @@ type PolymorphicProps<E extends ElementType> = {
 } & Omit<ComponentProps<E>, "as" | "className" | "children">;
 
 export const cardRootClassName =
-    "h-full rounded-xl border border-border-light bg-surface p-6 shadow-sm transition-shadow duration-200 hover:shadow-md active:shadow-md";
+    "h-full rounded-card border border-border-light bg-surface p-6 shadow-card transition-shadow duration-200 hover:shadow-card-hover active:shadow-card-hover";
 
 export function Card<E extends ElementType = "div">({ as, className, children, ...props }: PolymorphicProps<E>) {
     const Component = as ?? "div";

--- a/src/src/components/shared/primitives/TooltipPrimitives.tsx
+++ b/src/src/components/shared/primitives/TooltipPrimitives.tsx
@@ -16,7 +16,7 @@ export function TooltipContent({
             <TooltipPrimitive.Content
                 sideOffset={sideOffset}
                 className={mergeClassNames(
-                    "z-50 max-w-xs overflow-hidden rounded-md border border-border bg-surface-elevated px-3 py-1.5 text-sm text-text-primary shadow-md",
+                    "z-50 max-w-xs overflow-hidden rounded-control border border-border bg-surface-elevated px-3 py-1.5 text-sm text-text-primary shadow-popover",
                     className,
                 )}
                 {...props}

--- a/src/src/components/terminal/Prompt.tsx
+++ b/src/src/components/terminal/Prompt.tsx
@@ -24,7 +24,7 @@ export default function Prompt({
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
                 onKeyDown={onCommandSubmission}
-                style={{ backgroundColor: "black", color: "white", border: "none", outline: "none" }}
+                className="border-0 bg-surface text-text-primary outline-none"
                 autoFocus
             />
         </div>

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -36,17 +36,27 @@
 
 /* Base theme configuration using Tailwind v4 @theme directive */
 @theme {
-    /* Core colors */
+    /* Document colors */
     --color-background: oklch(100% 0 0); /* white */
     --color-foreground: oklch(13% 0.028 261.692); /* gray-950 */
-    --color-primary: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-primary-hover: oklch(54.6% 0.245 262.881); /* blue-600 */
-    --color-primary-light: oklch(97% 0.014 254.604); /* blue-50 */
+
+    /* Brand and accent colors */
+    --color-brand: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-brand-hover: oklch(54.6% 0.245 262.881); /* blue-600 */
+    --color-brand-subtle: oklch(97% 0.014 254.604); /* blue-50 */
+    --color-brand-foreground: oklch(100% 0 0); /* white */
+    --color-accent: oklch(70.4% 0.14 182.503); /* cyan-400 */
+    --color-accent-hover: oklch(60.9% 0.126 221.723); /* cyan-600 */
+    --color-accent-subtle: oklch(98.4% 0.019 200.873); /* cyan-50 */
+    --color-accent-foreground: oklch(13% 0.028 261.692); /* gray-950 */
+
+    /* Compatibility aliases */
+    --color-primary: var(--color-brand);
+    --color-primary-hover: var(--color-brand-hover);
+    --color-primary-light: var(--color-brand-subtle);
     --color-secondary: oklch(55.1% 0.027 264.364); /* gray-500 */
     --color-secondary-hover: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-accent: oklch(62.3% 0.214 259.815); /* Same as primary */
-    --color-accent-hover: oklch(54.6% 0.245 262.881); /* Same as primary-hover */
-    
+
     /* Text semantic colors */
     --color-text-primary: oklch(27.8% 0.033 256.848); /* gray-800 */
     --color-text-secondary: oklch(44.6% 0.03 256.802); /* gray-600 */
@@ -58,17 +68,43 @@
     --color-border: oklch(87.2% 0.01 258.338); /* gray-300 */
     --color-border-light: oklch(92.8% 0.006 264.531); /* gray-200 */
     --color-border-strong: oklch(70.7% 0.022 261.325); /* gray-400 */
-    
+
     /* Surface/background colors */
     --color-surface: oklch(100% 0 0); /* white */
     --color-surface-elevated: oklch(98.5% 0.002 247.839); /* gray-50 */
     --color-surface-hover: oklch(96.7% 0.003 264.542); /* gray-100 */
-    
+    --color-surface-muted: oklch(92.8% 0.006 264.531); /* gray-200 */
+    --color-muted: oklch(96.7% 0.003 264.542); /* gray-100 */
+    --color-muted-foreground: oklch(44.6% 0.03 256.802); /* gray-600 */
+
+    /* Focus ring colors */
+    --color-ring: var(--color-brand);
+    --color-ring-muted: var(--color-border-strong);
+
     /* Status colors */
     --color-success: oklch(69.6% 0.17 162.48); /* emerald-500 */
     --color-warning: oklch(76.9% 0.188 70.08); /* amber-500 */
     --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
     --color-info: oklch(62.3% 0.214 259.815); /* blue-500 */
+
+    /* Gradients */
+    --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
+    --gradient-accent: linear-gradient(135deg, var(--color-accent-subtle) 0%, var(--color-brand-subtle) 100%);
+    --gradient-surface: linear-gradient(180deg, var(--color-surface-elevated) 0%, var(--color-surface) 100%);
+    --gradient-fade-surface: linear-gradient(90deg, transparent 0%, var(--color-surface) 100%);
+    --background-image-gradient-brand: var(--gradient-brand);
+    --background-image-gradient-accent: var(--gradient-accent);
+    --background-image-gradient-surface: var(--gradient-surface);
+    --background-image-fade-surface: var(--gradient-fade-surface);
+
+    /* Elevation and shape */
+    --shadow-card: 0 1px 2px 0 oklch(13% 0.028 261.692 / 0.08);
+    --shadow-card-hover: 0 10px 20px -12px oklch(13% 0.028 261.692 / 0.22);
+    --shadow-popover: 0 12px 30px -16px oklch(13% 0.028 261.692 / 0.28);
+    --shadow-focus: 0 0 0 3px oklch(62.3% 0.214 259.815 / 0.22);
+    --radius-control: 0.5rem;
+    --radius-card: 0.75rem;
+    --radius-surface: 1rem;
 }
 
 /* Dark mode styles when .dark class is applied */
@@ -78,16 +114,18 @@
     --color-background: oklch(10% 0.012 264.8); /* Very dark gray */
     --color-foreground: oklch(98% 0.003 264.542); /* Near white */
     
-    /* Primary colors for dark mode */
-    --color-primary: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-primary-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-primary-light: oklch(28.2% 0.091 267.935); /* blue-950 */
+    /* Brand and accent colors for dark mode */
+    --color-brand: oklch(74.6% 0.16 232.661); /* sky-400 */
+    --color-brand-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-brand-subtle: oklch(28.2% 0.091 267.935); /* blue-950 */
+    --color-brand-foreground: oklch(13% 0.028 261.692); /* gray-950 */
+    --color-accent: oklch(77.7% 0.152 181.912); /* cyan-300 */
+    --color-accent-hover: oklch(70.4% 0.14 182.503); /* cyan-400 */
+    --color-accent-subtle: oklch(30.2% 0.056 229.695); /* cyan-950 */
+    --color-accent-foreground: oklch(13% 0.028 261.692); /* gray-950 */
     
     --color-secondary: oklch(70.7% 0.022 261.325); /* gray-400 */
     --color-secondary-hover: oklch(87.2% 0.01 258.338); /* gray-300 */
-    
-    --color-accent: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-accent-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
     
     /* Text colors for dark mode */
     --color-text-primary: oklch(98.5% 0.002 247.839); /* gray-50 */
@@ -105,6 +143,16 @@
     --color-surface: oklch(21% 0.034 264.665); /* gray-900 */
     --color-surface-elevated: oklch(27.8% 0.033 256.848); /* gray-800 */
     --color-surface-hover: oklch(37.3% 0.034 259.733); /* gray-700 */
+    --color-surface-muted: oklch(37.3% 0.034 259.733); /* gray-700 */
+    --color-muted: oklch(27.8% 0.033 256.848); /* gray-800 */
+    --color-muted-foreground: oklch(70.7% 0.022 261.325); /* gray-400 */
+    --color-ring: var(--color-brand);
+    --color-ring-muted: var(--color-border-strong);
+
+    --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.28);
+    --shadow-card-hover: 0 12px 24px -14px oklch(0% 0 0 / 0.5);
+    --shadow-popover: 0 16px 36px -18px oklch(0% 0 0 / 0.58);
+    --shadow-focus: 0 0 0 3px oklch(74.6% 0.16 232.661 / 0.24);
 }
 
 /* Font utilities */

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -37,45 +37,48 @@
 /* Base theme configuration using Tailwind v4 @theme directive */
 @theme {
     /* Document colors */
-    --color-background: oklch(100% 0 0); /* white */
-    --color-foreground: oklch(13% 0.028 261.692); /* gray-950 */
+    --color-background: oklch(99% 0.006 255); /* porcelain */
+    --color-foreground: oklch(18% 0.035 264); /* midnight ink */
 
     /* Brand and accent colors */
-    --color-brand: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-brand-hover: oklch(54.6% 0.245 262.881); /* blue-600 */
-    --color-brand-subtle: oklch(97% 0.014 254.604); /* blue-50 */
+    --color-brand: oklch(56% 0.19 258); /* signal blue */
+    --color-brand-hover: oklch(49% 0.21 260); /* deep signal blue */
+    --color-brand-subtle: oklch(96% 0.026 255); /* blue mist */
     --color-brand-foreground: oklch(100% 0 0); /* white */
-    --color-accent: oklch(70.4% 0.14 182.503); /* cyan-400 */
-    --color-accent-hover: oklch(60.9% 0.126 221.723); /* cyan-600 */
-    --color-accent-subtle: oklch(98.4% 0.019 200.873); /* cyan-50 */
-    --color-accent-foreground: oklch(13% 0.028 261.692); /* gray-950 */
+    --color-accent: oklch(68% 0.14 188); /* aurora teal */
+    --color-accent-hover: oklch(58% 0.13 194); /* deep aurora teal */
+    --color-accent-subtle: oklch(96.5% 0.032 190); /* teal glass */
+    --color-accent-foreground: var(--color-foreground);
+    --color-highlight: oklch(74% 0.16 72); /* copper spark */
+    --color-highlight-subtle: oklch(96.5% 0.04 82); /* warm vellum */
+    --color-highlight-foreground: var(--color-foreground);
 
     /* Compatibility aliases */
     --color-primary: var(--color-brand);
     --color-primary-hover: var(--color-brand-hover);
     --color-primary-light: var(--color-brand-subtle);
-    --color-secondary: oklch(55.1% 0.027 264.364); /* gray-500 */
-    --color-secondary-hover: oklch(44.6% 0.03 256.802); /* gray-600 */
+    --color-secondary: oklch(47% 0.032 262); /* graphite */
+    --color-secondary-hover: oklch(36% 0.038 263); /* ink graphite */
 
     /* Text semantic colors */
-    --color-text-primary: oklch(27.8% 0.033 256.848); /* gray-800 */
-    --color-text-secondary: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-text-tertiary: oklch(55.1% 0.027 264.364); /* gray-500 */
-    --color-text-muted: oklch(70.7% 0.022 261.325); /* gray-400 */
+    --color-text-primary: oklch(23% 0.036 264); /* ink */
+    --color-text-secondary: oklch(41% 0.034 263); /* slate */
+    --color-text-tertiary: oklch(53% 0.03 262); /* soft slate */
+    --color-text-muted: oklch(65% 0.026 260); /* quiet slate */
     --color-text-inverse: oklch(100% 0 0); /* white */
     
     /* Border semantic colors */
-    --color-border: oklch(87.2% 0.01 258.338); /* gray-300 */
-    --color-border-light: oklch(92.8% 0.006 264.531); /* gray-200 */
-    --color-border-strong: oklch(70.7% 0.022 261.325); /* gray-400 */
+    --color-border: oklch(86% 0.018 258); /* cool line */
+    --color-border-light: oklch(92.5% 0.012 258); /* hairline */
+    --color-border-strong: oklch(70% 0.026 260); /* etched line */
 
     /* Surface/background colors */
     --color-surface: oklch(100% 0 0); /* white */
-    --color-surface-elevated: oklch(98.5% 0.002 247.839); /* gray-50 */
-    --color-surface-hover: oklch(96.7% 0.003 264.542); /* gray-100 */
-    --color-surface-muted: oklch(92.8% 0.006 264.531); /* gray-200 */
-    --color-muted: oklch(96.7% 0.003 264.542); /* gray-100 */
-    --color-muted-foreground: oklch(44.6% 0.03 256.802); /* gray-600 */
+    --color-surface-elevated: oklch(97.5% 0.012 255); /* frosted canvas */
+    --color-surface-hover: oklch(94.5% 0.018 256); /* blue-gray hover */
+    --color-surface-muted: oklch(91.5% 0.02 256); /* muted canvas */
+    --color-muted: oklch(95.5% 0.016 256); /* quiet canvas */
+    --color-muted-foreground: var(--color-text-secondary);
 
     /* Focus ring colors */
     --color-ring: var(--color-brand);
@@ -85,74 +88,79 @@
     --color-success: oklch(69.6% 0.17 162.48); /* emerald-500 */
     --color-warning: oklch(76.9% 0.188 70.08); /* amber-500 */
     --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
-    --color-info: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-info: var(--color-brand);
 
     /* Gradients */
     --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
-    --gradient-accent: linear-gradient(135deg, var(--color-accent-subtle) 0%, var(--color-brand-subtle) 100%);
-    --gradient-surface: linear-gradient(180deg, var(--color-surface-elevated) 0%, var(--color-surface) 100%);
+    --gradient-accent: linear-gradient(135deg, var(--color-accent-subtle) 0%, var(--color-brand-subtle) 62%, var(--color-highlight-subtle) 100%);
+    --gradient-highlight: linear-gradient(135deg, var(--color-highlight) 0%, var(--color-accent) 100%);
+    --gradient-surface: radial-gradient(circle at 12% 8%, var(--color-brand-subtle) 0%, transparent 36%), linear-gradient(180deg, var(--color-surface-elevated) 0%, var(--color-surface) 100%);
     --gradient-fade-surface: linear-gradient(90deg, transparent 0%, var(--color-surface) 100%);
     --background-image-gradient-brand: var(--gradient-brand);
     --background-image-gradient-accent: var(--gradient-accent);
+    --background-image-gradient-highlight: var(--gradient-highlight);
     --background-image-gradient-surface: var(--gradient-surface);
     --background-image-fade-surface: var(--gradient-fade-surface);
 
     /* Elevation and shape */
-    --shadow-card: 0 1px 2px 0 oklch(13% 0.028 261.692 / 0.08);
-    --shadow-card-hover: 0 10px 20px -12px oklch(13% 0.028 261.692 / 0.22);
-    --shadow-popover: 0 12px 30px -16px oklch(13% 0.028 261.692 / 0.28);
-    --shadow-focus: 0 0 0 3px oklch(62.3% 0.214 259.815 / 0.22);
-    --radius-control: 0.5rem;
-    --radius-card: 0.75rem;
-    --radius-surface: 1rem;
+    --shadow-card: 0 1px 2px 0 oklch(18% 0.035 264 / 0.08), 0 10px 28px -24px oklch(56% 0.19 258 / 0.34);
+    --shadow-card-hover: 0 18px 36px -24px oklch(18% 0.035 264 / 0.24), 0 10px 22px -18px oklch(68% 0.14 188 / 0.28);
+    --shadow-popover: 0 22px 48px -28px oklch(18% 0.035 264 / 0.32), 0 8px 20px -18px oklch(56% 0.19 258 / 0.28);
+    --shadow-focus: 0 0 0 3px oklch(56% 0.19 258 / 0.24);
+    --radius-control: 0.625rem;
+    --radius-card: 0.875rem;
+    --radius-surface: 1.25rem;
 }
 
 /* Dark mode styles when .dark class is applied */
 :root.dark,
 .dark {
     color-scheme: dark;
-    --color-background: oklch(10% 0.012 264.8); /* Very dark gray */
-    --color-foreground: oklch(98% 0.003 264.542); /* Near white */
+    --color-background: oklch(13.5% 0.028 264); /* midnight */
+    --color-foreground: oklch(96.5% 0.01 255); /* moonlit text */
     
     /* Brand and accent colors for dark mode */
-    --color-brand: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-brand-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-brand-subtle: oklch(28.2% 0.091 267.935); /* blue-950 */
-    --color-brand-foreground: oklch(13% 0.028 261.692); /* gray-950 */
-    --color-accent: oklch(77.7% 0.152 181.912); /* cyan-300 */
-    --color-accent-hover: oklch(70.4% 0.14 182.503); /* cyan-400 */
-    --color-accent-subtle: oklch(30.2% 0.056 229.695); /* cyan-950 */
-    --color-accent-foreground: oklch(13% 0.028 261.692); /* gray-950 */
+    --color-brand: oklch(72% 0.15 252); /* luminous signal blue */
+    --color-brand-hover: oklch(78% 0.13 246); /* sky glow */
+    --color-brand-subtle: oklch(25% 0.072 262); /* midnight blue */
+    --color-brand-foreground: oklch(12.5% 0.03 264); /* ink */
+    --color-accent: oklch(77% 0.13 188); /* aurora teal */
+    --color-accent-hover: oklch(83% 0.115 184); /* teal glow */
+    --color-accent-subtle: oklch(24% 0.056 197); /* deep teal glass */
+    --color-accent-foreground: oklch(12.5% 0.03 264); /* ink */
+    --color-highlight: oklch(80% 0.15 78); /* warm instrument light */
+    --color-highlight-subtle: oklch(26% 0.055 76); /* ember glass */
+    --color-highlight-foreground: oklch(12.5% 0.03 264); /* ink */
     
-    --color-secondary: oklch(70.7% 0.022 261.325); /* gray-400 */
-    --color-secondary-hover: oklch(87.2% 0.01 258.338); /* gray-300 */
+    --color-secondary: oklch(73% 0.026 260); /* mist graphite */
+    --color-secondary-hover: oklch(86% 0.016 258); /* bright graphite */
     
     /* Text colors for dark mode */
-    --color-text-primary: oklch(98.5% 0.002 247.839); /* gray-50 */
-    --color-text-secondary: oklch(92.8% 0.006 264.531); /* gray-200 */
-    --color-text-tertiary: oklch(87.2% 0.01 258.338); /* gray-300 */
-    --color-text-muted: oklch(70.7% 0.022 261.325); /* gray-400 */
-    --color-text-inverse: oklch(27.8% 0.033 256.848); /* gray-800 */
+    --color-text-primary: oklch(96.5% 0.01 255); /* moonlit text */
+    --color-text-secondary: oklch(86% 0.018 258); /* silver */
+    --color-text-tertiary: oklch(75% 0.024 260); /* dim silver */
+    --color-text-muted: oklch(63% 0.028 262); /* blue ash */
+    --color-text-inverse: oklch(18% 0.035 264); /* midnight ink */
     
     /* Border colors for dark mode */
-    --color-border: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-border-light: oklch(37.3% 0.034 259.733); /* gray-700 */
-    --color-border-strong: oklch(55.1% 0.027 264.364); /* gray-500 */
+    --color-border: oklch(34% 0.038 262); /* night line */
+    --color-border-light: oklch(27% 0.034 262); /* low line */
+    --color-border-strong: oklch(47% 0.038 260); /* bright line */
     
     /* Surface colors for dark mode */
-    --color-surface: oklch(21% 0.034 264.665); /* gray-900 */
-    --color-surface-elevated: oklch(27.8% 0.033 256.848); /* gray-800 */
-    --color-surface-hover: oklch(37.3% 0.034 259.733); /* gray-700 */
-    --color-surface-muted: oklch(37.3% 0.034 259.733); /* gray-700 */
-    --color-muted: oklch(27.8% 0.033 256.848); /* gray-800 */
-    --color-muted-foreground: oklch(70.7% 0.022 261.325); /* gray-400 */
+    --color-surface: oklch(18.5% 0.034 264); /* ink panel */
+    --color-surface-elevated: oklch(23.5% 0.042 264); /* raised ink */
+    --color-surface-hover: oklch(29% 0.046 263); /* hover ink */
+    --color-surface-muted: oklch(30% 0.042 263); /* muted ink */
+    --color-muted: oklch(24% 0.038 264); /* quiet ink */
+    --color-muted-foreground: var(--color-text-muted);
     --color-ring: var(--color-brand);
     --color-ring-muted: var(--color-border-strong);
 
-    --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.28);
-    --shadow-card-hover: 0 12px 24px -14px oklch(0% 0 0 / 0.5);
-    --shadow-popover: 0 16px 36px -18px oklch(0% 0 0 / 0.58);
-    --shadow-focus: 0 0 0 3px oklch(74.6% 0.16 232.661 / 0.24);
+    --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.36), 0 12px 30px -26px oklch(72% 0.15 252 / 0.5);
+    --shadow-card-hover: 0 22px 42px -28px oklch(0% 0 0 / 0.68), 0 12px 28px -22px oklch(77% 0.13 188 / 0.34);
+    --shadow-popover: 0 24px 58px -32px oklch(0% 0 0 / 0.72), 0 12px 28px -24px oklch(72% 0.15 252 / 0.36);
+    --shadow-focus: 0 0 0 3px oklch(72% 0.15 252 / 0.32);
 }
 
 /* Font utilities */

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -24,6 +24,11 @@ export default {
                     subtle: "var(--color-accent-subtle)",
                     foreground: "var(--color-accent-foreground)",
                 },
+                highlight: {
+                    DEFAULT: "var(--color-highlight)",
+                    subtle: "var(--color-highlight-subtle)",
+                    foreground: "var(--color-highlight-foreground)",
+                },
 
                 // Compatibility aliases for existing semantic classes.
                 primary: {
@@ -78,6 +83,7 @@ export default {
             backgroundImage: {
                 "gradient-brand": "var(--gradient-brand)",
                 "gradient-accent": "var(--gradient-accent)",
+                "gradient-highlight": "var(--gradient-highlight)",
                 "gradient-surface": "var(--gradient-surface)",
                 "fade-surface": "var(--gradient-fade-surface)",
             },

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -5,28 +5,38 @@ export default {
         "./index.html",
         "./src/**/*.{js,ts,jsx,tsx}",
     ],
-    theme: { 
-        extend: { 
-            colors: { 
-                // Next.js compatibility
+    theme: {
+        extend: {
+            colors: {
+                // App-level document colors
                 background: "var(--color-background)",
                 foreground: "var(--color-foreground)",
-                
-                // Semantic theme colors
+
+                brand: {
+                    DEFAULT: "var(--color-brand)",
+                    hover: "var(--color-brand-hover)",
+                    subtle: "var(--color-brand-subtle)",
+                    foreground: "var(--color-brand-foreground)",
+                },
+                accent: {
+                    DEFAULT: "var(--color-accent)",
+                    hover: "var(--color-accent-hover)",
+                    subtle: "var(--color-accent-subtle)",
+                    foreground: "var(--color-accent-foreground)",
+                },
+
+                // Compatibility aliases for existing semantic classes.
                 primary: {
-                    DEFAULT: "var(--color-primary)",
-                    hover: "var(--color-primary-hover)",
-                    light: "var(--color-primary-light)",
+                    DEFAULT: "var(--color-brand)",
+                    hover: "var(--color-brand-hover)",
+                    light: "var(--color-brand-subtle)",
+                    foreground: "var(--color-brand-foreground)",
                 },
                 secondary: {
                     DEFAULT: "var(--color-secondary)",
                     hover: "var(--color-secondary-hover)",
                 },
-                accent: {
-                    DEFAULT: "var(--color-accent)",
-                    hover: "var(--color-accent-hover)",
-                },
-                
+
                 // Text colors
                 text: {
                     primary: "var(--color-text-primary)",
@@ -35,28 +45,54 @@ export default {
                     muted: "var(--color-text-muted)",
                     inverse: "var(--color-text-inverse)",
                 },
-                
+
                 // Border colors
                 border: {
                     DEFAULT: "var(--color-border)",
                     light: "var(--color-border-light)",
                     strong: "var(--color-border-strong)",
                 },
-                
+
                 // Surface colors
                 surface: {
                     DEFAULT: "var(--color-surface)",
                     elevated: "var(--color-surface-elevated)",
                     hover: "var(--color-surface-hover)",
+                    muted: "var(--color-surface-muted)",
                 },
-                
+                muted: {
+                    DEFAULT: "var(--color-muted)",
+                    foreground: "var(--color-muted-foreground)",
+                },
+                ring: {
+                    DEFAULT: "var(--color-ring)",
+                    muted: "var(--color-ring-muted)",
+                },
+
                 // Status colors
                 success: "var(--color-success)",
                 warning: "var(--color-warning)",
                 error: "var(--color-error)",
                 info: "var(--color-info)",
-            } 
-        } 
+            },
+            backgroundImage: {
+                "gradient-brand": "var(--gradient-brand)",
+                "gradient-accent": "var(--gradient-accent)",
+                "gradient-surface": "var(--gradient-surface)",
+                "fade-surface": "var(--gradient-fade-surface)",
+            },
+            boxShadow: {
+                card: "var(--shadow-card)",
+                "card-hover": "var(--shadow-card-hover)",
+                popover: "var(--shadow-popover)",
+                focus: "var(--shadow-focus)",
+            },
+            borderRadius: {
+                control: "var(--radius-control)",
+                card: "var(--radius-card)",
+                surface: "var(--radius-surface)",
+            },
+        }
     },
     darkMode: "class",
     plugins: [],


### PR DESCRIPTION
This establishes a reusable Tailwind token foundation so upcoming UI work can use consistent, theme-safe colors, elevation, gradients, and radii instead of ad hoc values.

## Summary

- Adds named brand, accent, highlight, surface, muted, border, ring, text, gradient, shadow, and radius tokens backed by CSS variables.
- Refines the palette into a "midnight craft" direction: porcelain/ink neutrals, signal blue, aurora teal, and a restrained copper highlight for warmth.
- Keeps existing primary/secondary token aliases for compatibility while exposing the newer brand/accent naming.
- Updates shared primitives and the terminal prompt to use the new semantic tokens where the replacements are directly related to the foundation work.

## Validation

- `npm run lint`
- `npm run build`

Fixes: #218