### PR TITLE
Add lint guardrail flagging raw <button>/<hr> in favor of primitives

### DIFF
--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -96,9 +96,20 @@ workflow itself) — so unrelated changes don't pay the cost.
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from
   [`tsconfig.json`](../../src/tsconfig.json) and `npm run build`. Lint and `tsc` are
   complementary gates; see [quality-bars.md](./quality-bars.md#typescript-strictness).
+- **Prefer shared primitives over hand-rolled elements** — a `no-restricted-syntax` rule
+  scoped to `**/*.tsx` flags raw `<button>` (use the `Button` primitive) and raw `<hr>`
+  (use the `Separator` primitive), pointing contributors at
+  `src/src/components/shared/primitives/`. This enforces the
+  [component conventions](./quality-bars.md#component-conventions) rule that interactive
+  behavior **MUST NOT** be reimplemented by hand. The primitive source files
+  (`src/src/components/shared/primitives/**`) are exempt — they legitimately render the raw
+  elements. The rule currently runs at **`warn`** while a few pre-existing violations are
+  worked off; it will be promoted to **`error`** once the codebase is clean (tracked by
+  [issue #260](https://github.com/lfarci/loganfarci.com/issues/260)).
 
-There are **no project-specific custom rules enabled yet** — the config today is the
-recommended sets plus Prettier compatibility. The section below defines how to add them.
+There are **no other project-specific custom rules enabled yet** — the rest of the config
+is the recommended sets plus Prettier compatibility. The section below defines how to add
+more.
 
 ## Custom rules & guardrails
 
@@ -171,9 +182,6 @@ the spec it would enforce and the likely mechanism:
   [quality-bars.md](./quality-bars.md#accessibility--target-wcag-21-aa) and
   [accessibility.md](./accessibility.md), via a local rule flagging raw hex/`rgb()` in
   `className`/style.
-- **Don't reimplement Radix primitive behavior by hand** —
-  [quality-bars.md](./quality-bars.md#component-conventions), via `no-restricted-syntax`
-  on the raw elements a primitive already covers.
 - **Keep the client bundle lean** — restrict importing heavy dependencies (e.g. `mermaid`)
   outside the modules meant to load them, via `no-restricted-imports`
   ([non-goals.md](./non-goals.md)).

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -36,5 +36,33 @@ export default tseslint.config(
         },
     },
     ...typeCheckedConfigs,
+    {
+        // Guardrail (docs/specs/quality-bars.md#component-conventions): interactive
+        // behavior MUST NOT be reimplemented by hand. Flag raw JSX elements that a shared
+        // primitive already covers so contributors reach for the primitive instead.
+        files: ["**/*.tsx"],
+        rules: {
+            "no-restricted-syntax": [
+                "warn",
+                {
+                    selector: "JSXOpeningElement[name.name='button']",
+                    message:
+                        "Use the Button primitive (@/components/shared/primitives) instead of a raw <button>; don't reimplement its behavior by hand.",
+                },
+                {
+                    selector: "JSXOpeningElement[name.name='hr']",
+                    message:
+                        "Use the Separator primitive (@/components/shared/primitives) instead of a raw <hr>; don't reimplement its behavior by hand.",
+                },
+            ],
+        },
+    },
+    {
+        // The primitive source files legitimately render these raw elements.
+        files: ["src/components/shared/primitives/**/*.tsx"],
+        rules: {
+            "no-restricted-syntax": "off",
+        },
+    },
     prettierConfig,
 );


### PR DESCRIPTION
## What

Implements **one** guardrail from #260: discourage reimplementing Radix primitive behavior by hand.

Adds a `no-restricted-syntax` rule in `src/eslint.config.mjs`, scoped to `**/*.tsx`, that flags raw JSX elements a shared primitive already covers, with a message pointing at the correct primitive:

- `<button>` → use the `Button` primitive
- `<hr>` → use the `Separator` primitive

Only `button` and `hr` are flagged — they map 1:1 to a primitive with low false-positive risk. Generic elements (`span`/`div` behind Badge/Card, the Tooltip trigger) are intentionally **not** flagged to avoid noise.

The primitive source files legitimately render these raw elements, so `src/src/components/shared/primitives/**` is exempted via a second config block that turns the rule off for that path. `eslint-config-prettier` remains last.

## Rule level & pre-existing violations

Per `docs/specs/linting.md`, the rule lands at **`warn`** while a few pre-existing violations are worked off; it will be promoted to **`error`** once the codebase is clean. `npm run lint` (`eslint . --ext .ts,.tsx`) does not fail on warnings, so the gate stays green.

The 3 pre-existing violations (left as documented warnings; not changed to keep this PR scoped to the guardrail):

| File | Element |
| --- | --- |
| `src/src/components/shared/ChevronToggleButton.tsx` | raw `<button>` |
| `src/src/components/layout/LayoutWrapper.tsx` | raw `<hr>` |
| `src/src/components/shared/MarkdownContent.tsx` | raw `<hr>` (markdown element map) |

Converting `ChevronToggleButton`'s bare icon button to the `Button` primitive would be a visual change, so it's deferred rather than bundled here.

## Docs

Updated the **What it enforces today** section of `docs/specs/linting.md` and removed the Radix bullet from the candidate backlog.

## Verification (from `src/`)

- `npm run lint` — 0 errors, exactly the 3 expected warnings ✅
- `npm run test` — 43 passed ✅
- `npm run build` — client + SSR bundles build ✅ (the local `prerender` step fails with a pre-existing Windows-only `ERR_UNSUPPORTED_ESM_URL_SCHEME` in `scripts/prerender.mjs`, unrelated to this change; it passes on CI/Ubuntu)

## Notes

Relates to #260 (kept open — it tracks all five guardrails). Scoped to just this one guardrail.