### PR TITLE
Lazy-load Mermaid diagrams

### DIFF
--- a/src/src/components/shared/CodeSnippet.test.tsx
+++ b/src/src/components/shared/CodeSnippet.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CodeSnippet from "./CodeSnippet";
+
+const { diagramModuleRequested, releaseDiagramModule, waitForDiagramModule } = vi.hoisted(() => {
+    let releaseDiagramModule = () => undefined;
+    const waitForDiagramModule = new Promise<void>((resolve) => {
+        releaseDiagramModule = resolve;
+    });
+
+    return { diagramModuleRequested: vi.fn(), releaseDiagramModule, waitForDiagramModule };
+});
+
+vi.mock("./MermaidDiagram", async () => {
+    diagramModuleRequested();
+    await waitForDiagramModule;
+
+    return {
+        default: ({ children }: { children: React.ReactNode }) => <div aria-label="Mermaid diagram">{children}</div>,
+    };
+});
+
+describe("CodeSnippet", () => {
+    it("renders an ordinary code block without requesting the diagram module", () => {
+        render(<CodeSnippet className="language-typescript">const answer = 42;</CodeSnippet>);
+
+        expect(diagramModuleRequested).not.toHaveBeenCalled();
+    });
+
+    it("reserves diagram space behind an accessible loading boundary", async () => {
+        const { container } = render(<CodeSnippet className="language-mermaid">graph TD; A--&gt;B</CodeSnippet>);
+
+        expect(screen.getByRole("status", { name: "Loading Mermaid diagram" })).toBeTruthy();
+        expect(container.firstElementChild?.className).toContain("min-h-48");
+
+        releaseDiagramModule();
+
+        expect(await screen.findByRole("generic", { name: "Mermaid diagram" })).toBeTruthy();
+    });
+});

--- a/src/src/components/shared/CodeSnippet.tsx
+++ b/src/src/components/shared/CodeSnippet.tsx
@@ -1,13 +1,14 @@
-import React from "react";
-import MermaidDiagram from "./MermaidDiagram";
+import { lazy, Suspense, type ReactNode } from "react";
+
+const MermaidDiagram = lazy(() => import("./MermaidDiagram"));
 
 export interface CodeSnippetProps {
-    children: React.ReactNode;
+    children: ReactNode;
     className?: string;
     forceBlock?: boolean;
 }
 
-function getTextContent(value: React.ReactNode): string {
+function getTextContent(value: ReactNode): string {
     if (typeof value === "string" || typeof value === "number") {
         return String(value);
     }
@@ -25,7 +26,24 @@ export default function CodeSnippet({ children, className, forceBlock = false }:
     const isMermaid = className?.includes("language-mermaid");
 
     if (isMermaid) {
-        return <MermaidDiagram>{children}</MermaidDiagram>;
+        return (
+            <div className="my-4 flex min-h-48 w-full items-center justify-center overflow-x-auto rounded-lg border border-border bg-surface-elevated p-4">
+                <Suspense
+                    fallback={
+                        <p
+                            aria-label="Loading Mermaid diagram"
+                            aria-live="polite"
+                            className="text-sm text-text-secondary"
+                            role="status"
+                        >
+                            Loading diagram…
+                        </p>
+                    }
+                >
+                    <MermaidDiagram>{children}</MermaidDiagram>
+                </Suspense>
+            </div>
+        );
     }
 
     return isInline ? (

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -26,10 +26,12 @@ describe("MarkdownContent", () => {
         expect(screen.getByRole("link", { name: "Project" }).getAttribute("target")).toBe("_blank");
     });
 
-    it("routes Mermaid code fences to the diagram renderer", () => {
+    it("routes Mermaid code fences to the diagram renderer", async () => {
         render(<MarkdownContent content={"```mermaid\ngraph TD; A-->B\n```"} />);
 
-        expect(screen.getByRole("generic", { name: "Mermaid diagram" }).textContent).toContain("graph TD; A-->B");
+        expect((await screen.findByRole("generic", { name: "Mermaid diagram" })).textContent).toContain(
+            "graph TD; A-->B",
+        );
     });
 
     it("keeps raw HTML inert", () => {


### PR DESCRIPTION
## What changed

- Lazy-load `MermaidDiagram` from the Mermaid branch in `CodeSnippet` with `React.lazy` and `Suspense`.
- Keep a persistent `min-h-48` semantic-token container around the diagram and expose a polite, visible loading status while the lazy module resolves.
- Add focused tests proving ordinary code blocks do not request the diagram module, the accessible loading boundary reserves space, and Mermaid fences still resolve through the markdown renderer.

## Why

The shared markdown path statically imported `MermaidDiagram`, which in turn made the Mermaid runtime reachable from the main client entry. As a result, every visitor downloaded the site's heaviest dependency even on routes that render no diagrams.

This change moves Mermaid behind a render-time dynamic import. Visitors to the home, about, and article-list routes no longer download the Mermaid runtime; article pages containing Mermaid fences still hydrate and render diagrams normally.

## Bundle impact

Production client build output before and after:

| Chunk | Before | After |
| --- | ---: | ---: |
| Shared `index` raw | 1,317.25 kB | 703.64 kB |
| Shared `index` gzip | 373.73 kB | 226.56 kB |
| Lazy `MermaidDiagram` raw | — | 611.00 kB |
| Lazy `MermaidDiagram` gzip | — | 146.43 kB |

The shared bundle is reduced by 613.61 kB raw and 147.17 kB gzip. Inspection found zero Mermaid runtime markers (`securityLevel`, `mermaidAPI`, or Mermaid's diagram-detection error) in the built `index` chunk; those markers are confined to the lazy chunk. `MermaidDiagram.tsx` remains the only source module importing `mermaid`.

## Validation

- Clean pre-change baseline: `npm test` — 22 files, 138 tests passed.
- Focused component tests — 3 files, 10 tests passed.
- `npm run test` — 23 files, 140 tests passed.
- `npm run lint` — passed with 0 errors and 2 pre-existing warnings.
- `npm run format:check` — passed.
- `npm run build` — client, SSR, all prerendered routes, and generated machine-readable files passed.
- `git diff --check` — passed.
- Built diagram article HTML retains the reserved boundary, Mermaid `<pre>`, and source content; `/`, `/about`, and `/articles` contain no eager Mermaid chunk references.

## Lighthouse limitation

Chrome/Chromium is not installed in the implementation environment, so Lighthouse's post-change unused-JavaScript values could not be remeasured locally. The issue's existing Lighthouse measurements remain the before baseline; the production build output above provides the exact shared-JavaScript transfer before/after evidence.

Closes #268