### PR TITLE
Add targeted unit test coverage

### DIFF
--- a/docs/specs/testing.md
+++ b/docs/specs/testing.md
@@ -1,6 +1,6 @@
 ---
 spec: testing
-version: 0.1.0
+version: 0.1.1
 status: current-state
 ---
 
@@ -89,6 +89,16 @@ Verified from [`src/vite.config.ts`](../../src/vite.config.ts) and
   when both checks describe the same outcome. Name the `describe` after the unit and
   the `it` after the observable behavior.
 - **Keep them fast.** A slow unit test usually means the boundary is wrong — mock it.
+
+### Markdown and diagram test boundary
+
+Markdown tests cover semantic element mapping, GFM behavior, safe handling of raw
+HTML, Mermaid fence routing, and the Vite plugin's front-matter transformation.
+Mermaid tests mock its module boundary and verify initialization, rendering requests,
+and error reporting. Exact generated SVG markup, layout, and browser paint are
+intentionally not unit-tested: Mermaid owns that output, jsdom does not provide
+meaningful layout coverage, and browser automation would exceed this suite's
+lightweight scope.
 
 ## Build gate
 

--- a/src/plugins/vite-plugin-markdown.test.ts
+++ b/src/plugins/vite-plugin-markdown.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { transformMarkdown } from "./vite-plugin-markdown";
+
+describe("markdownPlugin", () => {
+    it("ignores files that are not Markdown", () => {
+        const result = transformMarkdown("export default {}", "/src/module.ts");
+
+        expect(result).toBeNull();
+    });
+
+    it("exports parsed front matter and Markdown content", () => {
+        const source = "---\ntitle: Test article\ndraft: false\n---\n\n## Introduction\n";
+
+        const result = transformMarkdown(source, "/content/article.md");
+
+        expect(result).toEqual({
+            code: [
+                'export const frontmatter = {"title":"Test article","draft":false};',
+                'export const content = "\\n## Introduction\\n";',
+            ].join("\n"),
+            map: null,
+        });
+    });
+});

--- a/src/plugins/vite-plugin-markdown.ts
+++ b/src/plugins/vite-plugin-markdown.ts
@@ -1,21 +1,20 @@
-import { Plugin } from "vite";
+import { Plugin, TransformResult } from "vite";
 import matter from "gray-matter";
 
-export default function markdownPlugin(): Plugin {
+export function transformMarkdown(code: string, id: string): TransformResult {
+    if (!id.endsWith(".md")) return null;
+
+    const { data: frontmatter, content } = matter(code);
+
     return {
-        name: "vite-plugin-markdown",
-        transform(code, id) {
-            if (!id.endsWith(".md")) return null;
-
-            const { data: frontmatter, content } = matter(code);
-
-            return {
-                code: [
-                    `export const frontmatter = ${JSON.stringify(frontmatter)};`,
-                    `export const content = ${JSON.stringify(content)};`,
-                ].join("\n"),
-                map: null,
-            };
-        },
+        code: [
+            `export const frontmatter = ${JSON.stringify(frontmatter)};`,
+            `export const content = ${JSON.stringify(content)};`,
+        ].join("\n"),
+        map: null,
     };
+}
+
+export default function markdownPlugin(): Plugin {
+    return { name: "vite-plugin-markdown", transform: transformMarkdown };
 }

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import MarkdownContent from "./MarkdownContent";
+
+vi.mock("./MermaidDiagram", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <div aria-label="Mermaid diagram">{children}</div>,
+}));
+
+describe("MarkdownContent", () => {
+    it("maps a body-level heading to a level-two heading", () => {
+        render(<MarkdownContent content="# Body heading" />);
+
+        expect(screen.getByRole("heading", { level: 2, name: "Body heading" })).toBeTruthy();
+    });
+
+    it("renders GFM tables with their accessible table role", () => {
+        render(<MarkdownContent content={"| Name | Value |\n| --- | --- |\n| Test | Passed |"} />);
+
+        expect(screen.getByRole("table")).toBeTruthy();
+    });
+
+    it("opens rendered links in a new tab", () => {
+        render(<MarkdownContent content="[Project](https://example.com)" />);
+
+        expect(screen.getByRole("link", { name: "Project" }).getAttribute("target")).toBe("_blank");
+    });
+
+    it("routes Mermaid code fences to the diagram renderer", () => {
+        render(<MarkdownContent content={"```mermaid\ngraph TD; A-->B\n```"} />);
+
+        expect(screen.getByRole("generic", { name: "Mermaid diagram" }).textContent).toContain("graph TD; A-->B");
+    });
+
+    it("keeps raw HTML inert", () => {
+        render(<MarkdownContent content={'<img src="invalid" alt="unsafe" />'} />);
+
+        expect(screen.queryByRole("img", { name: "unsafe" })).toBeNull();
+    });
+});

