### PR TITLE
Add Codex repository guidance and app skills

### DIFF
--- a/.agents/skills/run-app-locally/SKILL.md
+++ b/.agents/skills/run-app-locally/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: run-app-locally
+description: Start and verify the loganfarci.com application on the local machine. Use when asked to run, launch, serve, preview, or open the app locally for development or review.
+---
+
+# Run App Locally
+
+Read `AGENTS.md` and `.github/copilot-instructions.md` before starting. Keep
+those files authoritative.
+
+1. Work from `src/`.
+2. Run `npm ci` only when dependencies are missing.
+3. Use development mode by default:
+
+    ```bash
+    npm run dev -- --host 127.0.0.1
+    ```
+
+4. If the user asks to inspect the production build locally, run:
+
+    ```bash
+    npm run build
+    npm run preview -- --host 127.0.0.1
+    ```
+
+5. Keep the server process running, wait for Vite to report readiness, and
+   provide the exact local URL. Do not open a browser unless asked.
+6. If the selected port is unavailable, report the URL Vite selected. Do not
+   stop unrelated processes.
+7. When asked to stop, terminate only the server process started by this skill.

--- a/.agents/skills/run-app-locally/SKILL.md
+++ b/.agents/skills/run-app-locally/SKILL.md
@@ -5,26 +5,5 @@ description: Start and verify the loganfarci.com application on the local machin
 
 # Run App Locally
 
-Read `AGENTS.md` and `.github/copilot-instructions.md` before starting. Keep
-those files authoritative.
-
-1. Work from `src/`.
-2. Run `npm ci` only when dependencies are missing.
-3. Use development mode by default:
-
-    ```bash
-    npm run dev -- --host 127.0.0.1
-    ```
-
-4. If the user asks to inspect the production build locally, run:
-
-    ```bash
-    npm run build
-    npm run preview -- --host 127.0.0.1
-    ```
-
-5. Keep the server process running, wait for Vite to report readiness, and
-   provide the exact local URL. Do not open a browser unless asked.
-6. If the selected port is unavailable, report the URL Vite selected. Do not
-   stop unrelated processes.
-7. When asked to stop, terminate only the server process started by this skill.
+Read and follow the canonical workflow in
+`../../../.github/skills/run-app-locally/SKILL.md`.

--- a/.agents/skills/run-app-locally/agents/openai.yaml
+++ b/.agents/skills/run-app-locally/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+    display_name: "Run App Locally"
+    short_description: "Start and verify the local development app"
+    default_prompt: "Use $run-app-locally to start the application for local development."

--- a/.agents/skills/validate-app/SKILL.md
+++ b/.agents/skills/validate-app/SKILL.md
@@ -5,24 +5,5 @@ description: Validate the loganfarci.com application with its complete local qua
 
 # Validate App
 
-Read `AGENTS.md`, `.github/copilot-instructions.md`, and
-`docs/specs/quality-bars.md` before validating. Keep those files authoritative.
-
-1. Confirm the repository state with `git status -sb`. Do not modify or discard
-   unrelated changes.
-2. Work from `src/`.
-3. Run `npm ci` only when dependencies are missing or the user explicitly asks
-   for a clean install.
-4. Inspect the scripts in `package.json`. Run `npm run format:check` first when
-   that script exists.
-5. Run the required quality gate in this order:
-
-    ```bash
-    npm run lint
-    npm run test
-    npm run build
-    ```
-
-6. Stop at the first failure, preserve its useful output, and identify the
-   failing command and likely cause. Do not fix failures unless asked.
-7. Report every command run, its result, and any validation that was skipped.
+Read and follow the canonical workflow in
+`../../../.github/skills/validate-app/SKILL.md`.

--- a/.agents/skills/validate-app/SKILL.md
+++ b/.agents/skills/validate-app/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: validate-app
+description: Validate the loganfarci.com application with its complete local quality gate. Use when asked to check, validate, verify, test, build, or determine whether the app is ready to ship.
+---
+
+# Validate App
+
+Read `AGENTS.md`, `.github/copilot-instructions.md`, and
+`docs/specs/quality-bars.md` before validating. Keep those files authoritative.
+
+1. Confirm the repository state with `git status -sb`. Do not modify or discard
+   unrelated changes.
+2. Work from `src/`.
+3. Run `npm ci` only when dependencies are missing or the user explicitly asks
+   for a clean install.
+4. Inspect the scripts in `package.json`. Run `npm run format:check` first when
+   that script exists.
+5. Run the required quality gate in this order:
+
+    ```bash
+    npm run lint
+    npm run test
+    npm run build
+    ```
+
+6. Stop at the first failure, preserve its useful output, and identify the
+   failing command and likely cause. Do not fix failures unless asked.
+7. Report every command run, its result, and any validation that was skipped.

