### PR TITLE
Fix shadcn component aliases

### DIFF
--- a/src/components.json
+++ b/src/components.json
@@ -13,9 +13,8 @@
     "aliases": {
         "components": "@/components",
         "utils": "@/lib/utils",
-        "ui": "@/components/ui",
-        "lib": "@/lib",
-        "hooks": "@/hooks"
+        "ui": "@/components/shared/primitives",
+        "lib": "@/lib"
     },
     "iconLibrary": "lucide"
 }

--- a/src/src/lib/utils.ts
+++ b/src/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { mergeClassNames as cn } from "@/core/mergeClassNames";


### PR DESCRIPTION
## Summary

- point the shadcn `ui` alias at the existing shared primitives directory
- remove the nonexistent hooks alias
- add a thin `@/lib/utils` adapter that exposes the existing `mergeClassNames` helper as the shadcn-compatible `cn` export

## Why

`components.json` referenced directories that do not exist, so newly scaffolded shadcn components would land in the wrong place and import a missing utility. The aliases now match the repository structure while preserving existing application imports.

Closes #257.

## Validation

- `npm run format:check`
- `npm run lint` (passes with 3 pre-existing warnings)
- `npm run test` (114 tests passed)
- `npm run build`

## Additional diagnostic

`npx tsc --noEmit` was also run and currently reports unrelated pre-existing type errors in tests, data conversions, `AboutPage.tsx`, and `vite.config.ts`; none involve the changed files.