### PR TITLE
Enforce @/ and @content/ aliases over deep relative imports

### DIFF
--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -92,13 +92,20 @@ workflow itself) — so unrelated changes don't pay the cost.
   promises, misused type-only constructs, and similar bugs that need type information.
 - **Core JS hygiene** — the recommended set (no unused vars where configured, no
   unreachable code, etc.).
+- **Prefer `@/` and `@content/` aliases over deep relative imports** — a
+  `no-restricted-imports` rule (scoped to `**/*.{ts,tsx}`) blocks `../../` and deeper
+  relative import paths, pointing authors to the `@/` (→ `src/src/`) and `@content/`
+  (→ `content/`) aliases. Enforces the alias convention in
+  [quality-bars.md](./quality-bars.md#typescript-strictness).
 - **TypeScript strictness is enforced by the compiler**, not ESLint: `strict`,
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from
   [`tsconfig.json`](../../src/tsconfig.json) and `npm run build`. Lint and `tsc` are
   complementary gates; see [quality-bars.md](./quality-bars.md#typescript-strictness).
 
-There are **no project-specific custom rules enabled yet** — the config today is the
-recommended sets plus Prettier compatibility. The section below defines how to add them.
+There are **no local custom rules (project-specific `local/*` plugins) enabled yet** —
+the config today is the recommended sets, the alias-import guardrail above (a configured
+core rule), plus Prettier compatibility. The section below defines how to add local
+rules.
 
 ## Custom rules & guardrails
 
@@ -164,9 +171,6 @@ These conventions from other specs are the natural first candidates to enforce i
 They are **not enabled today** (this list is the backlog, not current state); each names
 the spec it would enforce and the likely mechanism:
 
-- **Prefer `@/` and `@content/` aliases** over deep relative imports —
-  [quality-bars.md](./quality-bars.md#typescript-strictness), via `no-restricted-imports`
-  patterns on `../../`.
 - **No hardcoded colors; use semantic Tailwind tokens** —
   [quality-bars.md](./quality-bars.md#accessibility--target-wcag-21-aa) and
   [accessibility.md](./accessibility.md), via a local rule flagging raw hex/`rgb()` in

--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -94,8 +94,9 @@ workflow itself) — so unrelated changes don't pay the cost.
   unreachable code, etc.).
 - **Prefer `@/` and `@content/` aliases over deep relative imports** — a
   `no-restricted-imports` rule (scoped to `**/*.{ts,tsx}`) blocks `../../` and deeper
-  relative import paths, pointing authors to the `@/` (→ `src/src/`) and `@content/`
-  (→ `content/`) aliases. Enforces the alias convention in
+  relative import paths, and a companion `no-restricted-syntax` selector catches the same
+  depth in dynamic `import("../../…")` expressions, pointing authors to the `@/`
+  (→ `src/src/`) and `@content/` (→ `content/`) aliases. Enforces the alias convention in
   [quality-bars.md](./quality-bars.md#typescript-strictness).
 - **TypeScript strictness is enforced by the compiler**, not ESLint: `strict`,
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -51,6 +51,16 @@ export default tseslint.config(
                     ],
                 },
             ],
+            // `no-restricted-imports` only visits static imports, so guard deep
+            // dynamic `import("../../…")` expressions with a syntax selector too.
+            "no-restricted-syntax": [
+                "error",
+                {
+                    selector: "ImportExpression > Literal[value=/^\\.\\.\\/\\.\\.\\//]",
+                    message:
+                        "Avoid deep relative imports. Use the '@/' (src) or '@content/' (content) path aliases instead.",
+                },
+            ],
         },
     },
     prettierConfig,

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -36,5 +36,22 @@ export default tseslint.config(
         },
     },
     ...typeCheckedConfigs,
+    {
+        files: ["**/*.{ts,tsx}"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    patterns: [
+                        {
+                            group: ["../../*", "../../../**"],
+                            message:
+                                "Avoid deep relative imports. Use the '@/' (src) or '@content/' (content) path aliases instead.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
     prettierConfig,
 );


### PR DESCRIPTION
## Summary

Implements **one** of the five lint guardrails tracked in #260: prefer the `@/` and `@content/` path aliases over deep relative imports.

- Adds a `no-restricted-imports` config block (scoped to `**/*.{ts,tsx}`) in `src/eslint.config.mjs` that blocks `../../*` and deeper relative import paths, with a message directing authors to the `@/` (→ `src/src/`) and `@content/` (→ `content/`) aliases.
- Lands at **`error`** directly — there are 0 such imports in the codebase today, so nothing needs migrating.
- `eslint-config-prettier` stays last in the config array.
- Updates the **What it enforces today** section of `docs/specs/linting.md` to reflect the enabled rule, and removes it from the candidate-guardrails backlog.

## Verification

From `src/`:
- `npm run lint` — clean. Also verified the rule fires on probe imports (`../../bar` and `../../../foo` both reported), then removed the probes.
- `npm run test` — 43 passed.
- `npm run build` — client + server bundles build successfully. (The `prerender` step hits a pre-existing, Windows-local-only ESM absolute-path quirk unrelated to this change; it is unaffected on CI/Linux.)

## Notes

Refs #260 — intentionally **not** using a closing keyword, since that issue tracks all five guardrails and must stay open until the rest land.