--- a/.agents/skills/validate-app/agents/openai.yaml
+++ b/.agents/skills/validate-app/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+    display_name: "Validate App"
+    short_description: "Run the complete local app quality gate"
+    default_prompt: "Use $validate-app to validate the application before shipping."

--- a/.github/skills/run-app-locally/SKILL.md
+++ b/.github/skills/run-app-locally/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: run-app-locally
+description: Start and verify the loganfarci.com application on the local machine. Use when asked to run, launch, serve, preview, or open the app locally for development or review.
+---
+
+# Run App Locally
+
+Read `AGENTS.md` and `.github/copilot-instructions.md` before starting. Keep
+those files authoritative.
+
+1. Work from `src/`.
+2. Run `npm ci` only when dependencies are missing.
+3. Use development mode by default:
+
+    ```bash
+    npm run dev -- --host 127.0.0.1
+    ```
+
+4. If the user asks to inspect the production build locally, run:
+
+    ```bash
+    npm run build
+    npm run preview -- --host 127.0.0.1
+    ```
+
+5. Keep the server process running, wait for Vite to report readiness, and
+   provide the exact local URL. Do not open a browser unless asked.
+6. If the selected port is unavailable, report the URL Vite selected. Do not
+   stop unrelated processes.
+7. When asked to stop, terminate only the server process started by this skill.

--- a/.github/skills/validate-app/SKILL.md
+++ b/.github/skills/validate-app/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: validate-app
+description: Validate the loganfarci.com application with its complete local quality gate. Use when asked to check, validate, verify, test, build, or determine whether the app is ready to ship.
+---
+
+# Validate App
+
+Read `AGENTS.md`, `.github/copilot-instructions.md`, and
+`docs/specs/quality-bars.md` before validating. Keep those files authoritative.
+
+1. Confirm the repository state with `git status -sb`. Do not modify or discard
+   unrelated changes.
+2. Work from `src/`.
+3. Run `npm ci` only when dependencies are missing or the user explicitly asks
+   for a clean install.
+4. Inspect the scripts in `package.json`. Run `npm run format:check` first when
+   that script exists.
+5. Run the required quality gate in this order:
+
+    ```bash
+    npm run lint
+    npm run test
+    npm run build
+    ```
+
+6. Stop at the first failure, preserve its useful output, and identify the
+   failing command and likely cause. Do not fix failures unless asked.
+7. Report every command run, its result, and any validation that was skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Repository guidance
+
+## Project
+
+This repository contains `loganfarci.com`, a Vite, React 19, and TypeScript
+personal website. The site is prerendered to static HTML and deployed to Azure
+Static Web Apps. Terraform under `infra/` owns the Azure infrastructure.
+
+The specifications in `docs/specs/` are the source of truth. Read the spec that
+matches the task before changing code or content:
+
+- Architecture, routing, SSR, or prerendering: `docs/specs/architecture.md`
+- Shipping and review requirements: `docs/specs/quality-bars.md`
+- Tests and deployment checks: `docs/specs/testing.md`
+- Accessibility: `docs/specs/accessibility.md`
+- Structured JSON data: `docs/specs/data-contracts.md`
+- Articles and Markdown: `docs/specs/content-style-guide.md` and
+  `docs/specs/markdown-rendering.md`
+- New product proposals: `docs/specs/non-goals.md` and `docs/specs/vision.md`
+
+When guidance conflicts, follow the precedence documented in
+`docs/specs/README.md`. In particular, non-goals are hard scope boundaries and
+current code is authoritative for current-state facts.
+
+## Repository layout
+
+- `src/`: Vite application and all npm commands
+- `content/`: build-time Markdown articles and JSON data
+- `infra/`: Terraform for Azure resources
+- `docs/specs/`: canonical product and engineering requirements
+- `.github/workflows/`: CI, deployment, and agentic workflows
+
+More-specific `AGENTS.md` files under `src/` and `content/` add scoped guidance.
+
+## Working conventions
+
+- Inspect nearby code and the relevant spec before editing.
+- Make the smallest change that fully satisfies the request.
+- Do not introduce a runtime server, database, authentication, CMS, alternate
+  framework, or heavy dependency without an explicit architectural decision.
+- Do not edit generated output such as `src/dist/`.
+- Preserve unrelated working-tree changes.
+- Keep documentation consistent with code. If a current-state spec has drifted,
+  update it with the implementation and call out the drift.
+- Never hardcode credentials, deployment tokens, cloud resource names, or
+  environment-specific identifiers.
+
+## Verification
+
+Run application commands from `src/`:
+
+```bash
+npm run lint
+npm run test
+npm run build
+npm run format:check
+```
+
+Choose checks proportionate to the change, but run the full build for changes to
+application code, routes, content loading, SSR, or prerendering. Core logic and
+data-contract changes require colocated tests. For deployed-environment
+validation, run `npm run smoke -- <base-url>`.
+
+For GitHub Agentic Workflow changes, edit the Markdown source and regenerate its
+lock file:
+
+```bash
+gh aw compile
+gh aw compile --validate
+```
+
+Report the checks run and any checks that could not be run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,72 +1,17 @@
 # Repository guidance
 
