### PR TITLE
Disable the Application Insights unload handler

### DIFF
--- a/src/src/core/appInsights.test.ts
+++ b/src/src/core/appInsights.test.ts
@@ -53,6 +53,25 @@ describe("initAppInsights", () => {
         expect(ApplicationInsights).toHaveBeenCalledOnce();
     });
 
+    it("disables only the legacy unload event in the production SDK configuration", async () => {
+        vi.stubEnv("PROD", true);
+        vi.stubEnv("VITE_APPINSIGHTS_CONNECTION_STRING", "InstrumentationKey=test");
+        const { initAppInsights } = await import("./appInsights");
+        const { ApplicationInsights } = await import("@microsoft/applicationinsights-web");
+
+        initAppInsights();
+
+        expect(ApplicationInsights).toHaveBeenCalledWith({
+            config: {
+                connectionString: "InstrumentationKey=test",
+                disableCookiesUsage: true,
+                enableAutoRouteTracking: true,
+                disableExceptionTracking: false,
+                disablePageUnloadEvents: ["unload"],
+            },
+        });
+    });
+
     it("returns the same instance on repeated calls without reinitializing", async () => {
         vi.stubEnv("PROD", true);
         vi.stubEnv("VITE_APPINSIGHTS_CONNECTION_STRING", "InstrumentationKey=test");

--- a/src/src/core/appInsights.ts
+++ b/src/src/core/appInsights.ts
@@ -33,6 +33,7 @@ export function initAppInsights(): ApplicationInsights | null {
             disableCookiesUsage: true,
             enableAutoRouteTracking: true,
             disableExceptionTracking: false,
+            disablePageUnloadEvents: ["unload"],
         },
     });
 


### PR DESCRIPTION
## Summary

- configure the Application Insights SDK to skip only the deprecated `unload` event
- keep cookieless analytics, automatic route tracking, exception tracking, and the SDK's supported `pagehide`/visibility delivery behavior intact
- cover the production SDK configuration with a focused unit test

## Root cause

Application Insights registered its default legacy `unload` listener in production. That listener is deprecated and prevents pages from entering the browser back/forward cache.

Setting `disablePageUnloadEvents: ["unload"]` removes only that event from the SDK's unload event set. It does not disable `pagehide` or visibility-based telemetry delivery.

## Validation

- `npm run format:check`
- `npm run lint` (passes with three pre-existing warnings)
- `npm run test` (21 files, 135 tests)
- `npm run build` (client, SSR, and prerender)
- focused `appInsights` test (6 tests)

`npm run accessibility` could not run locally because Chrome is not installed in the environment. Deployed production verification remains required for telemetry delivery, Back/Forward restoration, and the Lighthouse `deprecations` and `bf-cache` audits on `/`, `/about/`, and `/articles/`.

Closes #323