### PR TITLE
Add backlog idea shaping skill

### DIFF
--- a/.agents/skills/shape-backlog-idea/SKILL.md
+++ b/.agents/skills/shape-backlog-idea/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: shape-backlog-idea
+description: Investigate loosely expressed product ideas, UX observations, refactoring proposals, and reported defects for loganfarci.com, then recommend, create, refine, or prioritize the correct GitHub backlog action. Use when Logan talks through an idea conversationally or via voice dictation, asks whether something should be kept or removed, requests a new issue, wants design or implementation options investigated, or asks how work should be sequenced.
+---
+
+# Shape Backlog Idea
+
+Read and follow the canonical workflow in
+`../../../.github/skills/shape-backlog-idea/SKILL.md`.

--- a/.github/instructions/issues.instructions.md
+++ b/.github/instructions/issues.instructions.md
@@ -15,6 +15,47 @@ You are assisting with issue management for the loganfarci.com repository using 
 - **Consistency**: Use standardized templates and naming conventions
 - **Traceability**: Link issues to requirements, PRs, and related work
 
+## Product Idea Collaboration
+
+Use the repository's `shape-backlog-idea` skill when Logan talks through a product
+idea, UX observation, refactor, defect, or prioritization question.
+
+- Treat fragmented or voice-dictated language as normal exploratory input. Resolve
+  approximate component names against the code and rendered flow, then restate the
+  understood outcome in clear product language.
+- Investigate the current implementation, relevant specs, Git history, live behavior
+  when applicable, and related open/recently closed issues before deciding what belongs
+  in the backlog.
+- Preserve the requested outcome without assuming the proposed implementation is
+  correct. Give an evidence-backed recommendation to keep, change, defer, combine, or
+  remove the idea.
+- When design uncertainty is real, document 2–3 credible options, identify a preferred
+  starting point, and require the implementation to record its choice. When the owner
+  selects a standard direction, make the issue decisive rather than reopening it.
+- Prefer updating an issue that already owns the outcome. Create a follow-up bug for a
+  regression or a new task for a distinct productization pass.
+- Before a GitHub write, restate the repository, target, type label, milestone, and
+  assignee choice. Report success only after the write is confirmed.
+
+## Prioritization
+
+GitHub is the source of truth; refresh the live backlog before recommending sequence.
+Use this default order unless the owner explicitly changes it:
+
+1. Production regressions, broken core journeys, privacy/security problems,
+   deployment failures, and accessibility blockers.
+2. Foundations or quality work that unblocks multiple accepted tasks or prevents
+   repeated regressions.
+3. High-value usability improvements to shipped journeys.
+4. Coherent design/content polish and maintainability refactors.
+5. Distinctive optional features.
+6. Larger strategic expansions such as new sections and locales.
+
+Fix regressions before polishing the same surface, sequence prerequisites before
+dependants, and avoid broad file moves while accepted work is changing the same files.
+Assignee means ownership and milestone means grouping; neither proves priority. Never
+invent unreadable GitHub Project status or present inferred sequencing as confirmed.
+
 ## Issue Status Management
 
 Always update issue status appropriately:

