### PR TITLE
Fix footer text alignment and full-width divider

### DIFF
--- a/src/src/components/layout/Footer.tsx
+++ b/src/src/components/layout/Footer.tsx
@@ -18,7 +18,7 @@ const Footer: React.FC<FooterProps> = ({ githubRepositoryUrl, commitHash, commit
         <footer
             className={mergeClassNames(
                 contentWidthStyles.pageContainer,
-                "flex flex-wrap justify-between items-center pb-8 gap-y-2",
+                "flex flex-wrap justify-center items-center pb-8 gap-x-1 gap-y-2 text-center",
             )}
         >
             <div className="flex flex-wrap items-center gap-1 min-w-0">

--- a/src/src/components/layout/LayoutWrapper.tsx
+++ b/src/src/components/layout/LayoutWrapper.tsx
@@ -1,6 +1,7 @@
 import NavigationBar from "@/components/layout/NavigationBar";
 import Footer from "@/components/layout/Footer";
 import { contentWidthStyles } from "@/components/layout/contentWidthStyles";
+import { Separator } from "@/components/shared/primitives/Separator";
 
 interface LayoutWrapperProps {
     readonly children: React.ReactNode;
@@ -13,7 +14,7 @@ const LayoutWrapper: React.FC<Readonly<LayoutWrapperProps>> = ({ children, githu
         <>
             <NavigationBar title="Logan Farci" />
             <main className={contentWidthStyles.pageContainer}>{children}</main>
-            <hr className="border-t border-border my-8" />
+            <Separator className="my-8" />
             <Footer githubRepositoryUrl={githubRepositoryUrl} commitHash={commitHash} />
         </>
     );

--- a/src/src/components/layout/LayoutWrapper.tsx
+++ b/src/src/components/layout/LayoutWrapper.tsx
@@ -1,7 +1,6 @@
 import NavigationBar from "@/components/layout/NavigationBar";
 import Footer from "@/components/layout/Footer";
 import { contentWidthStyles } from "@/components/layout/contentWidthStyles";
-import { mergeClassNames } from "@/core/mergeClassNames";
 
 interface LayoutWrapperProps {
     readonly children: React.ReactNode;
@@ -14,7 +13,7 @@ const LayoutWrapper: React.FC<Readonly<LayoutWrapperProps>> = ({ children, githu
         <>
             <NavigationBar title="Logan Farci" />
             <main className={contentWidthStyles.pageContainer}>{children}</main>
-            <hr className={mergeClassNames(contentWidthStyles.pageContainer, "border-t border-border my-8")} />
+            <hr className="border-t border-border my-8" />
             <Footer githubRepositoryUrl={githubRepositoryUrl} commitHash={commitHash} />
         </>
     );


### PR DESCRIPTION
## Summary

- center the copyright and optional commit metadata as one wrapping footer group
- keep footer content constrained to the existing page container
- let the decorative divider span the full viewport width independently of page padding

## Root cause

The footer used `justify-between`, which separated its two content groups, while the divider reused `contentWidthStyles.pageContainer`, constraining it to the site's maximum content width and horizontal padding.

## Impact

Footer content now stays centered with or without commit metadata and can wrap cleanly on narrow screens. The existing commit link behavior, typography, semantic tokens, and footer landmark are unchanged.

Closes #318

## Validation

- `npm run format:check` — passed
- `npm run lint` — passed with 3 existing warnings and 0 errors
- `npm run test` — passed (21 files, 134 tests)
- `npm run build` — passed (client, SSR, prerender)
- `npm run accessibility` — unavailable locally because Chrome/Chromium is not installed; LHCI stopped during its health check before running audits

No focused unit test was added because this is a presentational Tailwind layout change and jsdom cannot verify computed alignment, viewport width, wrapping, or overflow.