### PR TITLE
Reorganize “What I Do” around Cloud and AI

### DIFF
--- a/content/data/interests.json
+++ b/content/data/interests.json
@@ -12,7 +12,7 @@
   },
   {
     "title": "AI",
-    "description": "Building practical AI solutions and developer workflows with GitHub and Azure AI.",
+    "description": "Building practical AI solutions with Azure AI services and modern developer workflows.",
     "image": {
       "src": "/images/icons/robot.avif",
       "alt": "Robot icon",
@@ -23,7 +23,7 @@
   },
   {
     "title": "DevOps",
-    "description": "Implementing CI/CD pipelines and automating workflows to enhance development efficiency.",
+    "description": "Building reliable CI/CD pipelines, infrastructure as code, and cloud networking.",
     "image": {
       "src": "/images/icons/infinity.avif",
       "alt": "Infinity icon",

--- a/content/data/interests.json
+++ b/content/data/interests.json
@@ -1,25 +1,25 @@
 [
   {
-    "title": "Backend Development",
-    "description": "Building robust and scalable backend systems using C#, .NET, and Azure.",
-    "image": {
-      "src": "/images/icons/gear.avif",
-      "alt": "Gear icon",
-      "width": 128,
-      "height": 128
-    },
-    "redirectPath": "/about#backend-development"
-  },
-  {
-    "title": "Cloud Computing",
-    "description": "Leveraging the power of Azure to deliver scalable and efficient solutions.",
+    "title": "Cloud",
+    "description": "Designing resilient, scalable solutions on Microsoft Azure.",
     "image": {
       "src": "/images/icons/cloud.avif",
       "alt": "Cloud icon",
       "width": 128,
       "height": 128
     },
-    "redirectPath": "/about#cloud-computing"
+    "redirectPath": "/about#cloud"
+  },
+  {
+    "title": "AI",
+    "description": "Building practical AI solutions and developer workflows with GitHub and Azure AI.",
+    "image": {
+      "src": "/images/icons/robot.avif",
+      "alt": "Robot icon",
+      "width": 128,
+      "height": 128
+    },
+    "redirectPath": "/about#ai"
   },
   {
     "title": "DevOps",
@@ -33,14 +33,14 @@
     "redirectPath": "/about#devops"
   },
   {
-    "title": "Artificial Intelligence",
-    "description": "Exploring machine learning models and AI-driven solutions to solve complex problems.",
+    "title": "Software Engineering",
+    "description": "Building reliable software with C#, .NET, and modern engineering practices.",
     "image": {
-      "src": "/images/icons/robot.avif",
-      "alt": "Robot icon",
+      "src": "/images/icons/gear.avif",
+      "alt": "Gear icon",
       "width": 128,
       "height": 128
     },
-    "redirectPath": "/about#artificial-intelligence"
+    "redirectPath": "/about#software-engineering"
   }
 ]

--- a/content/data/interests.json
+++ b/content/data/interests.json
@@ -12,7 +12,7 @@
   },
   {
     "title": "AI",
-    "description": "Building practical AI solutions with Azure AI services and modern developer workflows.",
+    "description": "Building practical AI solutions and modern developer workflows with GitHub and Azure AI services.",
     "image": {
       "src": "/images/icons/robot.avif",
       "alt": "Robot icon",

--- a/content/data/skills.json
+++ b/content/data/skills.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "Backend Development",
-    "description": "Focused on building scalable backend systems and developer tooling for Azure. Experienced in designing robust APIs and services using ASP.NET or other modern technology stacks to deliver reliable, cloud-ready solutions.",
+    "name": "Software Engineering",
+    "description": "Builds reliable, maintainable software with C#, .NET, TypeScript, Java, and modern engineering practices, from APIs and data access to testing and developer tooling.",
     "skills": [
       {
         "name": ".NET",
@@ -53,8 +53,8 @@
     ]
   },
   {
-    "name": "Cloud Computing",
-    "description": "Experienced in designing, deploying, and managing scalable solutions on Microsoft Azure. Skilled in leveraging Azure services to build resilient cloud architectures, automate deployments, and deliver high-performing, maintainable applications.",
+    "name": "Cloud",
+    "description": "Designs, deploys, and manages resilient solutions on Microsoft Azure using cloud services that keep applications scalable and maintainable.",
     "skills": [
       {
         "name": "Azure App Service",
@@ -153,8 +153,8 @@
     ]
   },
   {
-    "name": "Artificial Intelligence",
-    "description": "Explores the integration of AI into applications to enhance developer workflows and user experiences. Experienced in building intelligent solutions using Azure AI services and modern frameworks for natural language processing and automation.",
+    "name": "AI",
+    "description": "Builds practical AI solutions and developer workflows with GitHub Copilot, Azure AI, and modern orchestration frameworks.",
     "skills": [
       {
         "name": "GitHub Copilot",

--- a/src/src/core/content-links.test.ts
+++ b/src/src/core/content-links.test.ts
@@ -1,0 +1,16 @@
+import interests from "@content/data/interests.json";
+import skillCategories from "@content/data/skills.json";
+import { describe, expect, it } from "vitest";
+import { createId } from "./string";
+
+describe("interest content", () => {
+    it("presents the professional focus in the expected order", () => {
+        expect(interests.map((interest) => interest.title)).toEqual(["Cloud", "AI", "DevOps", "Software Engineering"]);
+    });
+
+    it("links every interest to a matching skill category", () => {
+        const skillAnchors = skillCategories.map((category) => `/about#${createId(category.name)}`);
+
+        expect(interests.every((interest) => skillAnchors.includes(interest.redirectPath))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

- reorder the home-page “What I Do” cards to Cloud, AI, DevOps, and Software Engineering
- rename the matching About skill categories and refresh their descriptions and anchors
- preserve the existing icons, layout, and unrelated skill content
- add regression coverage for the card order and About anchor matching

## Impact

The home page now presents the current professional focus more clearly, and every card continues to navigate to its matching About section without changing the rest of the site.

## Validation

- `npm run lint` (0 errors; one unrelated existing warning)
- `npm run format:check`
- `npm test -- --run` (195 tests)
- `npm run build`
- verified prerendered home links match the generated About anchors

Closes #62