-## Project
+Use the existing GitHub Copilot custom instructions and repository specs as the
+shared agent guidance:
 
-This repository contains `loganfarci.com`, a Vite, React 19, and TypeScript
-personal website. The site is prerendered to static HTML and deployed to Azure
-Static Web Apps. Terraform under `infra/` owns the Azure infrastructure.
+- `.github/copilot-instructions.md` defines the project, layout, workflows, and
+  coding conventions.
+- `.github/instructions/` contains path-specific instructions.
+- `docs/specs/README.md` routes tasks to the canonical requirements and defines
+  their precedence.
 
-The specifications in `docs/specs/` are the source of truth. Read the spec that
-matches the task before changing code or content:
+Read the applicable files before making changes. Do not restate their rules here;
+update the relevant custom instruction or spec when guidance changes so Copilot
+and Codex stay aligned.
 
-- Architecture, routing, SSR, or prerendering: `docs/specs/architecture.md`
-- Shipping and review requirements: `docs/specs/quality-bars.md`
-- Tests and deployment checks: `docs/specs/testing.md`
-- Accessibility: `docs/specs/accessibility.md`
-- Structured JSON data: `docs/specs/data-contracts.md`
-- Articles and Markdown: `docs/specs/content-style-guide.md` and
-  `docs/specs/markdown-rendering.md`
-- New product proposals: `docs/specs/non-goals.md` and `docs/specs/vision.md`
-
-When guidance conflicts, follow the precedence documented in
-`docs/specs/README.md`. In particular, non-goals are hard scope boundaries and
-current code is authoritative for current-state facts.
-
-## Repository layout
-
-- `src/`: Vite application and all npm commands
-- `content/`: build-time Markdown articles and JSON data
-- `infra/`: Terraform for Azure resources
-- `docs/specs/`: canonical product and engineering requirements
-- `.github/workflows/`: CI, deployment, and agentic workflows
-
-More-specific `AGENTS.md` files under `src/` and `content/` add scoped guidance.
-
-## Working conventions
-
-- Inspect nearby code and the relevant spec before editing.
-- Make the smallest change that fully satisfies the request.
-- Do not introduce a runtime server, database, authentication, CMS, alternate
-  framework, or heavy dependency without an explicit architectural decision.
-- Do not edit generated output such as `src/dist/`.
-- Preserve unrelated working-tree changes.
-- Keep documentation consistent with code. If a current-state spec has drifted,
-  update it with the implementation and call out the drift.
-- Never hardcode credentials, deployment tokens, cloud resource names, or
-  environment-specific identifiers.
-
-## Verification
-
-Run application commands from `src/`:
-
-```bash
-npm run lint
-npm run test
-npm run build
-npm run format:check
-```
-
-Choose checks proportionate to the change, but run the full build for changes to
-application code, routes, content loading, SSR, or prerendering. Core logic and
-data-contract changes require colocated tests. For deployed-environment
-validation, run `npm run smoke -- <base-url>`.
-
-For GitHub Agentic Workflow changes, edit the Markdown source and regenerate its
-lock file:
-
-```bash
-gh aw compile
-gh aw compile --validate
-```
-
-Report the checks run and any checks that could not be run.
+More-specific `AGENTS.md` files may route a subtree to its applicable custom
+instructions and specs.

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -1,0 +1,40 @@
+# Content guidance
+
+Content is resolved during the Vite build and shipped as static output. Do not
+introduce a CMS, database, runtime API, or client-side fetch for core content.
+Follow the root `AGENTS.md` and the specifications under `docs/specs/`.
+
+## Articles
+
+For `articles/*.md`, follow `docs/specs/content-style-guide.md` and
+`docs/specs/markdown-rendering.md`.
+
+- Write for a technical audience in a clear, direct, focused style.
+- Keep one main takeaway and prefer practical, verified examples.
+- Use complete front matter matching the existing article schema.
+- Use `Logan Farci` as the default author.
+- Set `coauthoredWithAgent` accurately when an agent contributed materially.
+- Reuse established tags and verify internal and external links.
+- Prefer official technical sources and do not invent quotations or claims.
+- Avoid em dashes in article prose; prefer commas, periods, or parentheses.
+
+## Structured data
+
+For `data/*.json`, follow `docs/specs/data-contracts.md` and the corresponding
+types in `src/src/types/`.
+
+- Preserve the documented shape, required fields, ordering conventions, and
+  referential integrity.
+- Keep referenced image and icon paths valid.
+- When changing a shape, update the TypeScript type, accessor, documentation, and
+  tests together.
+
+## Verification
+
+Run checks from `src/`. Content changes that affect routes or rendering should pass:
+
+```bash
+npm run test
+npm run build
+npm run format:check
+```

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -1,40 +1,11 @@
 # Content guidance
 
