### PR TITLE
Fix mobile layout shifts

### DIFF
--- a/src/plugins/vite-plugin-stable-font-display.test.ts
+++ b/src/plugins/vite-plugin-stable-font-display.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { stabilizeFontDisplay } from "./vite-plugin-stable-font-display";
+
+describe("stableFontDisplayPlugin", () => {
+    it("uses optional display for layout-critical web fonts", () => {
+        const code = "@font-face { font-display: swap; }";
+
+        const result = stabilizeFontDisplay(code, "/node_modules/@fontsource-variable/manrope/index.css");
+
+        expect(result?.code).toBe("@font-face { font-display: optional; }");
+    });
+
+    it("leaves unrelated stylesheets unchanged", () => {
+        const result = stabilizeFontDisplay(
+            "@font-face { font-display: swap; }",
+            "/node_modules/@fontsource/reddit-mono/index.css",
+        );
+
+        expect(result).toBeNull();
+    });
+});

--- a/src/plugins/vite-plugin-stable-font-display.ts
+++ b/src/plugins/vite-plugin-stable-font-display.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from "vite";
+
+const layoutCriticalFontPackages = ["/@fontsource-variable/manrope/", "/@fontsource/noto-sans/"];
+
+export function stabilizeFontDisplay(code: string, id: string) {
+    const normalizedId = id.replaceAll("\\", "/");
+
+    if (!layoutCriticalFontPackages.some((fontPackage) => normalizedId.includes(fontPackage))) {
+        return null;
+    }
+
+    return { code: code.replaceAll("font-display: swap;", "font-display: optional;"), map: null };
+}
+
+export default function stableFontDisplayPlugin(): Plugin {
+    return { name: "stable-font-display", enforce: "pre", transform: stabilizeFontDisplay };
+}

--- a/src/src/components/shared/Tag.test.tsx
+++ b/src/src/components/shared/Tag.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Tag from "./Tag";
+
+describe("Tag", () => {
+    it("reserves a fixed rendered box for its icon", () => {
+        render(
+            <Tag imageSrc="/images/icon.svg" imageAlt="Test icon">
+                Test
+            </Tag>,
+        );
+
+        const iconClasses = screen.getByRole("img", { name: "Test icon" }).className.split(" ");
+
+        expect(iconClasses).toEqual(expect.arrayContaining(["h-4", "w-4", "shrink-0"]));
+    });
+});

--- a/src/src/components/shared/Tag.tsx
+++ b/src/src/components/shared/Tag.tsx
@@ -13,7 +13,7 @@ interface TagProps {
 }
 
 const TagIcon: React.FC<TagIconProps> = ({ src, alt }) => {
-    const imageClasses = ["mr-1"];
+    const imageClasses = ["mr-1", "h-4", "w-4", "shrink-0"];
 
     if (src.includes("-mono")) {
         imageClasses.push("filter", "dark:invert", "dark:brightness-125");

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import markdownPlugin from "./plugins/vite-plugin-markdown";
+import stableFontDisplayPlugin from "./plugins/vite-plugin-stable-font-display";
 import path from "node:path";
 
 export default defineConfig({
-    plugins: [tailwindcss(), react(), markdownPlugin()],
+    plugins: [stableFontDisplayPlugin(), tailwindcss(), react(), markdownPlugin()],
     resolve: {
         alias: { "@/": path.resolve(__dirname, "src") + "/", "@content/": path.resolve(__dirname, "../content") + "/" },
     },


### PR DESCRIPTION
## Summary

Fix the mobile layout shift affecting the prerendered Articles page and reduce the related shift on About and Home.

## Diagnosis and root cause

A Lighthouse 13.4.1 mobile audit of the local production build reproduced the issue on the canonical trailing-slash routes. The Articles page had a single shift cluster associated with the Manrope and Noto Sans web-font swaps and a 16×16 tag SVG. The separate unsized-images audit passed, but Tailwind's responsive image reset still left the tag icon's rendered geometry dependent on intrinsic media sizing.

A controlled experiment that changed only Manrope and Noto Sans from `font-display: swap` to `font-display: optional` reduced Articles CLS from 0.1683747 to 0, confirming that the late font swap was the material cause.

## What changed

- Add a focused Vite transform that changes only the Manrope and Noto Sans Fontsource declarations from `font-display: swap` to `font-display: optional`.
- Keep Reddit Mono's loading policy unchanged.
- Give tag icons an explicit `h-4 w-4 shrink-0` rendered box in addition to their existing 16×16 attributes.
- Add focused tests for the font transform scope and tag-icon geometry.

`font-display: optional` deliberately favors layout stability: on a slow, cache-cold first visit, users may see the fallback font instead of a late swap to the custom face. Cached or promptly available fonts continue to render normally.

## Lighthouse results

Lighthouse 13.4.1 mobile, local production preview, cache-cold trailing-slash routes:

| Route | CLS before | CLS after | Performance before | Performance after |
| --- | ---: | ---: | ---: | ---: |
| `/` | 0.0019567 | 0 | 0.84 | 0.84 |
| `/about/` | 0.0748590 | 0 | 0.80 | 0.84 |
| `/articles/` | 0.1683747 | 0 | 0.78 | 0.90 |

All after-runs reported zero layout-shift clusters. Cache-cold screenshots at 390px and 1440px confirmed that card media keeps its aspect ratio and content flows without clipping.

## Validation

- `npm run lint` — passed with two pre-existing warnings in untouched files
- `npm run format:check` — passed
- `npm test` — 24 test files and 141 tests passed
- `npm run build` — passed client build, SSR build, and all prerenders
- `git diff --check` — passed

Closes #322