### PR TITLE
Add a skip-to-content link

### DIFF
--- a/src/src/components/layout/LayoutWrapper.test.tsx
+++ b/src/src/components/layout/LayoutWrapper.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import LayoutWrapper from "./LayoutWrapper";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+function renderLayoutWrapper() {
+    return render(
+        <ThemeProvider>
+            <MemoryRouter>
+                <LayoutWrapper>Page content</LayoutWrapper>
+            </MemoryRouter>
+        </ThemeProvider>,
+    );
+}
+
+describe("LayoutWrapper", () => {
+    it("renders the skip link as the first focusable element", () => {
+        renderLayoutWrapper();
+
+        const skipLink = screen.getByRole("link", { name: "Skip to content" });
+        const firstFocusableElement = document.querySelector("a[href], button:not([disabled]), [tabindex]");
+
+        expect(firstFocusableElement).toBe(skipLink);
+    });
+
+    it("targets the main content landmark", () => {
+        renderLayoutWrapper();
+
+        const skipLink = screen.getByRole("link", { name: "Skip to content" });
+        const mainContent = screen.getByRole("main");
+
+        expect(skipLink.getAttribute("href")).toBe(`#${mainContent.id}`);
+    });
+
+    it("makes the main content programmatically focusable", () => {
+        renderLayoutWrapper();
+
+        const mainContent = screen.getByRole("main");
+
+        expect(mainContent.getAttribute("tabindex")).toBe("-1");
+    });
+});

--- a/src/src/components/layout/LayoutWrapper.tsx
+++ b/src/src/components/layout/LayoutWrapper.tsx
@@ -12,8 +12,16 @@ interface LayoutWrapperProps {
 const LayoutWrapper: React.FC<Readonly<LayoutWrapperProps>> = ({ children, githubRepositoryUrl, commitHash }) => {
     return (
         <>
+            <a
+                href="#main-content"
+                className="fixed left-4 top-4 z-50 -translate-y-[calc(100%+2rem)] rounded-control bg-surface px-4 py-3 font-medium text-primary shadow-popover transition-transform focus-visible:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none"
+            >
+                Skip to content
+            </a>
             <NavigationBar title="Logan Farci" />
-            <main className={contentWidthStyles.pageContainer}>{children}</main>
+            <main id="main-content" tabIndex={-1} className={contentWidthStyles.pageContainer}>
+                {children}
+            </main>
             <hr className={mergeClassNames(contentWidthStyles.pageContainer, "border-t border-border my-8")} />
             <Footer githubRepositoryUrl={githubRepositoryUrl} commitHash={commitHash} />
         </>

--- a/src/src/components/layout/LayoutWrapper.tsx
+++ b/src/src/components/layout/LayoutWrapper.tsx
@@ -1,6 +1,7 @@
 import NavigationBar from "@/components/layout/NavigationBar";
 import Footer from "@/components/layout/Footer";
 import { contentWidthStyles } from "@/components/layout/contentWidthStyles";
+import { Separator } from "@/components/shared/primitives/Separator";
 import { mergeClassNames } from "@/core/mergeClassNames";
 
 interface LayoutWrapperProps {
@@ -22,7 +23,7 @@ const LayoutWrapper: React.FC<Readonly<LayoutWrapperProps>> = ({ children, githu
             <main id="main-content" tabIndex={-1} className={contentWidthStyles.pageContainer}>
                 {children}
             </main>
-            <hr className={mergeClassNames(contentWidthStyles.pageContainer, "border-t border-border my-8")} />
+            <Separator className={mergeClassNames(contentWidthStyles.pageContainer, "my-8")} />
             <Footer githubRepositoryUrl={githubRepositoryUrl} commitHash={commitHash} />
         </>
     );


### PR DESCRIPTION
## Summary

- add a keyboard-accessible “Skip to content” link as the first focusable page element
- reveal the link with a visible semantic-token focus treatment
- make the main landmark a stable, programmatically focusable fragment target
- cover focus order, target wiring, and main-landmark focusability with component tests

## Impact

Keyboard and assistive-technology users can bypass the repeated site navigation and move directly to each page’s primary content.

## Validation

- `npm run format:check`
- `npm run lint` (passes with three pre-existing warnings)
- `npm run test` (22 files, 137 tests)
- `npm run build`
- prerendered HTML inspected to confirm the skip link and main target are emitted

`npm run accessibility` could not execute locally because Chrome/Chromium is not installed in the environment; Lighthouse CI stopped at its health check before running audits.

Closes #253