-Content is resolved during the Vite build and shipped as static output. Do not
-introduce a CMS, database, runtime API, or client-side fetch for core content.
-Follow the root `AGENTS.md` and the specifications under `docs/specs/`.
+Follow the root `AGENTS.md`, then use:
 
-## Articles
+- `../.github/instructions/articles.instructions.md` for `articles/*.md`.
+- `../docs/specs/content-style-guide.md` and `markdown-rendering.md` for articles.
+- `../docs/specs/data-contracts.md` for `data/*.json`.
+- `../.github/copilot-instructions.md` for the content pipeline and verification
+  commands.
 
-For `articles/*.md`, follow `docs/specs/content-style-guide.md` and
-`docs/specs/markdown-rendering.md`.
-
-- Write for a technical audience in a clear, direct, focused style.
-- Keep one main takeaway and prefer practical, verified examples.
-- Use complete front matter matching the existing article schema.
-- Use `Logan Farci` as the default author.
-- Set `coauthoredWithAgent` accurately when an agent contributed materially.
-- Reuse established tags and verify internal and external links.
-- Prefer official technical sources and do not invent quotations or claims.
-- Avoid em dashes in article prose; prefer commas, periods, or parentheses.
-
-## Structured data
-
-For `data/*.json`, follow `docs/specs/data-contracts.md` and the corresponding
-types in `src/src/types/`.
-
-- Preserve the documented shape, required fields, ordering conventions, and
-  referential integrity.
-- Keep referenced image and icon paths valid.
-- When changing a shape, update the TypeScript type, accessor, documentation, and
-  tests together.
-
-## Verification
-
-Run checks from `src/`. Content changes that affect routes or rendering should pass:
-
-```bash
-npm run test
-npm run build
-npm run format:check
-```
+Keep those shared sources authoritative; do not duplicate their rules here.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,44 @@
+# Application guidance
+
+This directory is the Vite project root. Run all npm commands here. Follow the
+repository-level `AGENTS.md` and the canonical requirements in `docs/specs/`.
+
+## Implementation
+
+- Use TypeScript and functional React 19 components with hooks.
+- Import only the React hooks and types that are used; JSX does not require a
+  default React import.
+- Use the `@/` alias for `src/src/` and `@content/` for repository content.
+- Keep core content build-time only. Use the existing Vite content pipeline
+  rather than runtime filesystem access or client-side fetching.
+- Register pages and static routes through `src/routes.tsx`. Preserve the
+  SSR/prerender contract described in `docs/specs/architecture.md`.
+- Render page title, description, canonical URL, Open Graph data, and structured
+  data consistently with nearby pages and `src/core/seo.ts`.
+
+## UI and accessibility
+
+- Prefer local primitives in `src/components/shared/primitives/`.
+- Style with Tailwind and semantic tokens from the existing theme. Do not add raw
+  hardcoded colors, inline styles, or another component/CSS framework.
+- Preserve visible focus, keyboard behavior, semantic HTML, accessible names,
+  contrast, reduced-motion behavior, and touch-target requirements.
+- Reuse established layout, typography, motion, icon, and breakpoint helpers
+  before creating new abstractions.
+
+## Tests
+
+- Colocate Vitest files as `*.test.ts` or `*.test.tsx`.
+- Changes to `src/core/`, content accessors, or data contracts must add or update
+  tests.
+- Test observable behavior and query components by role and accessible name.
+- Keep tests deterministic and offline; mock content at module boundaries.
+
+Before handing off an application change, run the relevant subset of:
+
+```bash
+npm run lint
+npm run test
+npm run build
+npm run format:check
+```

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,44 +1,11 @@
 # Application guidance
 
