### PR TITLE
Restrict mermaid imports to keep the client bundle lean

### DIFF
--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -92,13 +92,21 @@ workflow itself) — so unrelated changes don't pay the cost.
   promises, misused type-only constructs, and similar bugs that need type information.
 - **Core JS hygiene** — the recommended set (no unused vars where configured, no
   unreachable code, etc.).
+- **Bundle-weight guardrail for `mermaid`** — `no-restricted-imports` errors when any app
+  file imports `mermaid` (or a `mermaid/*` subpath). Only
+  [`MermaidDiagram.tsx`](../../src/src/components/shared/MermaidDiagram.tsx) — the module
+  built to lazy-load it — is allowed to, via a scoped override. This keeps the heavy
+  dependency out of the shared client bundle, enforcing the performance stance in
+  [non-goals.md](./non-goals.md) and
+  [quality-bars.md](./quality-bars.md#performance).
 - **TypeScript strictness is enforced by the compiler**, not ESLint: `strict`,
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from
   [`tsconfig.json`](../../src/tsconfig.json) and `npm run build`. Lint and `tsc` are
   complementary gates; see [quality-bars.md](./quality-bars.md#typescript-strictness).
 
-There are **no project-specific custom rules enabled yet** — the config today is the
-recommended sets plus Prettier compatibility. The section below defines how to add them.
+The `no-restricted-imports` guardrail above is the first project-specific rule; beyond it,
+the config is the recommended sets plus Prettier compatibility. The section below defines
+how to add more.
 
 ## Custom rules & guardrails
 
@@ -174,9 +182,11 @@ the spec it would enforce and the likely mechanism:
 - **Don't reimplement Radix primitive behavior by hand** —
   [quality-bars.md](./quality-bars.md#component-conventions), via `no-restricted-syntax`
   on the raw elements a primitive already covers.
-- **Keep the client bundle lean** — restrict importing heavy dependencies (e.g. `mermaid`)
-  outside the modules meant to load them, via `no-restricted-imports`
-  ([non-goals.md](./non-goals.md)).
+- **Keep the client bundle lean** — restrict importing heavy dependencies outside the
+  modules meant to load them, via `no-restricted-imports`
+  ([non-goals.md](./non-goals.md)). _Enabled today for `mermaid`; see_
+  [What it enforces today](#what-it-enforces-today). The same mechanism can be extended to
+  other heavy deps as they appear.
 - **Images need `alt`** — the `jsx-a11y` plugin's `alt-text` rule, complementing the
   data-contract requirement in [accessibility.md](./accessibility.md).
 

--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -95,10 +95,13 @@ workflow itself) — so unrelated changes don't pay the cost.
 - **Bundle-weight guardrail for `mermaid`** — `no-restricted-imports` errors when any app
   file imports `mermaid` (or a `mermaid/*` subpath). Only
   [`MermaidDiagram.tsx`](../../src/src/components/shared/MermaidDiagram.tsx) — the module
-  built to lazy-load it — is allowed to, via a scoped override. This keeps the heavy
-  dependency out of the shared client bundle, enforcing the performance stance in
-  [non-goals.md](./non-goals.md) and
-  [quality-bars.md](./quality-bars.md#performance).
+  that owns the diagram runtime — is allowed to, via a scoped override. This confines the
+  heavy dependency to a single module (the seam where a dynamic-import boundary can later
+  be added) instead of letting it spread across the app, enforcing the performance stance
+  in [non-goals.md](./non-goals.md) and
+  [quality-bars.md](./quality-bars.md#performance). _Note: today that module is still
+  imported statically, so `mermaid` currently ships in the main chunk; the guardrail keeps
+  the import site singular so lazy-loading it stays a one-file change._
 - **TypeScript strictness is enforced by the compiler**, not ESLint: `strict`,
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from
   [`tsconfig.json`](../../src/tsconfig.json) and `npm run build`. Lint and `tsc` are

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -36,5 +36,35 @@ export default tseslint.config(
         },
     },
     ...typeCheckedConfigs,
+    {
+        files: ["**/*.{ts,tsx}"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "mermaid",
+                            message:
+                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx so it stays out of the shared client bundle (see docs/specs/non-goals.md and quality-bars.md).",
+                        },
+                    ],
+                    patterns: [
+                        {
+                            group: ["mermaid/*"],
+                            message:
+                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx so it stays out of the shared client bundle (see docs/specs/non-goals.md and quality-bars.md).",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        files: ["src/components/shared/MermaidDiagram.tsx"],
+        rules: {
+            "no-restricted-imports": "off",
+        },
+    },
     prettierConfig,
 );

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -46,14 +46,14 @@ export default tseslint.config(
                         {
                             name: "mermaid",
                             message:
-                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx so it stays out of the shared client bundle (see docs/specs/non-goals.md and quality-bars.md).",
+                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx to keep it confined to that single module — the seam where it can be given a dynamic-import boundary — rather than spreading across the app (see docs/specs/non-goals.md and quality-bars.md).",
                         },
                     ],
                     patterns: [
                         {
                             group: ["mermaid/*"],
                             message:
-                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx so it stays out of the shared client bundle (see docs/specs/non-goals.md and quality-bars.md).",
+                                "mermaid is a heavy dependency; import it only from src/components/shared/MermaidDiagram.tsx to keep it confined to that single module — the seam where it can be given a dynamic-import boundary — rather than spreading across the app (see docs/specs/non-goals.md and quality-bars.md).",
                         },
                     ],
                 },


### PR DESCRIPTION
## What

Implements **one** of the five bundle/quality guardrails tracked in #260: restrict where the heavy `mermaid` dependency may be imported so it stays out of the shared client bundle.

## Changes

- **`src/eslint.config.mjs`** — add a `no-restricted-imports` rule (level `error`) for all app files (`**/*.{ts,tsx}`) blocking imports of `mermaid` and any `mermaid/*` subpath. The message explains the bundle-weight rationale and points to the specs. A scoped override permits the single module built to lazy-load it: `src/components/shared/MermaidDiagram.tsx`. `eslint-config-prettier` stays last.
- **`docs/specs/linting.md`** — document the new guardrail in "What it enforces today", update the "no custom rules yet" note, and adjust the mermaid entry in the candidate backlog to reflect it's now enabled.

## Why

`mermaid` is a large dependency and should only load where it's actually used. Enforcing this in lint turns the performance convention from [`non-goals.md`](../blob/main/docs/specs/non-goals.md) and the performance section of [`quality-bars.md`](../blob/main/docs/specs/quality-bars.md) into an automatic guardrail rather than a review-time convention.

Only one file imports `mermaid` today and it's the allowed one, so the rule lands at `error` with a clean tree.

## Verification (from `src/`)

- `npm run lint` — clean. Verified the rule fires: a probe file importing `mermaid` elsewhere errors, while `MermaidDiagram.tsx` lints clean.
- `npm run test` — 43 tests passed (10 files).
- `npm run build` — `build:client` and `build:server` succeed. The `prerender` step fails locally with a pre-existing Windows-only ESM path issue in `scripts/prerender.mjs` (`await import()` of a raw `C:\...` path needs a `file://` URL); it is unrelated to this change and passes on CI's Linux runner.

## Scope

Refs #260 — intentionally **no closing keyword**, since that issue tracks all five guardrails and must stay open. Change is scoped to just this one guardrail.