### PR TITLE
test: validate jsx-a11y alt-text guardrail (do not merge)

### DIFF
--- a/src/src/components/__AltTextProbe.tsx
+++ b/src/src/components/__AltTextProbe.tsx
@@ -1,0 +1,1 @@
+export const AltTextProbe = () => <img src="/probe.png" width={16} height={16} />;


### PR DESCRIPTION
Validation probe for the `jsx-a11y/alt-text` guardrail added in #262. Adds a temporary component with an `<img>` missing `alt` so the CI **Lint** workflow should fail.

Expected: Lint check ❌. This PR will be **closed, not merged** once validated. Refs #260.