-This directory is the Vite project root. Run all npm commands here. Follow the
-repository-level `AGENTS.md` and the canonical requirements in `docs/specs/`.
+Follow the root `AGENTS.md`, then use:
 
-## Implementation
+- `../.github/copilot-instructions.md` for application conventions and commands.
+- `../.github/instructions/components.instructions.md` for files under
+  `src/src/components/`.
+- `../docs/specs/architecture.md`, `quality-bars.md`, `testing.md`, and
+  `accessibility.md` for the applicable implementation requirements.
 
-- Use TypeScript and functional React 19 components with hooks.
-- Import only the React hooks and types that are used; JSX does not require a
-  default React import.
-- Use the `@/` alias for `src/src/` and `@content/` for repository content.
-- Keep core content build-time only. Use the existing Vite content pipeline
-  rather than runtime filesystem access or client-side fetching.
-- Register pages and static routes through `src/routes.tsx`. Preserve the
-  SSR/prerender contract described in `docs/specs/architecture.md`.
-- Render page title, description, canonical URL, Open Graph data, and structured
-  data consistently with nearby pages and `src/core/seo.ts`.
-
-## UI and accessibility
-
-- Prefer local primitives in `src/components/shared/primitives/`.
-- Style with Tailwind and semantic tokens from the existing theme. Do not add raw
-  hardcoded colors, inline styles, or another component/CSS framework.
-- Preserve visible focus, keyboard behavior, semantic HTML, accessible names,
-  contrast, reduced-motion behavior, and touch-target requirements.
-- Reuse established layout, typography, motion, icon, and breakpoint helpers
-  before creating new abstractions.
-
-## Tests
-
-- Colocate Vitest files as `*.test.ts` or `*.test.tsx`.
-- Changes to `src/core/`, content accessors, or data contracts must add or update
-  tests.
-- Test observable behavior and query components by role and accessible name.
-- Keep tests deterministic and offline; mock content at module boundaries.
-
-Before handing off an application change, run the relevant subset of:
-
-```bash
-npm run lint
-npm run test
-npm run build
-npm run format:check
-```
+Keep those shared sources authoritative; do not duplicate their rules here.


### PR DESCRIPTION
## What changed

- add a root `AGENTS.md` that directs Codex to the existing GitHub Copilot custom instructions and canonical repository specs
- add minimal scoped files under `src/` and `content/` that route to the applicable path-specific instructions and specs
- add canonical `validate-app` and `run-app-locally` workflows under `.github/skills/` for GitHub Copilot
- expose the same workflows to Codex through minimal `.agents/skills/` bridge files and Codex UI metadata

## Why

Codex needs repository-native entry points without duplicating maintained guidance. The existing Copilot custom instructions remain the shared operational guidance, while `docs/specs/` remains the canonical source for requirements and precedence.

The skill workflows are maintained once under `.github/skills/`. Codex discovers the lightweight `.agents/skills/` packages, whose bodies direct it to the canonical workflow. This avoids relying on undocumented symlink traversal and avoids maintaining two workflow copies.

## Impact

This does not change application or deployment behavior. Copilot and Codex share the same guidance and repeatable local validation/startup workflows.

## Validation

- canonical and bridge skill packages all pass `quick_validate.py`
- each bridge reference resolves to its canonical `.github/skills/.../SKILL.md`
- skill Markdown and YAML pass Prettier
- `run-app-locally` reached Vite at `http://127.0.0.1:5173/` and its test process was stopped cleanly
- `npm run lint` completed with 3 existing warnings and 0 errors
- `npm run test` passed 13 files / 85 tests
- `npm run build` passed
- `git diff --check` passed

`format:check` is detected conditionally because that script is being introduced on a separate branch and is not present on this PR's current base.