--- a/src/src/components/shared/MarkdownSection.test.tsx
+++ b/src/src/components/shared/MarkdownSection.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MarkdownSection from "./MarkdownSection";
+
+describe("MarkdownSection", () => {
+    it("renders its heading and markdown content", () => {
+        render(<MarkdownSection heading="Profile" content="A **short** introduction." />);
+
+        expect(screen.getByRole("heading", { name: "Profile" })).toBeTruthy();
+        expect(screen.getByText("short").tagName).toBe("STRONG");
+    });
+
+    it("renders the optional image with its accessible name and fixed dimensions", () => {
+        render(
+            <MarkdownSection
+                heading="Profile"
+                content="Introduction"
+                imageSrc="/images/profile.avif"
+                imageAlt="Logan speaking at a conference"
+            />,
+        );
+
+        const image = screen.getByRole("img", { name: "Logan speaking at a conference" });
+        expect(image.getAttribute("width")).toBe("300");
+        expect(image.getAttribute("height")).toBe("300");
+    });
+
+    it("omits the optional image when no source is provided", () => {
+        render(<MarkdownSection heading="Profile" content="Introduction" />);
+
+        expect(screen.queryByRole("img")).toBeNull();
+    });
+});

--- a/src/src/components/shared/MermaidDiagram.test.tsx
+++ b/src/src/components/shared/MermaidDiagram.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import MermaidDiagram from "./MermaidDiagram";
+
+const { initialize, run } = vi.hoisted(() => ({ initialize: vi.fn(), run: vi.fn() }));
+
+vi.mock("mermaid", () => ({ default: { initialize, run } }));
+
+describe("MermaidDiagram", () => {
+    beforeEach(() => {
+        run.mockResolvedValue(undefined);
+    });
+
+    it("initializes Mermaid with strict rendering security", async () => {
+        render(<MermaidDiagram>graph TD; A--&gt;B</MermaidDiagram>);
+
+        await waitFor(() => {
+            expect(initialize).toHaveBeenCalledWith({ startOnLoad: false, securityLevel: "strict" });
+        });
+    });
+
+    it("renders diagrams through the Mermaid container selector", async () => {
+        render(<MermaidDiagram>graph TD; A--&gt;B</MermaidDiagram>);
+
+        await waitFor(() => {
+            expect(run).toHaveBeenCalledWith({ querySelector: ".mermaid" });
+        });
+    });
+
+    it("reports Mermaid rendering failures without rejecting the component effect", async () => {
+        const error = new Error("invalid diagram");
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        run.mockRejectedValue(error);
+
+        render(<MermaidDiagram>not valid Mermaid</MermaidDiagram>);
+
+        await waitFor(() => {
+            expect(consoleError).toHaveBeenCalledWith("Failed to render Mermaid diagram", error);
+        });
+    });
+});

