### PR TITLE
Improve card contrast and muted text readability

### DIFF
--- a/src/src/components/cards/MediaTileCard.test.tsx
+++ b/src/src/components/cards/MediaTileCard.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MediaTileCard from "./MediaTileCard";
+
+describe("MediaTileCard", () => {
+    it("renders its description at the normal body-text size", () => {
+        render(<MediaTileCard title="Cloud" description="Build reliable cloud platforms." />);
+
+        const description = screen.getByText("Build reliable cloud platforms.");
+
+        expect(description.className).toContain("text-base");
+        expect(description.className).toContain("md:text-[1.0625rem]");
+    });
+});

--- a/src/src/components/cards/MediaTileCard.tsx
+++ b/src/src/components/cards/MediaTileCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Card, { CardBody, CardMedia, CardTitle } from "./Card";
-import { Caption } from "@/components/shared/typography";
+import { Text } from "@/components/shared/typography";
 import { ImageProps } from "@/types";
 
 export type MediaTileSize = "small" | "medium" | "large";
@@ -26,7 +26,7 @@ const MediaTileCard: React.FC<MediaTileCardProps> = ({ title, description, image
             )}
             <CardBody className="items-center justify-center grow text-center">
                 <CardTitle className="text-center leading-tight">{title}</CardTitle>
-                {description && <Caption className="mt-3 text-center">{description}</Caption>}
+                {description && <Text className="mt-3 text-center">{description}</Text>}
             </CardBody>
         </div>
     </Card>

--- a/src/src/components/shared/FadeoutText.test.tsx
+++ b/src/src/components/shared/FadeoutText.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import FadeoutText from "./FadeoutText";
+
+describe("FadeoutText", () => {
+    it("fades into the elevated card surface", () => {
+        const { container } = render(<FadeoutText>Preview text</FadeoutText>);
+
+        expect(container.querySelector(".to-surface-elevated")).toBeTruthy();
+    });
+});

--- a/src/src/components/shared/FadeoutText.tsx
+++ b/src/src/components/shared/FadeoutText.tsx
@@ -8,7 +8,7 @@ function FadeoutText({ children }: FadeoutTextProps) {
     return (
         <div className="relative overflow-hidden">
             <span className="truncate text-base/7 text-text-tertiary">{children}</span>
-            <div className="pointer-events-none absolute right-0 top-0 h-full w-96 bg-gradient-to-r from-transparent to-surface" />
+            <div className="pointer-events-none absolute right-0 top-0 h-full w-96 bg-gradient-to-r from-transparent to-surface-elevated" />
         </div>
     );
 }

--- a/src/src/components/shared/primitives/Badge.test.tsx
+++ b/src/src/components/shared/primitives/Badge.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "./Badge";
+
+describe("Badge", () => {
+    it("uses a distinct surface and strong border", () => {
+        render(<Badge>Azure</Badge>);
+
+        expect(screen.getByText("Azure").className).toContain("border-border-strong");
+        expect(screen.getByText("Azure").className).toContain("bg-surface");
+    });
+});