--- a/.github/skills/shape-backlog-idea/SKILL.md
+++ b/.github/skills/shape-backlog-idea/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: shape-backlog-idea
+description: Investigate loosely expressed product ideas, UX observations, refactoring proposals, and reported defects for loganfarci.com, then recommend, create, refine, or prioritize the correct GitHub backlog action. Use when Logan talks through an idea conversationally or via voice dictation, asks whether something should be kept or removed, requests a new issue, wants design or implementation options investigated, or asks how work should be sequenced.
+---
+
+# Shape Backlog Idea
+
+Turn conversational product input into an evidence-backed backlog decision. Preserve
+Logan's intent while supplying the repository research, design judgment, technical
+constraints, and issue structure he should not need to specify himself.
+
+## Prepare
+
+1. Read `AGENTS.md`, `.github/copilot-instructions.md`,
+   `.github/instructions/issues.instructions.md`, and `docs/specs/README.md`.
+2. Read [references/owner-collaboration.md](references/owner-collaboration.md).
+3. Read the specs and path-specific instructions relevant to the idea.
+4. Inspect `git status` and use the latest available `main` state for current facts.
+   Do not overwrite or mix in unrelated local work.
+5. Use the GitHub connector first for issue reads and writes. Use `gh` for gaps such
+   as targeted issue searches, milestones, local-branch context, or history.
+
+## Reconstruct the request
+
+- Treat fragmented or voice-dictated language as normal. Infer the intended outcome
+  from the whole message and surrounding conversation rather than correcting wording.
+- Resolve unclear nouns against the rendered UI and code. For example, determine
+  whether "the arrow beside headers" means `Section` redirects, heading permalinks, or
+  a disclosure chevron before shaping the issue.
+- Paraphrase the understood problem and affected flow in plain language during the
+  investigation. Ask only when multiple plausible interpretations would materially
+  change the backlog action and the repository cannot resolve them.
+- Separate the desired outcome from a suggested implementation. Preserve the outcome;
+  validate the implementation against current code, specs, and established patterns.
+
+## Investigate before deciding
+
+Use evidence proportional to the request:
+
+1. Inspect the current implementation, consumers, tests, specs, and relevant Git
+   history.
+2. Run or inspect the application when visual behavior, responsive design, or an
+   interaction is central. Use the repository's local-app or validation skill when it
+   applies.
+3. For production-only defects, reproduce or gather production evidence when feasible.
+   If not reproduced, label the suspected cause as a hypothesis and include a
+   repeatable reproduction step.
+4. Search open and recently closed issues by user outcome, component, symptom, and
+   likely solution. Inspect related PRs when a recent change may own or explain the
+   behavior.
+5. Check whether the idea fits the vision, non-goals, accessibility contract, static
+   architecture, and quality bars.
+
+Do not automatically agree with every proposal. Recommend keeping, changing,
+deferring, combining, or removing something based on user value and repository
+evidence. Explain the decisive tradeoff briefly.
+
+## Choose the backlog action
+
+- **Update an existing open issue** when it already owns the requested outcome.
+- **Create a new bug** for observable behavior that violates the current contract,
+  including regressions introduced by completed work.
+- **Create a new task** for an improvement, feature, refactor, or bounded
+  investigation.
+- **Do not create an issue** when the work already exists, is completed, is out of
+  scope, lacks a meaningful user/project outcome, or only duplicates another task.
+- Keep one actionable level. Do not create epics, parent trackers, or speculative
+  issue trees.
+
+Before any GitHub write, state the exact repository, issue action, type label,
+milestone, and assignee choice. Do not claim success until GitHub confirms it.
+
+## Handle solution certainty
+
+- When the outcome is clear but the design is not, include 2–3 credible options,
+  identify a preferred starting point, require testing them with real content and
+  representative viewports, and require the PR to record the chosen tradeoff.
+- When Logan selects a direction such as "follow an industry structure," make the
+  issue decisive. Stop reopening the architectural choice; retain investigation only
+  for ambiguous file ownership or implementation details.
+- Prefer existing primitives, platform behavior, typed data, semantic tokens, and
+  static rendering. Do not introduce a dependency unless the repository evidence
+  justifies it.
+- Make accessibility, responsive behavior, both themes, reduced motion, SSR/prerender,
+  and current quality gates part of the solution where relevant—not decorative
+  boilerplate.
+
+## Write agent-ready issues
+
+Follow `.github/instructions/issues.instructions.md`. In addition:
+
+- Explain the current behavior and why it matters to a visitor or maintainer.
+- Link the relevant specs and related issues/PRs.
+- Include concrete routes, destinations, examples, data flows, or interaction states.
+- Name likely affected files using current paths, while acknowledging an approved
+  pending refactor when necessary.
+- Preserve normal web/platform behavior such as keyboard access, browser history,
+  deep links, first-load rendering, and no-JavaScript fallbacks when applicable.
+- Include focused verification that can disprove the fix, including cold-cache,
+  responsive, zoom, theme, or production checks when they are central.
+- Avoid prescribing speculative internals as acceptance criteria. Mark a likely root
+  cause as a hypothesis until verified.
+
+## Prioritize and sequence
+
+Refresh the live GitHub backlog before giving priority advice. GitHub is the source of
+truth; the snapshot in the owner reference is context, not current state.
+
+Use this default order, then adjust for explicit owner direction and dependencies:
+
+1. Production regressions, broken core flows, security/privacy problems, deployment
+   failures, and accessibility blockers.
+2. Foundations or quality work that unblocks multiple accepted tasks or prevents
+   repeated regressions.
+3. High-value usability improvements to already shipped journeys.
+4. Coherent design/content polish and maintainability refactors.
+5. Distinctive but optional features.
+6. Larger strategic expansion such as new sections or locales.
+
+Apply these rules:
+
+- Fix a regression before adding polish to the same surface.
+- Sequence prerequisites before dependants and explicitly cross-reference them.
+- Avoid starting a broad structural move while accepted product issues are actively
+  changing the same files; complete them first or plan a deliberate rebase.
+- Treat assignee as ownership, milestone as grouping, and `agent:working` as execution
+  state—not as proof of priority.
+- Never claim a GitHub Project status or confirmed priority when it was not readable.
+  Present inferred sequencing as a recommendation.
+- Prefer closing completed zero-open-issue milestones during a dedicated backlog
+  cleanup rather than silently mutating them while shaping an unrelated idea.
+
+## Finish
+
+Return:
+
+- the recommendation or diagnosis;
+- the issue created or updated, with a direct link;
+- the most important scope/design decision;
+- any sequencing dependency or unverified assumption.
+
+Keep the handoff concise. The GitHub issue contains the implementation detail.

