### PR TITLE
Add lint guardrail forbidding hardcoded colors

### DIFF
--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -98,8 +98,11 @@ workflow itself) — so unrelated changes don't pay the cost.
   complementary gates; see [quality-bars.md](./quality-bars.md#typescript-strictness).
 - **No hardcoded colors** — a local custom rule (`local/no-hardcoded-colors`, scoped to
   `**/*.tsx`) flags raw color literals — hex (`#rgb`/`#rrggbb`), `rgb()`/`rgba()`,
-  `hsl()`/`hsla()` — in `className` strings and inline `style` values, so colors come from
-  semantic Tailwind tokens. This enforces the accessibility gate in
+  `hsl()`/`hsla()`, `hwb()`, `lab()`/`lch()`, `oklab()`/`oklch()`, and `color()` — in
+  `className` strings and inline `style` values, plus the string arguments of class-builder
+  calls (`cva`, `mergeClassNames`/`cn`, `clsx`, …) wherever they are called, so colors come
+  from semantic Tailwind tokens. `oklch()` is the repo's primary color notation, so it is
+  covered explicitly. This enforces the accessibility gate in
   [quality-bars.md](./quality-bars.md#accessibility--target-wcag-21-aa) and
   [accessibility.md](./accessibility.md). The rule lives at
   [`src/src/lint/no-hardcoded-colors.js`](../../src/src/lint/no-hardcoded-colors.js) with a

--- a/docs/specs/linting.md
+++ b/docs/specs/linting.md
@@ -96,9 +96,19 @@ workflow itself) — so unrelated changes don't pay the cost.
   `isolatedModules`, `resolveJsonModule`, and no implicit `any` come from
   [`tsconfig.json`](../../src/tsconfig.json) and `npm run build`. Lint and `tsc` are
   complementary gates; see [quality-bars.md](./quality-bars.md#typescript-strictness).
+- **No hardcoded colors** — a local custom rule (`local/no-hardcoded-colors`, scoped to
+  `**/*.tsx`) flags raw color literals — hex (`#rgb`/`#rrggbb`), `rgb()`/`rgba()`,
+  `hsl()`/`hsla()` — in `className` strings and inline `style` values, so colors come from
+  semantic Tailwind tokens. This enforces the accessibility gate in
+  [quality-bars.md](./quality-bars.md#accessibility--target-wcag-21-aa) and
+  [accessibility.md](./accessibility.md). The rule lives at
+  [`src/src/lint/no-hardcoded-colors.js`](../../src/src/lint/no-hardcoded-colors.js) with a
+  colocated `RuleTester` test; it landed directly at `error` because a full-codebase scan
+  found zero existing violations.
 
-There are **no project-specific custom rules enabled yet** — the config today is the
-recommended sets plus Prettier compatibility. The section below defines how to add them.
+There are currently a small number of project-specific custom rules enabled (see the
+`local` plugin in [`eslint.config.mjs`](../../src/eslint.config.mjs)); everything else is
+the recommended sets plus Prettier compatibility. The section below defines how to add more.
 
 ## Custom rules & guardrails
 
@@ -167,10 +177,6 @@ the spec it would enforce and the likely mechanism:
 - **Prefer `@/` and `@content/` aliases** over deep relative imports —
   [quality-bars.md](./quality-bars.md#typescript-strictness), via `no-restricted-imports`
   patterns on `../../`.
-- **No hardcoded colors; use semantic Tailwind tokens** —
-  [quality-bars.md](./quality-bars.md#accessibility--target-wcag-21-aa) and
-  [accessibility.md](./accessibility.md), via a local rule flagging raw hex/`rgb()` in
-  `className`/style.
 - **Don't reimplement Radix primitive behavior by hand** —
   [quality-bars.md](./quality-bars.md#component-conventions), via `no-restricted-syntax`
   on the raw elements a primitive already covers.

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -4,6 +4,15 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 
+import noHardcodedColors from "./src/lint/no-hardcoded-colors.js";
+
+// Local plugin holding project-specific guardrail rules (see docs/specs/linting.md).
+const local = {
+    rules: {
+        "no-hardcoded-colors": noHardcodedColors,
+    },
+};
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const tsconfigPath = path.resolve(__dirname, "./tsconfig.json");
@@ -36,5 +45,12 @@ export default tseslint.config(
         },
     },
     ...typeCheckedConfigs,
+    {
+        files: ["**/*.tsx"],
+        plugins: { local },
+        rules: {
+            "local/no-hardcoded-colors": "error",
+        },
+    },
     prettierConfig,
 );

--- a/src/src/lint/no-hardcoded-colors.js
+++ b/src/src/lint/no-hardcoded-colors.js
@@ -1,0 +1,111 @@
+/**
+ * Local ESLint rule: forbid hardcoded color literals in `className` and inline
+ * `style` values so colors come from semantic Tailwind tokens.
+ *
+ * Enforces the accessibility convention that colors must be sourced from
+ * semantic Tailwind tokens, documented in `docs/specs/accessibility.md` and the
+ * accessibility gate of `docs/specs/quality-bars.md`.
+ */
+
+// Hex colors: `#` followed by exactly 3, 4, 6, or 8 hex digits. The negative
+// lookahead prevents matching a longer hex run or a URL fragment like
+// `#about-me` (whose first characters are not all hex digits anyway).
+const HEX_COLOR = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/;
+
+// Functional color notations: rgb(), rgba(), hsl(), hsla().
+const FUNCTIONAL_COLOR = /\b(?:rgb|hsl)a?\(/i;
+
+/**
+ * Recursively collect every string `Literal` and template-literal
+ * `TemplateElement` reachable from the given AST node. This covers plain
+ * strings, template literals, `cn(...)`/`clsx(...)` arguments, ternaries, and
+ * `style={{ color: "..." }}` object property values.
+ *
+ * @param {unknown} node
+ * @param {Array<{ text: string, node: object }>} out
+ */
+function collectStrings(node, out) {
+    if (node === null || typeof node !== "object") {
+        return;
+    }
+
+    const candidate = /** @type {{ type?: string, value?: unknown }} */ (node);
+
+    if (candidate.type === "Literal" && typeof candidate.value === "string") {
+        out.push({ text: candidate.value, node: /** @type {object} */ (node) });
+    } else if (candidate.type === "TemplateElement") {
+        const element = /** @type {{ value?: { cooked?: string | null, raw?: string } }} */ (node);
+        const text = element.value?.cooked ?? element.value?.raw ?? "";
+        out.push({ text, node: /** @type {object} */ (node) });
+    }
+
+    for (const key of Object.keys(node)) {
+        if (key === "parent") {
+            continue;
+        }
+        const child = /** @type {Record<string, unknown>} */ (node)[key];
+        if (Array.isArray(child)) {
+            for (const item of child) {
+                collectStrings(item, out);
+            }
+        } else if (
+            child !== null &&
+            typeof child === "object" &&
+            typeof (/** @type {{ type?: string }} */ (child)).type === "string"
+        ) {
+            collectStrings(child, out);
+        }
+    }
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+    meta: {
+        type: "problem",
+        docs: {
+            description:
+                "Disallow hardcoded color literals in className and inline style values; use semantic Tailwind color tokens instead.",
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            hardcodedColor: 'Use a semantic Tailwind color token instead of the hardcoded color "{{color}}".',
+        },
+    },
+    create(context) {
+        return {
+            JSXAttribute(node) {
+                const nameNode = node.name;
+                if (!nameNode || nameNode.type !== "JSXIdentifier") {
+                    return;
+                }
+                if (nameNode.name !== "className" && nameNode.name !== "style") {
+                    return;
+                }
+                if (!node.value) {
+                    return;
+                }
+
+                /** @type {Array<{ text: string, node: object }>} */
+                const strings = [];
+                collectStrings(node.value, strings);
+
+                for (const { text, node: stringNode } of strings) {
+                    const hexMatch = text.match(HEX_COLOR);
+                    const fnMatch = text.match(FUNCTIONAL_COLOR);
+                    if (!hexMatch && !fnMatch) {
+                        continue;
+                    }
+                    const color = (hexMatch ?? fnMatch)?.[0] ?? text;
+                    context.report({
+                        node: /** @type {import("eslint").Rule.Node} */ (stringNode),
+                        messageId: "hardcodedColor",
+                        data: { color },
+                    });
+                }
+            },
+        };
+    },
+};
+
+export default rule;

--- a/src/src/lint/no-hardcoded-colors.js
+++ b/src/src/lint/no-hardcoded-colors.js
@@ -12,8 +12,18 @@
 // `#about-me` (whose first characters are not all hex digits anyway).
 const HEX_COLOR = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/;
 
-// Functional color notations: rgb(), rgba(), hsl(), hsla().
-const FUNCTIONAL_COLOR = /\b(?:rgb|hsl)a?\(/i;
+// Functional color notations (CSS Color 4): rgb()/rgba(), hsl()/hsla(), hwb(),
+// lab()/lch(), oklab()/oklch(), and color(). The trailing `\(` means the CSS
+// colorspace *keyword* form (e.g. `in oklch`) and the English word "color" are
+// not matched — only the function-call form is. `oklch()` in particular is this
+// repository's primary color notation (see src/src/globals.css).
+const FUNCTIONAL_COLOR = /\b(?:rgb|hsl|hwb|(?:ok)?lab|(?:ok)?lch|color)a?\(/i;
+
+// Class-building helpers whose string arguments are class names. A hardcoded
+// color passed to any of these bypasses the JSXAttribute check (the attribute
+// value is then just an identifier), so they are scanned wherever they are
+// called — e.g. `const variants = cva("bg-[#fff]", …)`.
+const CLASS_FACTORY_NAMES = new Set(["cva", "cn", "clsx", "cx", "tv", "twMerge", "twJoin", "mergeClassNames"]);
 
 /**
  * Recursively collect every string `Literal` and template-literal
@@ -73,6 +83,38 @@ const rule = {
         },
     },
     create(context) {
+        // Dedup by string-node identity so a factory call nested inside a
+        // className/style attribute isn't reported twice.
+        /** @type {Set<object>} */
+        const reported = new Set();
+
+        /**
+         * @param {unknown} valueNode
+         */
+        function reportColorsIn(valueNode) {
+            /** @type {Array<{ text: string, node: object }>} */
+            const strings = [];
+            collectStrings(valueNode, strings);
+
+            for (const { text, node: stringNode } of strings) {
+                if (reported.has(stringNode)) {
+                    continue;
+                }
+                const hexMatch = text.match(HEX_COLOR);
+                const fnMatch = text.match(FUNCTIONAL_COLOR);
+                if (!hexMatch && !fnMatch) {
+                    continue;
+                }
+                reported.add(stringNode);
+                const color = (hexMatch ?? fnMatch)?.[0] ?? text;
+                context.report({
+                    node: /** @type {import("eslint").Rule.Node} */ (stringNode),
+                    messageId: "hardcodedColor",
+                    data: { color },
+                });
+            }
+        }
+
         return {
             JSXAttribute(node) {
                 const nameNode = node.name;
@@ -85,23 +127,21 @@ const rule = {
                 if (!node.value) {
                     return;
                 }
-
-                /** @type {Array<{ text: string, node: object }>} */
-                const strings = [];
-                collectStrings(node.value, strings);
-
-                for (const { text, node: stringNode } of strings) {
-                    const hexMatch = text.match(HEX_COLOR);
-                    const fnMatch = text.match(FUNCTIONAL_COLOR);
-                    if (!hexMatch && !fnMatch) {
-                        continue;
-                    }
-                    const color = (hexMatch ?? fnMatch)?.[0] ?? text;
-                    context.report({
-                        node: /** @type {import("eslint").Rule.Node} */ (stringNode),
-                        messageId: "hardcodedColor",
-                        data: { color },
-                    });
+                reportColorsIn(node.value);
+            },
+            CallExpression(node) {
+                const callee = node.callee;
+                let name = null;
+                if (callee.type === "Identifier") {
+                    name = callee.name;
+                } else if (callee.type === "MemberExpression" && callee.property.type === "Identifier") {
+                    name = callee.property.name;
+                }
+                if (!name || !CLASS_FACTORY_NAMES.has(name)) {
+                    return;
+                }
+                for (const arg of node.arguments) {
+                    reportColorsIn(arg);
                 }
             },
         };

--- a/src/src/lint/no-hardcoded-colors.test.ts
+++ b/src/src/lint/no-hardcoded-colors.test.ts
@@ -1,0 +1,77 @@
+import { RuleTester } from "eslint";
+import { afterAll, describe, it } from "vitest";
+
+import rule from "./no-hardcoded-colors.js";
+
+// Wire ESLint's RuleTester into vitest's test lifecycle so its cases surface as
+// regular vitest tests.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        parserOptions: {
+            ecmaFeatures: { jsx: true },
+        },
+    },
+});
+
+ruleTester.run("no-hardcoded-colors", rule, {
+    valid: [
+        { code: `const A = () => <div className="text-primary bg-background" />;` },
+        { code: `const B = () => <div className={cn("border-border", isActive && "text-accent")} />;` },
+        { code: `const C = () => <div style={{ width: 10, opacity: 0.5 }} />;` },
+        // URL fragments in non-color attributes must not be flagged.
+        { code: `const D = () => <a href="#about-me" className="text-foreground">x</a>;` },
+        // A className string that merely contains a `#` fragment-like token, not a color.
+        { code: `const E = () => <div className="scroll-mt-[#header]" />;` },
+        // Colors outside className/style are out of scope.
+        { code: `const F = () => <svg fill="#ff0000" />;` },
+    ],
+    invalid: [
+        {
+            code: `const A = () => <div className="text-[#fff]" />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const B = () => <div className="bg-[#ff0000]" />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: "const C = () => <div className={`text-[#abcd]`} />;",
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const D = () => <div style={{ color: "#fff" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const E = () => <div style={{ color: "rgb(255, 0, 0)" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const F = () => <div className="bg-[rgba(0,0,0,0.5)]" />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const G = () => <div style={{ background: "hsl(200, 50%, 50%)" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const H = () => <div style={{ background: "hsla(200, 50%, 50%, 0.4)" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const I = () => <div className={active ? "text-[#fff]" : "text-primary"} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const J = () => <div className={cn("bg-[#000]", "text-[#fff]")} />;`,
+            errors: [{ messageId: "hardcodedColor" }, { messageId: "hardcodedColor" }],
+        },
+    ],
+});

--- a/src/src/lint/no-hardcoded-colors.test.ts
+++ b/src/src/lint/no-hardcoded-colors.test.ts
@@ -31,6 +31,10 @@ ruleTester.run("no-hardcoded-colors", rule, {
         { code: `const E = () => <div className="scroll-mt-[#header]" />;` },
         // Colors outside className/style are out of scope.
         { code: `const F = () => <svg fill="#ff0000" />;` },
+        // Class-factory calls with only semantic tokens are fine.
+        { code: `const v = cva("bg-brand text-brand-foreground", { variants: {} });` },
+        // The `oklch` colorspace keyword (not the function form) is not a color literal.
+        { code: `const G = () => <div className="[color-mix(in_oklch,var(--a),var(--b))]" />;` },
     ],
     invalid: [
         {
@@ -72,6 +76,33 @@ ruleTester.run("no-hardcoded-colors", rule, {
         {
             code: `const J = () => <div className={cn("bg-[#000]", "text-[#fff]")} />;`,
             errors: [{ messageId: "hardcodedColor" }, { messageId: "hardcodedColor" }],
+        },
+        // Modern CSS color functions, incl. the repo's primary notation oklch().
+        {
+            code: `const K = () => <div className="bg-[oklch(50%_0.2_20)]" />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const L = () => <div style={{ color: "oklch(50% 0.2 20)" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const M = () => <div style={{ color: "hwb(194 0% 0%)" }} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        // Class factories used outside a JSX attribute are still scanned.
+        {
+            code: `const variants = cva("base", { variants: { danger: { on: "bg-[#f00]" } } });`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        {
+            code: `const classes = mergeClassNames("bg-[oklch(60%_0.1_10)]", "p-2");`,
+            errors: [{ messageId: "hardcodedColor" }],
+        },
+        // A factory call inside a className attribute is reported exactly once (deduped).
+        {
+            code: `const N = () => <div className={mergeClassNames("bg-[#fff]")} />;`,
+            errors: [{ messageId: "hardcodedColor" }],
         },
     ],
 });


### PR DESCRIPTION
## What

Implements **one** of the five guardrails tracked in #260: a local ESLint rule that forbids raw color literals so colors come from semantic Tailwind tokens.

- Adds `local/no-hardcoded-colors` (a local flat-config plugin rule) scoped to `**/*.tsx`. It flags:
  - hex colors — `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`
  - functional notations (CSS Color 4) — `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`, `lab()`, `lch()`, `oklab()`, `oklch()`, `color()` (`oklch()` is the repo's primary notation — see `globals.css`)
  
  ...appearing in `className` strings (including template literals and ternaries), inline `style` object values, **and** the string arguments of class-builder calls (`cva`, `mergeClassNames`/`cn`, `clsx`, `cx`, `tv`, `twMerge`, `twJoin`) wherever they're called — so a color hardcoded in `cva(...)` outside a JSX attribute is still caught. A reported-node set dedups nested factory calls.
- Ships a colocated `RuleTester` test (`src/src/lint/no-hardcoded-colors.test.ts`) wired into vitest — 24 cases (valid + invalid).
- Updates the **"What it enforces today"** section of `docs/specs/linting.md` and removes the color item from the candidate/backlog list.

## Why `error` (not `warn`)

A full-codebase scan found **zero** existing violations — the only `#`-prefixed literals in `.tsx` files are `href="#about-me"`-style URL fragments, which the rule deliberately ignores (it only inspects `className`/`style`/class-factory args, and the hex matcher requires a valid 3/4/6/8-digit hex run). Since there was nothing to clean up, the rule lands directly at `error` rather than a permanently-`warn` guardrail.

## Design notes

- The rule module is authored as a JSDoc-typed **`.js`** file (`src/src/lint/no-hardcoded-colors.js`) because `eslint.config.mjs` is loaded by Node, which cannot import TypeScript. With `allowJs: true` in `tsconfig.json`, the JSDoc types flow into the `.ts` test import with no unsafe-import lint noise; `--ext .ts,.tsx` means the rule file itself isn't linted.
- `eslint-config-prettier` is kept **last** in the flat config.
- **Known limitation:** a bare local like `const c = "bg-[#fff]"; <div className={c} />` isn't tracked, since reliable variable data-flow resolution is beyond a static AST rule. Class-factory coverage handles the dominant real pattern in this repo (`cva`).

## Codex review

Both P2 review comments are addressed in `f99d24f`: (1) OKLCH/modern color functions are now matched; (2) class-factory calls outside JSX are now scanned.

## Verification (from `src/`)

- `npm run lint` — passes clean (0 errors; the stronger rule still finds zero violations, including Button.tsx's `cva()`).
- `npm run test` — 67 tests pass (24 in the new rule test).
- `npm run build` — client + SSR bundles build successfully.
  - Note: the `prerender` step fails locally on **Windows only** with a pre-existing `ERR_UNSUPPORTED_ESM_URL_SCHEME` (an absolute `c:\` path passed to `import()` in `scripts/prerender.mjs` without `pathToFileURL`). It is unrelated to this change — none of these files are imported by the app bundle or prerender — and does not affect CI, which runs on Linux.

## Scope

Refs #260. Intentionally **no closing keyword** — the issue tracks all five guardrails and must stay open. This PR is scoped to just the hardcoded-colors guardrail.