--- a/src/src/components/shared/primitives/Badge.tsx
+++ b/src/src/components/shared/primitives/Badge.tsx
@@ -6,7 +6,7 @@ export function Badge({ className, ...props }: ComponentProps<"span">) {
     return (
         <span
             className={mergeClassNames(
-                "inline-flex items-center gap-1 rounded-md border border-border bg-transparent px-3 py-1",
+                "inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface px-3 py-1",
                 typographyStyles.caption,
                 className,
             )}

--- a/src/src/components/shared/primitives/CardPrimitives.tsx
+++ b/src/src/components/shared/primitives/CardPrimitives.tsx
@@ -7,7 +7,7 @@ type PolymorphicProps<E extends ElementType> = { as?: E; className?: string; chi
 >;
 
 export const cardRootClassName =
-    "h-full rounded-card border border-border-light bg-surface p-6 shadow-card transition-shadow duration-200 hover:shadow-card-hover active:shadow-card-hover";
+    "h-full rounded-card border border-border-strong bg-surface-elevated p-6 shadow-card transition-shadow duration-200 hover:shadow-card-hover active:shadow-card-hover";
 
 export function Card<E extends ElementType = "div">({ as, className, children, ...props }: PolymorphicProps<E>) {
     const Component = as ?? "div";

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -64,7 +64,7 @@
     --color-text-primary: oklch(23% 0.036 264); /* ink */
     --color-text-secondary: oklch(41% 0.034 263); /* slate */
     --color-text-tertiary: oklch(53% 0.03 262); /* soft slate */
-    --color-text-muted: oklch(65% 0.026 260); /* quiet slate */
+    --color-text-muted: oklch(54% 0.026 260); /* quiet slate */
     --color-text-inverse: oklch(100% 0 0); /* white */
 
     /* Border semantic colors */

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -74,7 +74,7 @@
 
     /* Surface/background colors */
     --color-surface: oklch(100% 0 0); /* white */
-    --color-surface-elevated: oklch(97.5% 0.012 255); /* frosted canvas */
+    --color-surface-elevated: oklch(96.8% 0.018 255); /* cool mist */
     --color-surface-hover: oklch(94.5% 0.018 256); /* blue-gray hover */
     --color-surface-muted: oklch(91.5% 0.02 256); /* muted canvas */
     --color-muted: oklch(95.5% 0.016 256); /* quiet canvas */


### PR DESCRIPTION
## What changed

- Strengthen the shared card treatment with a Cool Mist elevated-surface token and the existing strong-border token.
- Recalibrate the light-theme muted-text token so normal-sized metadata, card descriptions, and the mobile footer copyright remain secondary without becoming faint.
- Keep the existing card shadows and hover, active, and focus-visible behavior unchanged.
- Give shared skill and article-tag badges a base-surface fill and strong semantic border so they remain distinct on Cool Mist cards.
- Render “What I Do” descriptions with the normal body-text role (16px mobile, 17px desktop) instead of the 14px caption role.

## Why

Shared cards were nearly indistinguishable from the page background, and the light-theme muted text used by “What I Do,” About metadata, certification issuers, and the footer failed WCAG 2.1 AA for normal text. Because these styles are shared, semantic token and primitive changes fix every affected consumer without one-off colors or a new styling system.

## User impact

Cards now have a more legible boundary and elevated surface in both themes. Supporting copy remains visually subordinate while meeting the 4.5:1 AA text contrast requirement. Existing interactive states remain distinct; the focus ring measures 4.35:1 against light cards and 6.75:1 against dark cards.

## Regression follow-up

Changing the shared card background exposed a coupled preview style: `FadeoutText` still ended its gradient at `surface`, while cards now use `surface-elevated`. The collapsed Experience and Education previews now fade into the actual card surface, with a focused regression test protecting that token pairing.

## Contrast evidence

| Pair | Before light | After light | Before dark | After dark |
| --- | ---: | ---: | ---: | ---: |
| Card / page background | 1.03:1 | 1.07:1 | 1.07:1 | 1.20:1 |
| Border / card | 1.25:1 | 2.43:1 | 1.24:1 | 2.45:1 |
| Border / page background | 1.21:1 | 2.59:1 | 1.33:1 | 2.93:1 |
| Muted text / card | 3.23:1 | 4.61:1 | 5.33:1 | 4.78:1 |
| Muted text / page background | 3.14:1 | 4.91:1 | 5.72:1 | 5.72:1 |

Ratios were calculated from the exact OKLCH semantic-token values.

## Validation

- `npm run lint` — passes with 0 errors and 2 pre-existing unrelated warnings
- `npm run format:check` — passes
- `npm test` — 25 test files and 141 tests pass
- `npm run build` — passes, including client build, SSR build, prerendering, and generated machine-readable files
- `git diff --check` — passes

`npm run accessibility` could not collect locally because Chrome/Chromium is not installed in the environment. The project’s CI accessibility workflow will provide the browser-based Lighthouse check.

Closes #227