### PR TITLE
docs(specs): add testing spec with deployment validation

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,6 +1,6 @@
 ---
 spec: loganfarci.com repository specs
-version: 0.1.0
+version: 0.2.0
 status: index
 ---
 
@@ -26,6 +26,7 @@ still a work in progress.
 | [vision.md](./vision.md) | The north star: core principles, planned sections, accessibility/SEO ambitions, and the target sitemap. |
 | [architecture.md](./architecture.md) | Routes and page responsibilities, SSR + prerender contract, and the content pipeline. |
 | [quality-bars.md](./quality-bars.md) | The rubric a reviewer agent checks against: accessibility, performance, TS strictness, testing, linting. |
+| [testing.md](./testing.md) | The testing contract: unit-test guidelines, the build gate, and deployment validation to check a live version is valid. |
 | [accessibility.md](./accessibility.md) | The detailed accessibility contract: current baseline, requirements, themes/contrast, machine-readability, and ideal state. |
 | [i18n.md](./i18n.md) | Multilanguage plan: locale scheme, per-locale prerendering, content/string translation, and SEO (`hreflang`). |
 | [data-contracts.md](./data-contracts.md) | Shape and required fields of each `content/data/*.json` file, mirroring `src/src/types/`. |
@@ -42,6 +43,7 @@ Read the spec that matches the task, then check it against the code before actin
 
 - Changing pages/rendering/content flow → [architecture.md](./architecture.md).
 - Reviewing or shipping a change → [quality-bars.md](./quality-bars.md).
+- Writing tests or validating a deploy → [testing.md](./testing.md).
 - Accessibility work → [accessibility.md](./accessibility.md).
 - Multilanguage / i18n work → [i18n.md](./i18n.md).
 - Editing `content/data/*.json` → [data-contracts.md](./data-contracts.md).

--- a/docs/specs/quality-bars.md
+++ b/docs/specs/quality-bars.md
@@ -63,11 +63,16 @@ Enforced by [`src/tsconfig.json`](../../src/tsconfig.json):
 
 ## Testing
 
+The detailed testing contract — unit-test guidelines, the build gate, and planned
+deployment validation — is in [testing.md](./testing.md).
+
 - Runner: **vitest**. `npm run test` (CI), `npm run test:watch`, `npm run test:coverage`.
 - Tests are colocated with the code as `*.test.ts` / `*.test.tsx` (e.g.
   `core/articles.test.ts`, `core/data.test.ts`).
 - A change to core logic (`src/src/core/`) or a data contract MUST add or update tests.
 - New tests use Testing Library + jsdom (already configured).
