### PR TITLE
Make the app intentionally ugly

### DIFF
--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -22,6 +22,11 @@
   body {
     color: var(--color-foreground);
     background: var(--color-background);
+    font-family: var(--font-noto-sans);
+    letter-spacing: 0.08em;
+    line-height: 1.9;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 0 oklch(0% 0 0 / 0.45);
   }
 
   h1,
@@ -31,80 +36,81 @@
   h5,
   h6 {
     font-family: var(--font-manrope);
+    text-decoration: underline wavy;
   }
 }
 
 /* Base theme configuration using Tailwind v4 @theme directive */
 @theme {
     /* Core colors */
-    --color-background: oklch(100% 0 0); /* white */
-    --color-foreground: oklch(13% 0.028 261.692); /* gray-950 */
-    --color-primary: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-primary-hover: oklch(54.6% 0.245 262.881); /* blue-600 */
-    --color-primary-light: oklch(97% 0.014 254.604); /* blue-50 */
-    --color-secondary: oklch(55.1% 0.027 264.364); /* gray-500 */
-    --color-secondary-hover: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-accent: oklch(62.3% 0.214 259.815); /* Same as primary */
-    --color-accent-hover: oklch(54.6% 0.245 262.881); /* Same as primary-hover */
+  --color-background: oklch(82% 0.22 96); /* aggressive mustard */
+  --color-foreground: oklch(74% 0.28 142); /* bright green */
+  --color-primary: oklch(78% 0.29 328); /* loud magenta */
+  --color-primary-hover: oklch(70% 0.31 12); /* harsh red-orange */
+  --color-primary-light: oklch(89% 0.18 236); /* washed cyan */
+  --color-secondary: oklch(64% 0.25 250); /* electric blue */
+  --color-secondary-hover: oklch(84% 0.21 48); /* neon yellow */
+  --color-accent: oklch(92% 0.2 32); /* pale orange */
+  --color-accent-hover: oklch(64% 0.26 178); /* acidic teal */
     
     /* Text semantic colors */
-    --color-text-primary: oklch(27.8% 0.033 256.848); /* gray-800 */
-    --color-text-secondary: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-text-tertiary: oklch(55.1% 0.027 264.364); /* gray-500 */
-    --color-text-muted: oklch(70.7% 0.022 261.325); /* gray-400 */
-    --color-text-inverse: oklch(100% 0 0); /* white */
+    --color-text-primary: oklch(70% 0.28 20); /* red-orange */
+    --color-text-secondary: oklch(56% 0.24 312); /* bruised purple */
+    --color-text-tertiary: oklch(80% 0.18 220); /* dull cyan */
+    --color-text-muted: oklch(60% 0.22 120); /* muddy green */
+    --color-text-inverse: oklch(18% 0.09 262); /* deep gray */
     
     /* Border semantic colors */
-    --color-border: oklch(87.2% 0.01 258.338); /* gray-300 */
-    --color-border-light: oklch(92.8% 0.006 264.531); /* gray-200 */
-    --color-border-strong: oklch(70.7% 0.022 261.325); /* gray-400 */
+    --color-border: oklch(78% 0.29 352); /* hot pink */
+    --color-border-light: oklch(88% 0.2 70); /* lemon */
+    --color-border-strong: oklch(63% 0.29 190); /* bright aqua */
     
     /* Surface/background colors */
-    --color-surface: oklch(100% 0 0); /* white */
-    --color-surface-elevated: oklch(98.5% 0.002 247.839); /* gray-50 */
-    --color-surface-hover: oklch(96.7% 0.003 264.542); /* gray-100 */
+    --color-surface: oklch(94% 0.16 140); /* mint */
+    --color-surface-elevated: oklch(90% 0.2 300); /* bubblegum */
+    --color-surface-hover: oklch(95% 0.14 52); /* pale yellow */
     
     /* Status colors */
-    --color-success: oklch(69.6% 0.17 162.48); /* emerald-500 */
-    --color-warning: oklch(76.9% 0.188 70.08); /* amber-500 */
-    --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
-    --color-info: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-success: oklch(78% 0.28 150);
+    --color-warning: oklch(88% 0.22 88);
+    --color-error: oklch(72% 0.3 18);
+    --color-info: oklch(74% 0.25 242);
 }
 
 /* Dark mode styles when .dark class is applied */
 :root.dark,
 .dark {
     color-scheme: dark;
-    --color-background: oklch(10% 0.012 264.8); /* Very dark gray */
-    --color-foreground: oklch(98% 0.003 264.542); /* Near white */
+  --color-background: oklch(34% 0.15 78); /* swamp brown */
+  --color-foreground: oklch(88% 0.26 130); /* radioactive green */
     
     /* Primary colors for dark mode */
-    --color-primary: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-primary-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
-    --color-primary-light: oklch(28.2% 0.091 267.935); /* blue-950 */
+    --color-primary: oklch(86% 0.24 326); /* neon pink */
+    --color-primary-hover: oklch(76% 0.29 24); /* intense orange */
+    --color-primary-light: oklch(48% 0.16 222); /* dimmed blue */
     
-    --color-secondary: oklch(70.7% 0.022 261.325); /* gray-400 */
-    --color-secondary-hover: oklch(87.2% 0.01 258.338); /* gray-300 */
+    --color-secondary: oklch(78% 0.24 252); /* vivid indigo */
+    --color-secondary-hover: oklch(94% 0.17 92); /* pale yellow */
     
-    --color-accent: oklch(74.6% 0.16 232.661); /* sky-400 */
-    --color-accent-hover: oklch(62.3% 0.214 259.815); /* blue-500 */
+    --color-accent: oklch(84% 0.22 34); /* peach */
+    --color-accent-hover: oklch(68% 0.24 176); /* weird teal */
     
     /* Text colors for dark mode */
-    --color-text-primary: oklch(98.5% 0.002 247.839); /* gray-50 */
-    --color-text-secondary: oklch(92.8% 0.006 264.531); /* gray-200 */
-    --color-text-tertiary: oklch(87.2% 0.01 258.338); /* gray-300 */
-    --color-text-muted: oklch(70.7% 0.022 261.325); /* gray-400 */
-    --color-text-inverse: oklch(27.8% 0.033 256.848); /* gray-800 */
+    --color-text-primary: oklch(92% 0.19 22); /* peach-red */
+    --color-text-secondary: oklch(86% 0.21 298); /* lavender */
+    --color-text-tertiary: oklch(84% 0.16 214); /* pale cyan */
+    --color-text-muted: oklch(70% 0.18 112); /* algae green */
+    --color-text-inverse: oklch(28% 0.07 260); /* graphite */
     
     /* Border colors for dark mode */
-    --color-border: oklch(44.6% 0.03 256.802); /* gray-600 */
-    --color-border-light: oklch(37.3% 0.034 259.733); /* gray-700 */
-    --color-border-strong: oklch(55.1% 0.027 264.364); /* gray-500 */
+    --color-border: oklch(82% 0.27 342); /* pink */
+    --color-border-light: oklch(80% 0.18 66); /* yellow */
+    --color-border-strong: oklch(70% 0.25 188); /* cyan */
     
     /* Surface colors for dark mode */
-    --color-surface: oklch(21% 0.034 264.665); /* gray-900 */
-    --color-surface-elevated: oklch(27.8% 0.033 256.848); /* gray-800 */
-    --color-surface-hover: oklch(37.3% 0.034 259.733); /* gray-700 */
+    --color-surface: oklch(46% 0.14 124); /* moss */
+    --color-surface-elevated: oklch(58% 0.17 306); /* plum */
+    --color-surface-hover: oklch(64% 0.15 54); /* mustard */
 }
 
 /* Font utilities */