--- a/src/src/components/shared/preview/Preview.test.tsx
+++ b/src/src/components/shared/preview/Preview.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TooltipProvider } from "@/components/shared/primitives/TooltipPrimitives";
+import Preview from "./Preview";
+
+function renderPreview() {
+    render(
+        <TooltipProvider>
+            <Preview collapsedContent={<h2>Summary</h2>} expandedContent={<h2>Full details</h2>} />
+        </TooltipProvider>,
+    );
+}
+
+describe("Preview", () => {
+    it("starts with the collapsed preview selected", () => {
+        renderPreview();
+
+        expect(screen.getByRole("heading", { name: "Summary" })).toBeTruthy();
+    });
+
+    it("expands the preview", () => {
+        renderPreview();
+
+        fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+        expect(screen.getByRole("heading", { name: "Full details" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+    });
+
+    it("collapses an expanded preview", () => {
+        renderPreview();
+        fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+        fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+        expect(screen.getByRole("heading", { name: "Summary" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
+    });
+});

--- a/src/src/components/shared/preview/Preview.tsx
+++ b/src/src/components/shared/preview/Preview.tsx
@@ -19,6 +19,7 @@ function Preview({ collapsedContent, expandedContent }: PreviewProps) {
                 style={{ height: isExpanded ? `${expandedContentRef.current?.scrollHeight || 0}px` : "2em" }}
             >
                 <div
+                    aria-hidden={isExpanded}
                     className={`w-full overflow-hidden transition-opacity duration-300 motion-reduce:transition-none ${
                         !isExpanded ? "opacity-100" : "opacity-0 pointer-events-none absolute top-0"
                     }`}
@@ -28,6 +29,7 @@ function Preview({ collapsedContent, expandedContent }: PreviewProps) {
                 </div>
 
                 <div
+                    aria-hidden={!isExpanded}
                     ref={expandedContentRef}
                     className={`w-full transition-opacity duration-300 motion-reduce:transition-none ${
                         isExpanded ? "opacity-100" : "opacity-0 pointer-events-none absolute top-0"

--- a/src/src/core/mergeClassNames.test.ts
+++ b/src/src/core/mergeClassNames.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeClassNames } from "./mergeClassNames";
+
+describe("mergeClassNames", () => {
+    it("keeps the last conflicting Tailwind class", () => {
+        expect(mergeClassNames("px-2 text-sm", "px-4")).toBe("text-sm px-4");
+    });
+
+    it("omits conditional classes that are not enabled", () => {
+        expect(mergeClassNames("block", { hidden: false }, null, undefined)).toBe("block");
+    });
+});

--- a/src/src/core/site.test.ts
+++ b/src/src/core/site.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { siteOgImage, siteUrl } from "./site";
+
+describe("site", () => {
+    it("uses the production site URL by default", () => {
+        expect(siteUrl).toBe("https://loganfarci.com");
+    });
+
+    it("derives the Open Graph image URL from the site URL", () => {
+        expect(siteOgImage).toBe(`${siteUrl}/images/avatar.png`);
+    });
+});

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "jsdom",
-        include: ["tests/unit/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
+        include: ["tests/unit/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}", "plugins/**/*.test.{ts,tsx}"],
         setupFiles: ["src/test/setup.ts"],
         coverage: {
             provider: "v8",


### PR DESCRIPTION
## Summary

- add behavior-level coverage for Preview expansion and collapse, including accessible hidden-state handling
- add baseline tests for site URL constants and Tailwind class merging
- add targeted coverage for Mermaid, MarkdownContent, MarkdownSection, and the Markdown Vite plugin
- document the intentional Mermaid unit-test boundary and include plugin tests in Vitest discovery

## Why

These stateful and core rendering paths lacked regression coverage. The new tests follow the repository testing conventions: observable behavior, accessible queries, deterministic module-boundary mocks, and no browser automation or heavy dependencies.

## Impact

The unit suite now protects Preview reversals, markdown semantic mapping and raw-HTML safety, Mermaid initialization and failures, front-matter transformation, and core URL/class helpers. Preview content that is visually inactive is also removed from the accessibility tree.

## Validation

- `npm run format:check`
- `npm run lint` (zero errors; three existing warnings)
- `npm run test` (134 tests passed across 21 files)
- `npm run build`
- `git diff --check`

Closes #278
Closes #279
Closes #280