+- After a deploy, deployment validation SHOULD confirm the live URL is actually valid
+  (see [testing.md](./testing.md#deployment-validation-planned)).
 
 ## Linting & formatting
 

--- a/docs/specs/testing.md
+++ b/docs/specs/testing.md
@@ -1,0 +1,162 @@
+---
+spec: testing
+version: 0.1.0
+status: current-state
+---
+
+# Testing Spec
+
+[Back to the specs index.](./README.md)
+
+How this project verifies correctness — from unit tests that run in CI today to the
+**deployment validation** that answers one question: _is the version that just went
+live actually working?_ Requirement keywords (**MUST**, **SHOULD**, **MAY**) follow
+[RFC 2119](./README.md#requirement-levels). All commands run from `src/`.
+
+The enforced gate lives in [quality-bars.md](./quality-bars.md#testing); this spec is
+the detailed contract behind it. Sections marked **Planned** are direction, not
+current behavior.
+
+## Testing strategy
+
+The site is **static prerendered HTML with no runtime server** (see
+[architecture.md](./architecture.md#ssr--prerender-contract)), which shapes the whole
+strategy: there is no backend to integration-test, so confidence comes from three
+layers.
+
+| Layer | Scope | Runs | Status |
+| --- | --- | --- | --- |
+| **Unit** | Pure logic in `core/`, components in isolation | `npm run test` (local + CI) | Current |
+| **Build gate** | `npm run build` produces valid client + SSR + prerendered HTML | CI on every change | Current |
+| **Deployment validation** | HTTP smoke checks against a live deployed URL | After each deploy | **Planned** |
+
+Keep the pyramid bottom-heavy: prefer many fast unit tests, a green build, and a
+small, high-signal set of smoke checks. Do **not** add a heavy end-to-end framework
+without cause (see [non-goals.md](./non-goals.md)) — the deployment checks below are
+intentionally lightweight.
+
+## Unit tests
+
+### Tooling and layout
+
+Verified from [`src/vite.config.ts`](../../src/vite.config.ts) and
+[`src/package.json`](../../src/package.json):
+
+- Runner: **vitest** with `globals: true` and the **jsdom** environment.
+- Setup file: [`src/src/test/setup.ts`](../../src/src/test/setup.ts) — runs Testing
+  Library `cleanup()` after each test, clears `localStorage`, resets the document
+  class, and polyfills `matchMedia` / `ResizeObserver`.
+- Component rendering: **@testing-library/react**.
+- Coverage: **@vitest/coverage-v8** (`text`, `json`, `html` reporters).
+- Test files match `src/**/*.test.{ts,tsx}` and `tests/unit/**/*.test.{ts,tsx}`, and
+  are **colocated** next to the code (e.g.
+  [`core/data.test.ts`](../../src/src/core/data.test.ts),
+  [`core/articles.test.ts`](../../src/src/core/articles.test.ts),
+  [`components/shared/ThemeToggle.test.tsx`](../../src/src/components/shared/ThemeToggle.test.tsx)).
+
+### Commands
+
+| Command | Use |
+| --- | --- |
+| `npm run test` | One-shot run (what CI runs). |
+| `npm run test:watch` | Watch mode while developing. |
+| `npm run test:coverage` | Run with a coverage report. |
+
+### What MUST be tested
+
+- **Core logic.** Any change to `src/src/core/` (articles, data accessors, SEO,
+  commands, date/string helpers) **MUST** add or update a colocated `*.test.ts`.
+- **Data contracts.** A change to a `content/data/*.json` shape or its accessor in
+  `core/data.ts` **MUST** be covered — see the mock-and-assert pattern in
+  [`core/data.test.ts`](../../src/src/core/data.test.ts) and
+  [data-contracts.md](./data-contracts.md).
+- **Behavioral component logic.** Components with real behavior (theme toggle,
+  terminal commands, prompt handling) **MUST** have tests. Purely presentational
+  components **MAY** be left untested.
+
+### Guidelines
+
+- **Test behavior, not implementation.** Query by **role and accessible name**
+  (`getByRole("button", { name: ... })`), not by test IDs or DOM structure — this
+  doubles as an accessibility check (see [accessibility.md](./accessibility.md)).
+- **Mock content at the module boundary.** Stub `@content/data/*.json` and article
+  imports with `vi.mock` rather than depending on real content, so tests stay stable
+  as content changes.
+- **Deterministic and offline.** No real network, no wall-clock dependence, no shared
+  state between tests. The setup file already resets globals after each test.
+- **One behavior per `it`**, arranged Arrange–Act–Assert. Name the `describe` after
+  the unit and the `it` after the observable behavior.
+- **Keep them fast.** A slow unit test usually means the boundary is wrong — mock it.
+
+## Build gate
+
+A change **MUST** pass `npm run build` (client → SSR → prerender) cleanly before it
+ships (see [quality-bars.md](./quality-bars.md#definition-of-done-reviewer-checklist)).
+The build is itself a test: it fails if a route can't be server-rendered, if
+`getStaticRoutes()` references a missing page, or if the prerender step
+([`scripts/prerender.mjs`](../../src/scripts/prerender.mjs)) can't emit the HTML,
+`sitemap.xml`, `robots.txt`, `llms.txt`, and `llms-full.txt`. Treat a red build as a
+failing test, never as noise to work around.
+
+## Deployment validation (Planned)
+
+> **Status: planned — not yet wired.** This is the core of "quickly assess whether a
+> deployed version is actually valid." It is defined here so it lands consistently.
+
+Goal: after a deploy — **preview** (`pr-<n>`) or **production** — run a small suite of
+HTTP checks against the **live URL** and fail loudly if the site is broken. This
+catches problems a local build cannot: a bad SWA config, a broken
+`navigationFallback`, missing assets, or a route that 404s in production.
+
+### Where it hooks in
+
+The deploy workflows already surface the target:
+[`reusable-deploy-static-web-app.yml`](../../.github/workflows/reusable-deploy-static-web-app.yml)
+outputs `static_web_app_url`, consumed by
+[`deploy-app.yml`](../../.github/workflows/deploy-app.yml). A validation job
+**SHOULD** run **after** `deploy_preview` / `deploy_production`, take that URL as
+input, and gate the deploy's success on the checks passing.
+
+### What to check (smoke suite)
+
+Against the deployed base URL, the suite **SHOULD** assert:
+
+- **Routes return `200`.** Every route from `getStaticRoutes()` — `/`, `/about`,
+  `/articles`, and at least one `/articles/{slug}` — responds `200` with
+  `content-type: text/html`.
+- **Content is prerendered, not blank.** Each route's HTML contains real body content
+  inside `<div id="root">` (not an empty shell), confirming the prerender shipped.
+- **SEO head is intact.** Each page has a non-empty `<title>`, a
+  `<meta name="description">`, a `<link rel="canonical">`, Open Graph tags, and the
+  expected JSON-LD — matching [quality-bars.md](./quality-bars.md#seo--metadata).
+- **Machine files are reachable.** `sitemap.xml`, `robots.txt`, `llms.txt`, and
+  `llms-full.txt` all return `200` with a sensible content-type and non-empty body.
+- **404 fallback works.** An unknown path serves the `/404.html` fallback configured
+  in [`staticwebapp.config.json`](../../src/public/staticwebapp.config.json) — ideally
+  with a `404` status — rather than a broken or blank page.
+- **Static assets load.** A referenced hashed JS/CSS asset and a key image resolve
+  `200`.
+
+Optionally, the production run **MAY** assert the deployed commit matches the expected
+SHA by reading the `VITE_COMMIT_HASH` surfaced in the UI/footer, to confirm the right
+build went live.
+
+### Constraints
+
+- **Stay lightweight and static-friendly.** Prefer a small **Node script** or a
+  **vitest** suite that `fetch`es the deployed URL over a heavy browser-automation
+  framework. Any browser-driven tool (e.g. Playwright) is a heavy dependency and
+  **MUST** be justified against [non-goals.md](./non-goals.md) before adoption.
+- **No runtime server or datastore.** These are black-box HTTP checks against static
+  output; they **MUST NOT** introduce a backend to test against.
+- **Fast and reliable.** The suite should finish in seconds and avoid flaky waits, so
+  a red result reliably means "the deploy is broken," not "the test is flaky."
+
+## Definition of Done (testing)
+
+A change satisfies the testing bar when:
+
+- [ ] `npm run test` passes; new/changed core logic and data contracts have colocated tests.
+- [ ] Component tests query by role/accessible name and mock content at the boundary.
+- [ ] `npm run build` succeeds (client + SSR + prerender).
+- [ ] Once deployment validation lands: the post-deploy smoke suite is green against the deployed URL.

--- a/docs/specs/testing.md
+++ b/docs/specs/testing.md
@@ -26,8 +26,8 @@ layers.
 
 | Layer | Scope | Runs | Status |
 | --- | --- | --- | --- |
-| **Unit** | Pure logic in `core/`, components in isolation | `npm run test` (local + CI) | Current |
-| **Build gate** | `npm run build` produces valid client + SSR + prerendered HTML | CI on every change | Current |
+| **Unit** | Pure logic in `core/`, components in isolation | `npm run test` locally; CI on app changes | Current |
+| **Build gate** | `npm run build` produces valid client + SSR + prerendered HTML | CI on deploy-triggering app/content changes | Current |
 | **Deployment validation** | HTTP smoke checks against a live deployed URL | After each deploy | **Planned** |
 
 Keep the pyramid bottom-heavy: prefer many fast unit tests, a green build, and a
@@ -92,6 +92,12 @@ Verified from [`src/vite.config.ts`](../../src/vite.config.ts) and
 
 A change **MUST** pass `npm run build` (client → SSR → prerender) cleanly before it
 ships (see [quality-bars.md](./quality-bars.md#definition-of-done-reviewer-checklist)).
+In CI the build runs as the first step of the deploy workflow
+([`reusable-deploy-static-web-app.yml`](../../.github/workflows/reusable-deploy-static-web-app.yml)
+via [`deploy-app.yml`](../../.github/workflows/deploy-app.yml)), so it is exercised on
+**deploy-triggering changes** — pushes to `main` and PRs touching `src/**` or
+`content/**`. Changes that don't match those path filters (e.g. docs- or infra-only)
+are not build-gated in CI, so run `npm run build` locally for those.
 The build is itself a test: it fails if a route can't be server-rendered, if
 `getStaticRoutes()` references a missing page, or if the prerender step
 ([`scripts/prerender.mjs`](../../src/scripts/prerender.mjs)) can't emit the HTML,


### PR DESCRIPTION
## Why

The specs set had no dedicated testing contract, and there was no documented way to answer a key question: once a version is deployed, is it actually valid? This adds a testing spec so both humans and automated agents have one source of truth for how correctness is verified, and defines the deployment-validation approach before it gets built.

## What

Adds `docs/specs/testing.md`, grounded in the real code and CI config, and wires it into the rest of the spec set.

- **Testing strategy** - a three-layer pyramid (unit tests, build gate, deployment validation) shaped by the site's static, no-runtime-server architecture.
- **Unit tests** - documents the current setup (vitest + jsdom + Testing Library, `src/src/test/setup.ts`, colocated `*.test.ts`), the test commands, what MUST be tested (core logic, data contracts, behavioral components), and guidelines (query by role/accessible name, mock `@content` at the module boundary, keep tests deterministic and offline).
- **Build gate** - treats `npm run build` (client -> SSR -> prerender) as a test that must pass.
- **Deployment validation (Planned)** - the core ask: after each preview/production deploy, run lightweight HTTP smoke checks against the live `static_web_app_url` (routes return 200, `#root` is not blank, SEO head intact, `sitemap.xml`/`robots.txt`/`llms*.txt` reachable, `/404.html` fallback works, assets load, optional commit-SHA match). Constrained to stay static-friendly and avoid heavy browser tooling per non-goals.

Also updates `docs/specs/README.md` (index table, agent-usage list, version bump to 0.2.0) and the `quality-bars.md` Testing section to link to the new spec.

## Notes

- Deployment validation is documented as **Planned** - this PR defines the contract but does not yet wire the CI smoke suite. It calls out where it should hook in (`reusable-deploy-static-web-app.yml` already outputs `static_web_app_url`).
- Docs-only change; no build, lint, or test runs required.