--- a/.github/skills/shape-backlog-idea/agents/openai.yaml
+++ b/.github/skills/shape-backlog-idea/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Shape Backlog Idea"
+  short_description: "Turn rough ideas into prioritized GitHub issues"
+  default_prompt: "Use $shape-backlog-idea to investigate this product idea and turn it into the right backlog action."

--- a/.github/skills/shape-backlog-idea/references/owner-collaboration.md
+++ b/.github/skills/shape-backlog-idea/references/owner-collaboration.md
@@ -1,0 +1,111 @@
+# Owner collaboration and backlog context
+
+## Communication profile
+
+- Logan commonly develops ideas aloud or through voice dictation. Messages may contain
+  pauses, repeated words, approximate component names, and transcription errors. Treat
+  this as exploratory input, not as a requirement for him to rewrite the request.
+- Reconstruct the intended user experience, inspect the application, and reflect the
+  interpretation back in clearer product language before writing the issue.
+- Logan expects the agent to investigate first: inspect code, Git history, specs,
+  related issues, and the rendered or deployed behavior when relevant.
+- Offer an honest recommendation. When the evidence favors removing code, say so; when
+  an idea adds meaningful personality or usability, explain why it is worth keeping.
+- Do not force premature choices. If design uncertainty is real, place a small set of
+  options and a preferred starting point in the issue. Once Logan chooses a direction,
+  make the issue decisive and coherent.
+- Lead with the outcome and use plain language. Keep the conversational handoff short;
+  put detailed requirements and verification in the issue.
+
+## Product and engineering preferences
+
+- Favor a modern, clear, friendly professional experience with restrained personality.
+- Make controls self-explanatory. Do not rely on ambiguous chevrons, icon-only meaning,
+  or hover-only explanations when visible contextual language is practical.
+- Design mobile and desktop as complete journeys. A feature is not finished when a
+  reader can enter a flow but cannot conveniently return, switch section, or recover.
+- Preserve the site's history and distinctive technical character when it serves the
+  professional story, as with the terminal, but keep optional experiences secondary to
+  normal navigation.
+- Prefer pragmatic industry conventions and coherent feature ownership over bespoke
+  architecture. Once a standard direction is selected, apply it consistently.
+- Reuse the same typed content sources. Do not duplicate biography, skills, article,
+  certification, or contact data inside UI features.
+- Accessibility, static prerendering, first-visit behavior, responsive layouts, both
+  themes, reduced motion, and maintainable tests are part of the feature definition.
+- Avoid heavy dependencies and complexity that do not earn clear user value.
+
+## Issue-shaping preferences
+
+- Search for duplicates before creating anything. Refine an exact open match rather
+  than splitting ownership across issues.
+- Preserve completed historical issues and create a follow-up when the new request is
+  a distinct productization pass or a regression.
+- Use imperative titles and exactly one type label: `task` or `bug`. Add topical labels
+  only when they add useful filtering.
+- Keep issues standalone, self-contained, agent-ready, and measurable. Use milestones
+  only for meaningful delivery grouping.
+- Include relevant specs, affected paths, related issue/PR history, acceptance
+  criteria, and the full repository quality gate when implementation changes the app.
+- For design work, describe the current UX problem, 2–3 viable patterns when needed,
+  the evaluation criteria, and which pattern is the preferred starting point.
+- For defects, include reproducible steps, expected/actual behavior, a verified or
+  explicitly suspected root cause, regression history, and a validation matrix that
+  covers the failing environment.
+
+## Backlog model
+
+GitHub issues are the live source of truth. The repository uses a flat actionable
+backlog:
+
+- `bug`: current behavior is broken or regressed;
+- `task`: feature, improvement, refactor, content work, or bounded investigation;
+- topical labels such as `accessibility`, `ui/ux`, `refactor`, `content`, `seo`, and
+  `ci/cd` supplement rather than replace the type.
+
+Milestones group delivery themes but are not a priority scale. Several legacy
+milestones have no open issues and should be audited separately rather than treated as
+active work. Assignment indicates ownership, not urgency. GitHub Project status must
+be queried when permissions allow; do not infer it from issue order.
+
+## Backlog snapshot: 2026-07-31
+
+This snapshot records context from the conversation and must be refreshed before use.
+
+### Immediate regression
+
+- #338: custom fonts require a reload on the first uncached visit. This is the clearest
+  first priority because it affects every production entry and regressed from #322.
+
+### Accepted UX and quality improvements
+
+- #337: mobile return-to-contents control for article reading.
+- #335: clearer homepage section navigation actions.
+- #321: experience-card detail presentation.
+- #328: icon-backed skill/article-tag taxonomy.
+- #223, #216, #213: article typography, code-block controls, and callouts.
+- #62: reorganize the homepage's “What I Do” content.
+
+### Structural foundation
+
+- #336: feature-first React structure. It deliberately coordinates with #321, #334,
+  and #335 because they touch the same ownership boundaries. Treat that conflict plan
+  as sequencing evidence, not as permission to absorb their product decisions.
+
+### Distinctive optional feature
+
+- #334: revive the terminal as a professional, optional profile experience. It belongs
+  to the active Terminal milestone and should stay secondary to normal navigation.
+
+### Brand, content, and strategic expansion
+
+- #320: replace the AI-generated avatar with an approved recent photograph.
+- #201: add a static résumé PDF.
+- #202: create a projects showcase.
+- #206: add technical recommendations.
+- Internationalization chain: #224, #225, #228, #217, and #258. Sequence build-time
+  message/catalog and route foundations before switcher and additional-locale polish.
+
+No explicit priority labels or due dates were present. The available GitHub token could
+not read Project fields, so this grouping is a recommended product sequence, not a
+confirmed project-board status.


### PR DESCRIPTION
## Summary

- add a repository-local `shape-backlog-idea` skill and Codex discovery wrapper
- capture Logan's collaboration preferences and a clearly dated backlog snapshot for future issue-shaping sessions
- align the shared issue instructions with the investigation, design-option, GitHub-write, and prioritization workflow

## Why

Product ideas for this repository often begin as conversational or voice-dictated observations. This gives future agents a repeatable way to reconstruct the intended outcome, investigate the implementation and existing backlog, recommend the right action, and produce implementation-ready issues without treating stale priority context as current truth.

## Impact

Agent guidance and documentation only. There are no runtime application changes.

## Validation

- `quick_validate.py .github/skills/shape-backlog-idea`
- `quick_validate.py .agents/skills/shape-backlog-idea`
- targeted Prettier check for all five changed files (passed before commit; a later rerun could not reach the npm registry)
- `git diff --check`