@@ -118,8 +124,8 @@
 
 /* Font CSS variables (Fontsource self-hosted fonts) */
 :root {
-    --font-manrope: "Manrope Variable", sans-serif;
-    --font-noto-sans: "Noto Sans", sans-serif;
+    --font-manrope: "Times New Roman", serif;
+    --font-noto-sans: "Comic Sans MS", "Comic Neue", cursive;
     --font-reddit-mono: "Reddit Mono", monospace;
     --background: var(--color-background);
     --foreground: var(--color-foreground);
@@ -135,4 +141,33 @@
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
     }
+}
+
+body {
+    background-image:
+        repeating-linear-gradient(45deg, oklch(94% 0.2 25) 0 18px, transparent 18px 36px),
+        repeating-linear-gradient(-45deg, oklch(86% 0.22 146) 0 12px, transparent 12px 24px);
+    background-attachment: fixed;
+}
+
+main,
+section,
+article,
+nav,
+header,
+footer,
+aside {
+    border: 3px dashed var(--color-border-strong);
+    box-shadow: 6px 6px 0 var(--color-primary);
+}
+
+a,
+button {
+    text-decoration: underline wavy;
+    text-underline-offset: 0.28em;
+}
+
+img,
+svg {
+    filter: saturate(220%) hue-rotate(110deg) contrast(140%);
 }


### PR DESCRIPTION
## Summary
- replace the global theme tokens with clashing colors in both light and dark modes
- swap typography to deliberately awkward font choices and uppercase text styling
- add heavy background patterns, dashed borders, loud shadows, and distorted media treatment across the whole app

## Validation
- `npm run build` from `src/` could not run in this environment because `vite` is not installed locally
- editor diagnostics for `@config` and `@theme` remain unchanged from the existing Tailwind v4 stylesheet pattern