### PR TITLE
Add accessible Markdown callouts

### DIFF
--- a/content/articles/agentic-workflow-pr-quality-checks.md
+++ b/content/articles/agentic-workflow-pr-quality-checks.md
@@ -36,7 +36,8 @@ When everything passes, the workflow resolves cleanly without leaving extra nois
 
 GitHub Agentic Workflows are defined as Markdown files with a YAML front matter block. The workflow source lives at `.github/workflows/pull-request-quality-checks.md` and looks like this:
 
-This front matter is workflow source syntax, not plain GitHub Actions YAML. Keys like `engine`, `tools`, and `safe-outputs` are GitHub Agentic Workflows extensions that `gh aw` understands before compilation.
+> [!NOTE]
+> This front matter is workflow source syntax, not plain GitHub Actions YAML. Keys like `engine`, `tools`, and `safe-outputs` are GitHub Agentic Workflows extensions that `gh aw` understands before compilation.
 
 ```yaml
 ---
@@ -101,7 +102,10 @@ You compile this Markdown source into a generated GitHub Actions lock file with 
 gh aw compile
 ```
 
-This turns `.github/workflows/pull-request-quality-checks.md` into `.github/workflows/pull-request-quality-checks.lock.yml`. Never edit the `.lock.yml` directly, it is auto-generated and will be overwritten on the next compile.
+This turns `.github/workflows/pull-request-quality-checks.md` into `.github/workflows/pull-request-quality-checks.lock.yml`.
+
+> [!CAUTION]
+> Never edit the `.lock.yml` directly. It is auto-generated and will be overwritten on the next compile.
 
 ## The Core Pattern: Shared Skill
 

--- a/content/articles/azure-vm-entra-id-ssh.md
+++ b/content/articles/azure-vm-entra-id-ssh.md
@@ -74,7 +74,8 @@ az vm extension set \
   --version 1.0
 ```
 
-The VM must have a **system-assigned managed identity** enabled:
+> [!IMPORTANT]
+> The VM must have a **system-assigned managed identity** enabled.
 
 ```bash
 az vm identity assign \

--- a/content/articles/git-worktree-vscode.md
+++ b/content/articles/git-worktree-vscode.md
@@ -79,7 +79,8 @@ Each worktree has its own Git state, so you can commit, push, and pull independe
 
 ### Remove a Worktree When Finished
 
-To clean up, remove a worktree with `git worktree remove`. Make sure to never delete a worktree directory manually to avoid issues:
+> [!CAUTION]
+> Remove a worktree with `git worktree remove`. Never delete a worktree directory manually.
 
 ```bash
 git worktree remove ../features

--- a/content/articles/github-copilot-customizations.md
+++ b/content/articles/github-copilot-customizations.md
@@ -61,7 +61,8 @@ For example, when you switch to Articles Chat Mode, Copilot stops offering code 
 
 To activate Articles Chat Mode, define it in `.github/copilot/chatmodes/articles.chatmode.md`. Once set up, select it from the Copilot chat mode picker in Visual Studio Code. This instantly shifts Copilot's persona to match your technical writing workflow, making every edit session more focused and productive.
 
-> **Note:** I'm sure this mode can be improved further, but it already helps me focus on writing without getting distracted by coding tasks. It's like having a personal writing assistant that understands my style and needs.
+> [!NOTE]
+> I'm sure this mode can be improved further, but it already helps me focus on writing without getting distracted by coding tasks. It's like having a personal writing assistant that understands my style and needs.
 
 ### Articles Instructions
 

--- a/content/articles/github-mcp-server.md
+++ b/content/articles/github-mcp-server.md
@@ -91,7 +91,8 @@ For more control, you can run the GitHub MCP server locally with Docker. In VS C
     }
     ```
 
-This local configuration does not use `http://localhost:8080`. If you want an HTTP transport instead, make sure you follow the official GitHub MCP Server transport documentation and configure the server for that transport explicitly.
+> [!IMPORTANT]
+> This local configuration does not use `http://localhost:8080`. If you want an HTTP transport instead, follow the official GitHub MCP Server transport documentation and configure the server for that transport explicitly.
 
 ### Security
 

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -96,20 +96,22 @@ depends on color alone. The body uses normal article typography rather than quot
 italics. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
 `measure` behavior at narrow widths and high zoom.
 
-The callout label, icon, and edge use narrowly scoped semantic accent tokens against
-`surface-elevated`. Contrast checks for those pairings are:
+Each callout uses a narrowly scoped semantic accent, tinted surface, and matching
+border. This makes the variants easier to scan in light mode while the visible label
+and distinct icon preserve meaning without color. Contrast checks for the accent
+against its corresponding surface are:
 
 | Variant | Light theme | Dark theme |
 | --- | ---: | ---: |
-| Note | 6.12:1 | 7.25:1 |
-| Tip | 6.74:1 | 8.23:1 |
-| Important | 6.90:1 | 8.78:1 |
-| Warning | 6.93:1 | 8.81:1 |
-| Caution | 6.51:1 | 5.98:1 |
+| Note | 6.00:1 | 7.16:1 |
+| Tip | 6.99:1 | 8.03:1 |
+| Important | 6.48:1 | 8.39:1 |
+| Warning | 6.73:1 | 8.47:1 |
+| Caution | 6.17:1 | 5.91:1 |
 
 These values exceed the 4.5:1 text requirement and the 3:1 meaningful graphical-object
-requirement in both themes. Body text and the surrounding neutral border continue to
-use the site's existing text and border tokens.
+requirement in both themes. Body text continues to use the site's existing semantic
+text tokens.
 
 During local development, `/_dev/markdown-callouts` renders all variants and fallback
 states through `MarkdownContent` for visual review. The route is development-only: it

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -1,6 +1,6 @@
 ---
 spec: markdown-rendering
-version: 0.2.0
+version: 0.3.0
 status: current-state
 ---
 
@@ -42,6 +42,8 @@ step.
 - Tables.
 - Strikethrough.
 - Inline code and fenced code blocks (including Mermaid, below).
+- Callouts using the blockquote markers `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`,
+  `[!WARNING]`, and `[!CAUTION]`.
 
 **Raw HTML is not rendered.** There is no `rehype-raw` in the pipeline, so HTML tags in
 markdown are treated as text and escaped. Authors MUST express content with
@@ -58,11 +60,61 @@ as unstyled default HTML:
 | `###` / `####` | `Heading3` / `Heading4` | Article headings receive the same ID and permalink treatment. |
 | Paragraph | `Text` | Constrained to a readable width when `measure` is set. |
 | Lists / items | `UnorderedList` / `OrderedList` / `ListItem` | |
-| `>` blockquote | Styled blockquote | Left border + `primary-light` background, italic. |
+| Ordinary `>` blockquote | Styled blockquote | Left border + `primary-light` background, italic. |
+| Supported callout blockquote | Labeled callout | Compact label, decorative icon, semantic accent, and normal article typography. |
 | Link | `NewTabLink` | **All links open in a new tab** with safe `rel`. |
 | Inline/fenced code | `CodeSnippet` | See below. |
 | Table (GFM) | Styled `table` | Bordered, rounded, `surface` background. |
 | `---` rule / `**`/`_` | `hr` / `Strong` / `Emphasis` | |
+
+## Callouts
+
+Callouts use GitHub-compatible blockquote markers. The marker MUST be the first content
+in a top-level blockquote, use one of the five supported uppercase values, and appear
+on its own line:
+
+```markdown
+> [!NOTE]
+> Useful context that is worth noticing while skimming.
+```
+
+The renderer removes the marker and adds the visible label **Note**, **Tip**,
+**Important**, **Warning**, or **Caution** before the body. The body continues through
+the shared Markdown element mapping, so multiple paragraphs, emphasis, links, inline
+code, and lists retain their normal semantics.
+
+Ordinary quotations keep the existing italic blockquote treatment. Unsupported markers
+such as `[!ALERT]`, lowercase or malformed markers, markers with body text on the same
+line, markers later in a quote, and nested callout attempts remain ordinary blockquote
+content. Their marker text is intentionally preserved rather than silently discarded.
+Nested callouts are not supported.
+
+Callouts are static prose. They do not use `role="alert"`, live-region semantics, or
+interactive behavior. A visible text label occurs before the body in reading order,
+icons are decorative and hidden from assistive technology, and variant identity never
+depends on color alone. The body uses normal article typography rather than quotation
+italics. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
+`measure` behavior at narrow widths and high zoom.
+
+The callout label, icon, and edge use narrowly scoped semantic accent tokens against
+`surface-elevated`. Contrast checks for those pairings are:
+
+| Variant | Light theme | Dark theme |
+| --- | ---: | ---: |
+| Note | 6.12:1 | 7.25:1 |
+| Tip | 6.74:1 | 8.23:1 |
+| Important | 6.90:1 | 8.78:1 |
+| Warning | 6.93:1 | 8.81:1 |
+| Caution | 6.51:1 | 5.98:1 |
+
+These values exceed the 4.5:1 text requirement and the 3:1 meaningful graphical-object
+requirement in both themes. Body text and the surrounding neutral border continue to
+use the site's existing text and border tokens.
+
+During local development, `/_dev/markdown-callouts` renders all variants and fallback
+states through `MarkdownContent` for visual review. The route is development-only: it
+is absent from the production route table, static route list, prerendered output,
+sitemap, and machine-readable text files.
 
 ## Article heading navigation
 
@@ -138,8 +190,6 @@ bespoke system, and only add weight where it earns its place.
 - **Mermaid diagrams.** Ideally rendered at **build time** (during prerender) so
   diagrams appear without JavaScript and are indexable, with a graceful fallback —
   replacing today's client-only render.
-- **Callouts / admonitions.** Note / tip / warning blocks (e.g. via a blockquote
-  convention) for emphasis beyond a plain quote.
 - **Footnotes.** GFM footnotes with back-references for citations and asides.
 - **Tables.** Remain readable on small screens (horizontal scroll or responsive
   treatment) without breaking layout.
@@ -156,6 +206,8 @@ pipeline deliberately avoids. Revisit only if a concrete article need justifies 
 - Article heading IDs and table-of-contents links **MUST** be derived from the same
   parsed syntax tree and remain present in prerendered HTML.
 - **MUST NOT** rely on raw HTML in markdown — it will not render.
+- Callout authors **MUST** put an exact supported marker first in a top-level
+  blockquote and on its own line; use an ordinary blockquote for quotations.
 - Body headings **SHOULD** start at `##` (the `h1` is the front-matter title).
 - Mermaid diagrams **MUST** use a fenced ```` ```mermaid ```` block and **SHOULD** stay
   lightweight, remembering they render only on the client.

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -93,8 +93,9 @@ Callouts are static prose. They do not use `role="alert"`, live-region semantics
 interactive behavior. A visible text label occurs before the body in reading order,
 icons are decorative and hidden from assistive technology, and variant identity never
 depends on color alone. The body uses normal article typography rather than quotation
-italics. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
-`measure` behavior at narrow widths and high zoom.
+italics, with paragraph and list text set to the same compact size as the callout title.
+Its constrained grid and overflow wrapping preserve `MarkdownContent`'s `measure`
+behavior at narrow widths and high zoom.
 
 All callouts use the same quiet neutral surface and hairline border. Only the line icon
 and sentence-case title use the variant's semantic accent; there are no variant-tinted

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -60,12 +60,22 @@ as unstyled default HTML:
 | `###` / `####` | `Heading3` / `Heading4` | Article headings receive the same ID and permalink treatment. |
 | Paragraph | `Text` | Constrained to a readable width when `measure` is set. |
 | Lists / items | `UnorderedList` / `OrderedList` / `ListItem` | |
-| Ordinary `>` blockquote | Styled blockquote | Left border + `primary-light` background, italic. |
+| Ordinary `>` blockquote | Styled blockquote | Editorial quote mark, horizontal hairlines, and italic body text. |
 | Supported callout blockquote | Labeled callout | Compact label, decorative icon, semantic accent, and normal article typography. |
 | Link | `NewTabLink` | **All links open in a new tab** with safe `rel`. |
 | Inline/fenced code | `CodeSnippet` | See below. |
 | Table (GFM) | Styled `table` | Bordered, rounded, `surface` background. |
 | `---` rule / `**`/`_` | `hr` / `Strong` / `Emphasis` | |
+
+## Blockquotes
+
+Ordinary quotations use a restrained editorial treatment: a large decorative opening
+mark sits beside italic article typography, framed by quiet horizontal hairlines. They
+do not use the former tinted panel or heavy colored side rule, which keeps them distinct
+from both normal prose and the neutral callout container. The quotation mark is hidden
+from assistive technology, while the semantic `<blockquote>` and all rendered Markdown
+content remain in the reading order. Long content wraps within the readable measure at
+narrow widths and high zoom.
 
 ## Callouts
 
@@ -83,19 +93,19 @@ The renderer removes the marker and adds the visible label **Note**, **Tip**,
 the shared Markdown element mapping, so multiple paragraphs, emphasis, links, inline
 code, and lists retain their normal semantics.
 
-Ordinary quotations keep the existing italic blockquote treatment. Unsupported markers
-such as `[!ALERT]`, lowercase or malformed markers, markers with body text on the same
-line, markers later in a quote, and nested callout attempts remain ordinary blockquote
-content. Their marker text is intentionally preserved rather than silently discarded.
-Nested callouts are not supported.
+Ordinary quotations keep the editorial blockquote treatment. Unsupported markers such
+as `[!ALERT]`, lowercase or malformed markers, markers with body text on the same line,
+markers later in a quote, and nested callout attempts remain ordinary blockquote content.
+Their marker text is intentionally preserved rather than silently discarded. Nested
+callouts are not supported.
 
 Callouts are static prose. They do not use `role="alert"`, live-region semantics, or
 interactive behavior. A visible text label occurs before the body in reading order,
 icons are decorative and hidden from assistive technology, and variant identity never
 depends on color alone. The body uses normal article typography rather than quotation
-italics, with paragraph and list text set to the same compact size as the callout title.
-Its constrained grid and overflow wrapping preserve `MarkdownContent`'s `measure`
-behavior at narrow widths and high zoom.
+italics. The callout title uses the same responsive size as the article body, with font
+family and weight establishing its hierarchy. Its constrained grid and overflow
+wrapping preserve `MarkdownContent`'s `measure` behavior at narrow widths and high zoom.
 
 All callouts use the same quiet neutral surface and hairline border. Only the line icon
 and sentence-case title use the variant's semantic accent; there are no variant-tinted

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -96,25 +96,25 @@ depends on color alone. The body uses normal article typography rather than quot
 italics. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
 `measure` behavior at narrow widths and high zoom.
 
-Each callout uses a narrowly scoped semantic accent, tinted surface, strong colored
-edge, and solid icon tile inside a neutral outline. The flat, editorial treatment
-avoids card-like elevation so the article prose remains primary. It also makes the
-variants easier to scan in light mode while the visible sentence-case label and
-distinct icon preserve meaning without color. Contrast checks for the accent against
-its corresponding surface are:
+All callouts use the same quiet neutral surface and hairline border. Only the line icon
+and sentence-case title use the variant's semantic accent; there are no variant-tinted
+backgrounds, colored edges, solid icon tiles, or card-like elevation. This keeps the
+article prose primary while blue Note, green Tip, violet Important, amber Warning, and
+red Caution remain visually separated. The visible label and distinct icon also
+preserve meaning without color. Contrast checks for each accent against the shared
+neutral surface are:
 
 | Variant | Light theme | Dark theme |
 | --- | ---: | ---: |
-| Note | 6.00:1 | 7.16:1 |
-| Tip | 6.99:1 | 8.03:1 |
-| Important | 6.48:1 | 8.39:1 |
-| Warning | 6.73:1 | 8.47:1 |
-| Caution | 6.17:1 | 5.91:1 |
+| Note | 6.12:1 | 7.25:1 |
+| Tip | 6.93:1 | 8.16:1 |
+| Important | 6.83:1 | 7.31:1 |
+| Warning | 6.90:1 | 8.81:1 |
+| Caution | 6.51:1 | 5.98:1 |
 
 These values exceed the 4.5:1 text requirement and the 3:1 meaningful graphical-object
 requirement in both themes. Body text continues to use the site's existing semantic
-text tokens. Icon glyphs use the document background token against the solid accent,
-producing 6.52–7.39:1 contrast in light mode and 7.17–10.56:1 in dark mode.
+text tokens.
 
 During local development, `/_dev/markdown-callouts` renders all variants and fallback
 states through `MarkdownContent` for visual review. The route is development-only: it

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -60,7 +60,7 @@ as unstyled default HTML:
 | `###` / `####` | `Heading3` / `Heading4` | Article headings receive the same ID and permalink treatment. |
 | Paragraph | `Text` | Constrained to a readable width when `measure` is set. |
 | Lists / items | `UnorderedList` / `OrderedList` / `ListItem` | |
-| Ordinary `>` blockquote | Styled blockquote | Editorial quote mark, horizontal hairlines, and italic body text. |
+| Ordinary `>` blockquote | Styled blockquote | Editorial quote mark, horizontal hairlines, and standard body text. |
 | Supported callout blockquote | Labeled callout | Compact label, decorative icon, semantic accent, and normal article typography. |
 | Link | `NewTabLink` | **All links open in a new tab** with safe `rel`. |
 | Inline/fenced code | `CodeSnippet` | See below. |
@@ -70,8 +70,9 @@ as unstyled default HTML:
 ## Blockquotes
 
 Ordinary quotations use a restrained editorial treatment: a large decorative opening
-mark sits beside italic article typography, framed by quiet horizontal hairlines. They
-do not use the former tinted panel or heavy colored side rule, which keeps them distinct
+mark sits beside standard article typography, framed by quiet horizontal hairlines. The
+copy uses the same responsive size and upright style as surrounding body text. Quotes do
+not use the former tinted panel or heavy colored side rule, which keeps them distinct
 from both normal prose and the neutral callout container. The quotation mark is hidden
 from assistive technology, while the semantic `<blockquote>` and all rendered Markdown
 content remain in the reading order. Long content wraps within the readable measure at
@@ -102,10 +103,10 @@ callouts are not supported.
 Callouts are static prose. They do not use `role="alert"`, live-region semantics, or
 interactive behavior. A visible text label occurs before the body in reading order,
 icons are decorative and hidden from assistive technology, and variant identity never
-depends on color alone. The body uses normal article typography rather than quotation
-italics. The callout title uses the same responsive size as the article body, with font
-family and weight establishing its hierarchy. Its constrained grid and overflow
-wrapping preserve `MarkdownContent`'s `measure` behavior at narrow widths and high zoom.
+depends on color alone. The body uses normal article typography. The callout title uses
+the same responsive size as the article body, with font family and weight establishing
+its hierarchy. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
+`measure` behavior at narrow widths and high zoom.
 
 All callouts use the same quiet neutral surface and hairline border. Only the line icon
 and sentence-case title use the variant's semantic accent; there are no variant-tinted

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -96,10 +96,12 @@ depends on color alone. The body uses normal article typography rather than quot
 italics. Its constrained grid and overflow wrapping preserve `MarkdownContent`'s
 `measure` behavior at narrow widths and high zoom.
 
-Each callout uses a narrowly scoped semantic accent, tinted surface, and matching
-border. This makes the variants easier to scan in light mode while the visible label
-and distinct icon preserve meaning without color. Contrast checks for the accent
-against its corresponding surface are:
+Each callout uses a narrowly scoped semantic accent, tinted surface, strong colored
+edge, and solid icon tile inside a neutral outline. The flat, editorial treatment
+avoids card-like elevation so the article prose remains primary. It also makes the
+variants easier to scan in light mode while the visible sentence-case label and
+distinct icon preserve meaning without color. Contrast checks for the accent against
+its corresponding surface are:
 
 | Variant | Light theme | Dark theme |
 | --- | ---: | ---: |
@@ -111,7 +113,8 @@ against its corresponding surface are:
 
 These values exceed the 4.5:1 text requirement and the 3:1 meaningful graphical-object
 requirement in both themes. Body text continues to use the site's existing semantic
-text tokens.
+text tokens. Icon glyphs use the document background token against the solid accent,
+producing 6.52–7.39:1 contrast in light mode and 7.17–10.56:1 in dark mode.
 
 During local development, `/_dev/markdown-callouts` renders all variants and fallback
 states through `MarkdownContent` for visual review. The route is development-only: it

--- a/docs/specs/markdown-rendering.md
+++ b/docs/specs/markdown-rendering.md
@@ -126,7 +126,8 @@ neutral surface are:
 
 These values exceed the 4.5:1 text requirement and the 3:1 meaningful graphical-object
 requirement in both themes. Body text continues to use the site's existing semantic
-text tokens.
+text tokens. Inline links use a dedicated callout link token so their default, hover,
+and focus presentation remains compliant on the shared neutral surface in both themes.
 
 During local development, `/_dev/markdown-callouts` renders all variants and fallback
 states through `MarkdownContent` for visual review. The route is development-only: it

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -97,7 +97,9 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
                         {presentation.label}
                     </span>
                 </div>
-                <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0">{children}</div>
+                <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_a]:text-callout-link">
+                    {children}
+                </div>
             </div>
         </div>
     );

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -10,6 +10,7 @@ interface MarkdownCalloutProps {
 }
 
 interface CalloutPresentation {
+    containerClassName: string;
     edgeClassName: string;
     foregroundClassName: string;
     icon: ReactNode;
@@ -18,6 +19,7 @@ interface CalloutPresentation {
 
 const calloutPresentation = {
     note: {
+        containerClassName: "border-callout-note bg-callout-note-subtle",
         edgeClassName: "bg-callout-note",
         foregroundClassName: "text-callout-note",
         icon: (
@@ -29,6 +31,7 @@ const calloutPresentation = {
         label: "Note",
     },
     tip: {
+        containerClassName: "border-callout-tip bg-callout-tip-subtle",
         edgeClassName: "bg-callout-tip",
         foregroundClassName: "text-callout-tip",
         icon: (
@@ -37,6 +40,7 @@ const calloutPresentation = {
         label: "Tip",
     },
     important: {
+        containerClassName: "border-callout-important bg-callout-important-subtle",
         edgeClassName: "bg-callout-important",
         foregroundClassName: "text-callout-important",
         icon: (
@@ -45,12 +49,14 @@ const calloutPresentation = {
         label: "Important",
     },
     warning: {
+        containerClassName: "border-callout-warning bg-callout-warning-subtle",
         edgeClassName: "bg-callout-warning",
         foregroundClassName: "text-callout-warning",
         icon: <path d="M12 4 3.75 19h16.5L12 4Zm0 5.25v4.5M12 16.75h.01" />,
         label: "Warning",
     },
     caution: {
+        containerClassName: "border-callout-caution bg-callout-caution-subtle",
         edgeClassName: "bg-callout-caution",
         foregroundClassName: "text-callout-caution",
         icon: <path d="m8 3-5 5v8l5 5h8l5-5V8l-5-5H8Zm4 5.25v5.5M12 16.75h.01" />,
@@ -80,7 +86,8 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
     return (
         <div
             className={mergeClassNames(
-                "mb-6 grid min-w-0 grid-cols-[0.25rem_minmax(0,1fr)] overflow-hidden rounded-card border border-border bg-surface-elevated shadow-sm",
+                "mb-6 grid min-w-0 grid-cols-[0.375rem_minmax(0,1fr)] overflow-hidden rounded-card border shadow-sm",
+                presentation.containerClassName,
                 className,
             )}
         >

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -97,7 +97,9 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
                         {presentation.label}
                     </span>
                 </div>
-                <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0">{children}</div>
+                <div className="min-w-0 text-sm leading-6 [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_ol]:text-sm [&_ol]:leading-6 [&_p]:text-sm [&_p]:leading-6 [&_ul]:text-sm [&_ul]:leading-6">
+                    {children}
+                </div>
             </div>
         </div>
     );

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from "react";
+
+import type { MarkdownCalloutVariant } from "@/components/shared/markdownCallouts";
+import { mergeClassNames } from "@/core/mergeClassNames";
+
+interface MarkdownCalloutProps {
+    children: ReactNode;
+    className?: string;
+    variant: MarkdownCalloutVariant;
+}
+
+interface CalloutPresentation {
+    edgeClassName: string;
+    foregroundClassName: string;
+    icon: ReactNode;
+    label: string;
+}
+
+const calloutPresentation = {
+    note: {
+        edgeClassName: "bg-callout-note",
+        foregroundClassName: "text-callout-note",
+        icon: (
+            <>
+                <circle cx="12" cy="12" r="8.5" />
+                <path d="M12 10.75v5.5M12 7.75h.01" />
+            </>
+        ),
+        label: "Note",
+    },
+    tip: {
+        edgeClassName: "bg-callout-tip",
+        foregroundClassName: "text-callout-tip",
+        icon: (
+            <path d="M9.25 18h5.5M10 21h4M8.5 14.75a6 6 0 1 1 7 0c-.9.65-1.25 1.35-1.25 2.25h-4.5c0-.9-.35-1.6-1.25-2.25Z" />
+        ),
+        label: "Tip",
+    },
+    important: {
+        edgeClassName: "bg-callout-important",
+        foregroundClassName: "text-callout-important",
+        icon: (
+            <path d="m12 3 1.75 5.25L19 10l-5.25 1.75L12 17l-1.75-5.25L5 10l5.25-1.75L12 3Zm6 12 .75 2.25L21 18l-2.25.75L18 21l-.75-2.25L15 18l2.25-.75L18 15Z" />
+        ),
+        label: "Important",
+    },
+    warning: {
+        edgeClassName: "bg-callout-warning",
+        foregroundClassName: "text-callout-warning",
+        icon: <path d="M12 4 3.75 19h16.5L12 4Zm0 5.25v4.5M12 16.75h.01" />,
+        label: "Warning",
+    },
+    caution: {
+        edgeClassName: "bg-callout-caution",
+        foregroundClassName: "text-callout-caution",
+        icon: <path d="m8 3-5 5v8l5 5h8l5-5V8l-5-5H8Zm4 5.25v5.5M12 16.75h.01" />,
+        label: "Caution",
+    },
+} satisfies Record<MarkdownCalloutVariant, CalloutPresentation>;
+
+function CalloutIcon({ presentation }: { presentation: CalloutPresentation }) {
+    return (
+        <svg
+            aria-hidden="true"
+            className={mergeClassNames(
+                "size-4 shrink-0 fill-none stroke-current stroke-[1.8]",
+                presentation.foregroundClassName,
+            )}
+            focusable="false"
+            viewBox="0 0 24 24"
+        >
+            {presentation.icon}
+        </svg>
+    );
+}
+
+export default function MarkdownCallout({ children, className, variant }: MarkdownCalloutProps) {
+    const presentation = calloutPresentation[variant];
+
+    return (
+        <div
+            className={mergeClassNames(
+                "mb-6 grid min-w-0 grid-cols-[0.25rem_minmax(0,1fr)] overflow-hidden rounded-card border border-border bg-surface-elevated shadow-sm",
+                className,
+            )}
+        >
+            <div aria-hidden="true" className={presentation.edgeClassName} />
+            <div className="min-w-0 px-4 py-4 sm:px-5">
+                <div className="mb-3 flex items-center gap-2">
+                    <CalloutIcon presentation={presentation} />
+                    <span
+                        className={mergeClassNames(
+                            "heading-font text-xs font-bold uppercase tracking-[0.16em]",
+                            presentation.foregroundClassName,
+                        )}
+                    >
+                        {presentation.label}
+                    </span>
+                </div>
+                <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0">{children}</div>
+            </div>
+        </div>
+    );
+}

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -11,17 +11,17 @@ interface MarkdownCalloutProps {
 
 interface CalloutPresentation {
     containerClassName: string;
-    edgeClassName: string;
     foregroundClassName: string;
+    iconClassName: string;
     icon: ReactNode;
     label: string;
 }
 
 const calloutPresentation = {
     note: {
-        containerClassName: "border-callout-note bg-callout-note-subtle",
-        edgeClassName: "bg-callout-note",
+        containerClassName: "border-l-callout-note bg-callout-note-subtle",
         foregroundClassName: "text-callout-note",
+        iconClassName: "bg-callout-note text-background",
         icon: (
             <>
                 <circle cx="12" cy="12" r="8.5" />
@@ -31,34 +31,34 @@ const calloutPresentation = {
         label: "Note",
     },
     tip: {
-        containerClassName: "border-callout-tip bg-callout-tip-subtle",
-        edgeClassName: "bg-callout-tip",
+        containerClassName: "border-l-callout-tip bg-callout-tip-subtle",
         foregroundClassName: "text-callout-tip",
+        iconClassName: "bg-callout-tip text-background",
         icon: (
             <path d="M9.25 18h5.5M10 21h4M8.5 14.75a6 6 0 1 1 7 0c-.9.65-1.25 1.35-1.25 2.25h-4.5c0-.9-.35-1.6-1.25-2.25Z" />
         ),
         label: "Tip",
     },
     important: {
-        containerClassName: "border-callout-important bg-callout-important-subtle",
-        edgeClassName: "bg-callout-important",
+        containerClassName: "border-l-callout-important bg-callout-important-subtle",
         foregroundClassName: "text-callout-important",
+        iconClassName: "bg-callout-important text-background",
         icon: (
             <path d="m12 3 1.75 5.25L19 10l-5.25 1.75L12 17l-1.75-5.25L5 10l5.25-1.75L12 3Zm6 12 .75 2.25L21 18l-2.25.75L18 21l-.75-2.25L15 18l2.25-.75L18 15Z" />
         ),
         label: "Important",
     },
     warning: {
-        containerClassName: "border-callout-warning bg-callout-warning-subtle",
-        edgeClassName: "bg-callout-warning",
+        containerClassName: "border-l-callout-warning bg-callout-warning-subtle",
         foregroundClassName: "text-callout-warning",
+        iconClassName: "bg-callout-warning text-background",
         icon: <path d="M12 4 3.75 19h16.5L12 4Zm0 5.25v4.5M12 16.75h.01" />,
         label: "Warning",
     },
     caution: {
-        containerClassName: "border-callout-caution bg-callout-caution-subtle",
-        edgeClassName: "bg-callout-caution",
+        containerClassName: "border-l-callout-caution bg-callout-caution-subtle",
         foregroundClassName: "text-callout-caution",
+        iconClassName: "bg-callout-caution text-background",
         icon: <path d="m8 3-5 5v8l5 5h8l5-5V8l-5-5H8Zm4 5.25v5.5M12 16.75h.01" />,
         label: "Caution",
     },
@@ -66,17 +66,24 @@ const calloutPresentation = {
 
 function CalloutIcon({ presentation }: { presentation: CalloutPresentation }) {
     return (
-        <svg
+        <span
             aria-hidden="true"
             className={mergeClassNames(
-                "size-4 shrink-0 fill-none stroke-current stroke-[1.8]",
-                presentation.foregroundClassName,
+                "flex size-8 shrink-0 items-center justify-center rounded-control",
+                presentation.iconClassName,
             )}
-            focusable="false"
-            viewBox="0 0 24 24"
         >
-            {presentation.icon}
-        </svg>
+            <svg
+                aria-hidden="true"
+                className="size-[1.125rem] fill-none stroke-current stroke-[1.8]"
+                focusable="false"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                viewBox="0 0 24 24"
+            >
+                {presentation.icon}
+            </svg>
+        </span>
     );
 }
 
@@ -86,18 +93,17 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
     return (
         <div
             className={mergeClassNames(
-                "mb-6 grid min-w-0 grid-cols-[0.375rem_minmax(0,1fr)] overflow-hidden rounded-card border shadow-sm",
+                "mb-6 min-w-0 overflow-hidden rounded-card border border-border border-l-[0.375rem]",
                 presentation.containerClassName,
                 className,
             )}
         >
-            <div aria-hidden="true" className={presentation.edgeClassName} />
-            <div className="min-w-0 px-4 py-4 sm:px-5">
+            <div className="min-w-0 p-4 sm:p-5">
                 <div className="mb-3 flex items-center gap-2">
                     <CalloutIcon presentation={presentation} />
                     <span
                         className={mergeClassNames(
-                            "heading-font text-xs font-bold uppercase tracking-[0.16em]",
+                            "heading-font text-sm font-bold tracking-[-0.01em]",
                             presentation.foregroundClassName,
                         )}
                     >

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -10,18 +10,14 @@ interface MarkdownCalloutProps {
 }
 
 interface CalloutPresentation {
-    containerClassName: string;
     foregroundClassName: string;
-    iconClassName: string;
     icon: ReactNode;
     label: string;
 }
 
 const calloutPresentation = {
     note: {
-        containerClassName: "border-l-callout-note bg-callout-note-subtle",
         foregroundClassName: "text-callout-note",
-        iconClassName: "bg-callout-note text-background",
         icon: (
             <>
                 <circle cx="12" cy="12" r="8.5" />
@@ -31,34 +27,26 @@ const calloutPresentation = {
         label: "Note",
     },
     tip: {
-        containerClassName: "border-l-callout-tip bg-callout-tip-subtle",
         foregroundClassName: "text-callout-tip",
-        iconClassName: "bg-callout-tip text-background",
         icon: (
             <path d="M9.25 18h5.5M10 21h4M8.5 14.75a6 6 0 1 1 7 0c-.9.65-1.25 1.35-1.25 2.25h-4.5c0-.9-.35-1.6-1.25-2.25Z" />
         ),
         label: "Tip",
     },
     important: {
-        containerClassName: "border-l-callout-important bg-callout-important-subtle",
         foregroundClassName: "text-callout-important",
-        iconClassName: "bg-callout-important text-background",
         icon: (
             <path d="m12 3 1.75 5.25L19 10l-5.25 1.75L12 17l-1.75-5.25L5 10l5.25-1.75L12 3Zm6 12 .75 2.25L21 18l-2.25.75L18 21l-.75-2.25L15 18l2.25-.75L18 15Z" />
         ),
         label: "Important",
     },
     warning: {
-        containerClassName: "border-l-callout-warning bg-callout-warning-subtle",
         foregroundClassName: "text-callout-warning",
-        iconClassName: "bg-callout-warning text-background",
         icon: <path d="M12 4 3.75 19h16.5L12 4Zm0 5.25v4.5M12 16.75h.01" />,
         label: "Warning",
     },
     caution: {
-        containerClassName: "border-l-callout-caution bg-callout-caution-subtle",
         foregroundClassName: "text-callout-caution",
-        iconClassName: "bg-callout-caution text-background",
         icon: <path d="m8 3-5 5v8l5 5h8l5-5V8l-5-5H8Zm4 5.25v5.5M12 16.75h.01" />,
         label: "Caution",
     },
@@ -69,13 +57,13 @@ function CalloutIcon({ presentation }: { presentation: CalloutPresentation }) {
         <span
             aria-hidden="true"
             className={mergeClassNames(
-                "flex size-8 shrink-0 items-center justify-center rounded-control",
-                presentation.iconClassName,
+                "flex size-6 shrink-0 items-center justify-center",
+                presentation.foregroundClassName,
             )}
         >
             <svg
                 aria-hidden="true"
-                className="size-[1.125rem] fill-none stroke-current stroke-[1.8]"
+                className="size-5 fill-none stroke-current stroke-2"
                 focusable="false"
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -93,13 +81,12 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
     return (
         <div
             className={mergeClassNames(
-                "mb-6 min-w-0 overflow-hidden rounded-card border border-border border-l-[0.375rem]",
-                presentation.containerClassName,
+                "mb-6 min-w-0 overflow-hidden rounded-card border border-border-light bg-surface-elevated",
                 className,
             )}
         >
             <div className="min-w-0 p-4 sm:p-5">
-                <div className="mb-3 flex items-center gap-2">
+                <div className="mb-3 flex items-center gap-2.5">
                     <CalloutIcon presentation={presentation} />
                     <span
                         className={mergeClassNames(

--- a/src/src/components/shared/MarkdownCallout.tsx
+++ b/src/src/components/shared/MarkdownCallout.tsx
@@ -90,16 +90,14 @@ export default function MarkdownCallout({ children, className, variant }: Markdo
                     <CalloutIcon presentation={presentation} />
                     <span
                         className={mergeClassNames(
-                            "heading-font text-sm font-bold tracking-[-0.01em]",
+                            "heading-font text-base font-bold leading-7 tracking-[-0.01em] md:text-[1.0625rem] md:leading-8",
                             presentation.foregroundClassName,
                         )}
                     >
                         {presentation.label}
                     </span>
                 </div>
-                <div className="min-w-0 text-sm leading-6 [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_ol]:text-sm [&_ol]:leading-6 [&_p]:text-sm [&_p]:leading-6 [&_ul]:text-sm [&_ul]:leading-6">
-                    {children}
-                </div>
+                <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0">{children}</div>
             </div>
         </div>
     );

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -180,7 +180,16 @@ describe("MarkdownContent", () => {
             constrainedGrid: callout?.classList.contains("min-w-0"),
             clippedChrome: callout?.classList.contains("overflow-hidden"),
             wrappingBody: content?.lastElementChild?.classList.contains("[overflow-wrap:anywhere]"),
-        }).toEqual({ readableMeasure: true, constrainedGrid: true, clippedChrome: true, wrappingBody: true });
+            matchesTitleSize: content?.lastElementChild?.classList.contains("text-sm"),
+            keepsParagraphsCompact: content?.lastElementChild?.classList.contains("[&_p]:text-sm"),
+        }).toEqual({
+            readableMeasure: true,
+            constrainedGrid: true,
+            clippedChrome: true,
+            wrappingBody: true,
+            matchesTitleSize: true,
+            keepsParagraphsCompact: true,
+        });
     });
 
     it("renders complete callout content in static HTML", () => {

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -63,6 +63,121 @@ describe("MarkdownContent", () => {
         expect(screen.queryByRole("img", { name: "unsafe" })).toBeNull();
     });
 
+    it.each([
+        ["NOTE", "Note"],
+        ["TIP", "Tip"],
+        ["IMPORTANT", "Important"],
+        ["WARNING", "Warning"],
+        ["CAUTION", "Caution"],
+    ])("renders the %s marker as a labeled callout", (marker, label) => {
+        const { container } = render(<MarkdownContent content={`> [!${marker}]\n> ${label} body content.`} />);
+
+        expect({
+            hasLabel: screen.getByText(label).textContent,
+            hasBody: screen.getByText(`${label} body content.`).textContent,
+            hidesMarker: container.textContent?.includes(`[!${marker}]`),
+        }).toEqual({ hasLabel: label, hasBody: `${label} body content.`, hidesMarker: false });
+    });
+
+    it("preserves Markdown semantics throughout a callout body", () => {
+        render(
+            <MarkdownContent
+                content={
+                    "> [!TIP]\n> First paragraph with *emphasis*.\n>\n> Second paragraph with a [link](https://example.com) and `code`.\n>\n> - First item\n> - Second item"
+                }
+            />,
+        );
+
+        expect({
+            paragraphs: [screen.getByText(/First paragraph/).tagName, screen.getByText(/Second paragraph/).tagName],
+            emphasis: screen.getByText("emphasis").tagName,
+            link: screen.getByRole("link", { name: "link" }).getAttribute("href"),
+            code: screen.getByText("code").tagName,
+            listItems: screen.getAllByRole("listitem").map((item) => item.textContent),
+        }).toEqual({
+            paragraphs: ["P", "P"],
+            emphasis: "EM",
+            link: "https://example.com",
+            code: "CODE",
+            listItems: ["First item", "Second item"],
+        });
+    });
+
+    it.each([
+        ["> An ordinary quotation.", "An ordinary quotation."],
+        ["> [!ALERT]\n> Unsupported marker.", "[!ALERT]"],
+        ["> [!NOTE] Same-line content.", "[!NOTE] Same-line content."],
+        ["> Before the marker.\n> [!NOTE]\n> After the marker.", "[!NOTE]"],
+        ["> [!note]\n> Lowercase marker.", "[!note]"],
+    ])("keeps non-callout blockquotes as ordinary quotations", (content, visibleText) => {
+        const { container } = render(<MarkdownContent content={content} />);
+
+        expect({
+            blockquoteIncludesText: container.querySelector("blockquote")?.textContent?.includes(visibleText),
+            fallbackIsVisible: screen.getByText((text) => text.includes(visibleText)).textContent.includes(visibleText),
+            calloutLabel: screen.queryByText("Note")?.textContent,
+        }).toEqual({ blockquoteIncludesText: true, fallbackIsVisible: true, calloutLabel: undefined });
+    });
+
+    it("does not convert a nested callout attempt", () => {
+        const { container } = render(
+            <MarkdownContent content={"> Outer quotation.\n>\n> > [!NOTE]\n> > Nested attempt."} />,
+        );
+
+        expect({
+            blockquotes: container.querySelectorAll("blockquote").length,
+            markerVisible: container.textContent?.includes("[!NOTE]"),
+            calloutLabel: screen.queryByText("Note"),
+        }).toEqual({ blockquotes: 2, markerVisible: true, calloutLabel: null });
+    });
+
+    it("keeps callout labels in reading order without live-region semantics", () => {
+        const { container } = render(<MarkdownContent content={"> [!WARNING]\n> Read this body carefully."} />);
+        const text = container.textContent ?? "";
+
+        expect({
+            labelBeforeBody: text.indexOf("Warning") < text.indexOf("Read this body carefully."),
+            decorativeIcon: container.querySelector("svg")?.getAttribute("aria-hidden"),
+            alertRole: container.querySelector('[role="alert"]'),
+            liveRegion: container.querySelector("[aria-live]"),
+        }).toEqual({ labelBeforeBody: true, decorativeIcon: "true", alertRole: null, liveRegion: null });
+    });
+
+    it("preserves readable measure and wraps stress content within the callout", () => {
+        render(
+            <MarkdownContent
+                content={
+                    "> [!NOTE]\n> VeryLongUnbrokenCalloutContentThatMustWrapWithoutForcingPageLevelHorizontalScrolling1234567890"
+                }
+                measure
+            />,
+        );
+
+        const label = screen.getByText("Note");
+        const content = label.parentElement?.parentElement;
+        const callout = content?.parentElement;
+
+        expect({
+            readableMeasure: callout?.classList.contains("max-w-[72ch]"),
+            constrainedGrid: callout?.classList.contains("min-w-0"),
+            clippedChrome: callout?.classList.contains("overflow-hidden"),
+            wrappingBody: content?.lastElementChild?.classList.contains("[overflow-wrap:anywhere]"),
+        }).toEqual({ readableMeasure: true, constrainedGrid: true, clippedChrome: true, wrappingBody: true });
+    });
+
+    it("renders complete callout content in static HTML", () => {
+        const html = renderToStaticMarkup(
+            <MarkdownContent content={"> [!IMPORTANT]\n> Prerendered **callout content**."} />,
+        );
+
+        expect({
+            hasLabel: html.includes("Important"),
+            hasBody: html.includes("<strong"),
+            hasMarker: html.includes("[!IMPORTANT]"),
+            hidesIcon: html.includes('aria-hidden="true"'),
+        }).toEqual({ hasLabel: true, hasBody: true, hasMarker: false, hidesIcon: true });
+    });
+
     it("assigns collision-safe ids to duplicate article headings", () => {
         const { container } = render(
             <MarkdownContent content={"## Repeat\n\n## Repeat\n\n## Repeat 2"} articleNavigation />,

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -75,15 +75,18 @@ describe("MarkdownContent", () => {
         const title = screen.getByText(label);
         const icon = title.previousElementSibling;
         const callout = title.parentElement?.parentElement?.parentElement;
+        const body = screen.getByText(`${label} body content.`);
 
         expect({
             hasLabel: title.textContent,
-            hasBody: screen.getByText(`${label} body content.`).textContent,
+            hasBody: body.textContent,
             hidesMarker: container.textContent?.includes(`[!${marker}]`),
             hasSharedSurface: callout?.classList.contains("bg-surface-elevated"),
             hasSharedBorder: callout?.classList.contains("border-border-light"),
             titleUsesVariantColor: title.classList.contains(`text-callout-${variant}`),
             iconUsesVariantColor: icon?.classList.contains(`text-callout-${variant}`),
+            titleUsesBodySize: title.classList.contains("text-base") && title.classList.contains("md:text-[1.0625rem]"),
+            bodyUsesBodySize: body.classList.contains("text-base") && body.classList.contains("md:text-[1.0625rem]"),
             avoidsCardElevation: callout?.classList.contains("shadow-sm"),
         }).toEqual({
             hasLabel: label,
@@ -93,6 +96,8 @@ describe("MarkdownContent", () => {
             hasSharedBorder: true,
             titleUsesVariantColor: true,
             iconUsesVariantColor: true,
+            titleUsesBodySize: true,
+            bodyUsesBodySize: true,
             avoidsCardElevation: false,
         });
     });
@@ -135,6 +140,29 @@ describe("MarkdownContent", () => {
             fallbackIsVisible: screen.getByText((text) => text.includes(visibleText)).textContent.includes(visibleText),
             calloutLabel: screen.queryByText("Note")?.textContent,
         }).toEqual({ blockquoteIncludesText: true, fallbackIsVisible: true, calloutLabel: undefined });
+    });
+
+    it("gives ordinary quotations a distinct editorial treatment", () => {
+        const { container } = render(<MarkdownContent content="> A considered observation." />);
+        const blockquote = container.querySelector("blockquote");
+        const quoteMark = blockquote?.querySelector('[aria-hidden="true"]');
+
+        expect({
+            keepsBlockquoteSemantics: blockquote?.tagName,
+            usesEditorialRules:
+                blockquote?.classList.contains("border-y") && blockquote.classList.contains("border-border-light"),
+            usesEditorialLayout: blockquote?.classList.contains("grid"),
+            hasDecorativeQuoteMark: quoteMark?.textContent?.trim(),
+            avoidsTintedPanel: blockquote?.classList.contains("bg-primary-light"),
+            avoidsHeavySideRule: blockquote?.classList.contains("border-l-4"),
+        }).toEqual({
+            keepsBlockquoteSemantics: "BLOCKQUOTE",
+            usesEditorialRules: true,
+            usesEditorialLayout: true,
+            hasDecorativeQuoteMark: "“",
+            avoidsTintedPanel: false,
+            avoidsHeavySideRule: false,
+        });
     });
 
     it("does not convert a nested callout attempt", () => {
@@ -180,16 +208,7 @@ describe("MarkdownContent", () => {
             constrainedGrid: callout?.classList.contains("min-w-0"),
             clippedChrome: callout?.classList.contains("overflow-hidden"),
             wrappingBody: content?.lastElementChild?.classList.contains("[overflow-wrap:anywhere]"),
-            matchesTitleSize: content?.lastElementChild?.classList.contains("text-sm"),
-            keepsParagraphsCompact: content?.lastElementChild?.classList.contains("[&_p]:text-sm"),
-        }).toEqual({
-            readableMeasure: true,
-            constrainedGrid: true,
-            clippedChrome: true,
-            wrappingBody: true,
-            matchesTitleSize: true,
-            keepsParagraphsCompact: true,
-        });
+        }).toEqual({ readableMeasure: true, constrainedGrid: true, clippedChrome: true, wrappingBody: true });
     });
 
     it("renders complete callout content in static HTML", () => {

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -115,12 +115,16 @@ describe("MarkdownContent", () => {
             paragraphs: [screen.getByText(/First paragraph/).tagName, screen.getByText(/Second paragraph/).tagName],
             emphasis: screen.getByText("emphasis").tagName,
             link: screen.getByRole("link", { name: "link" }).getAttribute("href"),
+            linkUsesCalloutColor: screen
+                .getByRole("link", { name: "link" })
+                .parentElement?.parentElement?.classList.contains("[&_a]:text-callout-link"),
             code: screen.getByText("code").tagName,
             listItems: screen.getAllByRole("listitem").map((item) => item.textContent),
         }).toEqual({
             paragraphs: ["P", "P"],
             emphasis: "EM",
             link: "https://example.com",
+            linkUsesCalloutColor: true,
             code: "CODE",
             listItems: ["First item", "Second item"],
         });

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -146,6 +146,7 @@ describe("MarkdownContent", () => {
         const { container } = render(<MarkdownContent content="> A considered observation." />);
         const blockquote = container.querySelector("blockquote");
         const quoteMark = blockquote?.querySelector('[aria-hidden="true"]');
+        const quoteText = screen.getByText("A considered observation.");
 
         expect({
             keepsBlockquoteSemantics: blockquote?.tagName,
@@ -153,6 +154,9 @@ describe("MarkdownContent", () => {
                 blockquote?.classList.contains("border-y") && blockquote.classList.contains("border-border-light"),
             usesEditorialLayout: blockquote?.classList.contains("grid"),
             hasDecorativeQuoteMark: quoteMark?.textContent?.trim(),
+            usesBodyTextSize:
+                quoteText.classList.contains("text-base") && quoteText.classList.contains("md:text-[1.0625rem]"),
+            keepsBodyTextUpright: quoteText.parentElement?.classList.contains("italic"),
             avoidsTintedPanel: blockquote?.classList.contains("bg-primary-light"),
             avoidsHeavySideRule: blockquote?.classList.contains("border-l-4"),
         }).toEqual({
@@ -160,6 +164,8 @@ describe("MarkdownContent", () => {
             usesEditorialRules: true,
             usesEditorialLayout: true,
             hasDecorativeQuoteMark: "“",
+            usesBodyTextSize: true,
+            keepsBodyTextUpright: false,
             avoidsTintedPanel: false,
             avoidsHeavySideRule: false,
         });

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -72,20 +72,25 @@ describe("MarkdownContent", () => {
     ])("renders the %s marker as a labeled callout", (marker, label) => {
         const { container } = render(<MarkdownContent content={`> [!${marker}]\n> ${label} body content.`} />);
         const variant = marker.toLowerCase();
+        const icon = screen.getByText(label).previousElementSibling;
         const callout = screen.getByText(label).parentElement?.parentElement?.parentElement;
 
         expect({
             hasLabel: screen.getByText(label).textContent,
             hasBody: screen.getByText(`${label} body content.`).textContent,
             hidesMarker: container.textContent?.includes(`[!${marker}]`),
-            hasVariantBorder: callout?.classList.contains(`border-callout-${variant}`),
+            hasVariantEdge: callout?.classList.contains(`border-l-callout-${variant}`),
             hasVariantSurface: callout?.classList.contains(`bg-callout-${variant}-subtle`),
+            hasSolidIconTile: icon?.classList.contains(`bg-callout-${variant}`),
+            avoidsCardElevation: callout?.classList.contains("shadow-sm"),
         }).toEqual({
             hasLabel: label,
             hasBody: `${label} body content.`,
             hidesMarker: false,
-            hasVariantBorder: true,
+            hasVariantEdge: true,
             hasVariantSurface: true,
+            hasSolidIconTile: true,
+            avoidsCardElevation: false,
         });
     });
 

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -71,12 +71,22 @@ describe("MarkdownContent", () => {
         ["CAUTION", "Caution"],
     ])("renders the %s marker as a labeled callout", (marker, label) => {
         const { container } = render(<MarkdownContent content={`> [!${marker}]\n> ${label} body content.`} />);
+        const variant = marker.toLowerCase();
+        const callout = screen.getByText(label).parentElement?.parentElement?.parentElement;
 
         expect({
             hasLabel: screen.getByText(label).textContent,
             hasBody: screen.getByText(`${label} body content.`).textContent,
             hidesMarker: container.textContent?.includes(`[!${marker}]`),
-        }).toEqual({ hasLabel: label, hasBody: `${label} body content.`, hidesMarker: false });
+            hasVariantBorder: callout?.classList.contains(`border-callout-${variant}`),
+            hasVariantSurface: callout?.classList.contains(`bg-callout-${variant}-subtle`),
+        }).toEqual({
+            hasLabel: label,
+            hasBody: `${label} body content.`,
+            hidesMarker: false,
+            hasVariantBorder: true,
+            hasVariantSurface: true,
+        });
     });
 
     it("preserves Markdown semantics throughout a callout body", () => {

--- a/src/src/components/shared/MarkdownContent.test.tsx
+++ b/src/src/components/shared/MarkdownContent.test.tsx
@@ -72,24 +72,27 @@ describe("MarkdownContent", () => {
     ])("renders the %s marker as a labeled callout", (marker, label) => {
         const { container } = render(<MarkdownContent content={`> [!${marker}]\n> ${label} body content.`} />);
         const variant = marker.toLowerCase();
-        const icon = screen.getByText(label).previousElementSibling;
-        const callout = screen.getByText(label).parentElement?.parentElement?.parentElement;
+        const title = screen.getByText(label);
+        const icon = title.previousElementSibling;
+        const callout = title.parentElement?.parentElement?.parentElement;
 
         expect({
-            hasLabel: screen.getByText(label).textContent,
+            hasLabel: title.textContent,
             hasBody: screen.getByText(`${label} body content.`).textContent,
             hidesMarker: container.textContent?.includes(`[!${marker}]`),
-            hasVariantEdge: callout?.classList.contains(`border-l-callout-${variant}`),
-            hasVariantSurface: callout?.classList.contains(`bg-callout-${variant}-subtle`),
-            hasSolidIconTile: icon?.classList.contains(`bg-callout-${variant}`),
+            hasSharedSurface: callout?.classList.contains("bg-surface-elevated"),
+            hasSharedBorder: callout?.classList.contains("border-border-light"),
+            titleUsesVariantColor: title.classList.contains(`text-callout-${variant}`),
+            iconUsesVariantColor: icon?.classList.contains(`text-callout-${variant}`),
             avoidsCardElevation: callout?.classList.contains("shadow-sm"),
         }).toEqual({
             hasLabel: label,
             hasBody: `${label} body content.`,
             hidesMarker: false,
-            hasVariantEdge: true,
-            hasVariantSurface: true,
-            hasSolidIconTile: true,
+            hasSharedSurface: true,
+            hasSharedBorder: true,
+            titleUsesVariantColor: true,
+            iconUsesVariantColor: true,
             avoidsCardElevation: false,
         });
     });

--- a/src/src/components/shared/MarkdownContent.tsx
+++ b/src/src/components/shared/MarkdownContent.tsx
@@ -88,11 +88,19 @@ function createMarkdownComponents(measure: boolean): Components {
     const MarkdownBlockquote = ({ children }: { children: React.ReactNode }) => (
         <blockquote
             className={mergeClassNames(
-                "mb-6 border-l-4 border-primary bg-primary-light py-3 pl-5 italic text-text-secondary",
+                "mb-8 grid grid-cols-[auto_minmax(0,1fr)] gap-3 border-y border-border-light px-3 py-5 text-text-secondary sm:gap-4 sm:px-4",
                 measureClassName,
             )}
         >
-            {children}
+            <span
+                aria-hidden="true"
+                className="heading-font select-none text-[2.25rem] font-extrabold leading-[0.8] text-brand"
+            >
+                “
+            </span>
+            <div className="min-w-0 italic [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_ol]:text-text-secondary [&_p]:text-text-secondary [&_ul]:text-text-secondary">
+                {children}
+            </div>
         </blockquote>
     );
 

--- a/src/src/components/shared/MarkdownContent.tsx
+++ b/src/src/components/shared/MarkdownContent.tsx
@@ -98,7 +98,7 @@ function createMarkdownComponents(measure: boolean): Components {
             >
                 “
             </span>
-            <div className="min-w-0 italic [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_ol]:text-text-secondary [&_p]:text-text-secondary [&_ul]:text-text-secondary">
+            <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0 [&_ol]:text-text-secondary [&_p]:text-text-secondary [&_ul]:text-text-secondary">
                 {children}
             </div>
         </blockquote>

--- a/src/src/components/shared/MarkdownContent.tsx
+++ b/src/src/components/shared/MarkdownContent.tsx
@@ -23,6 +23,12 @@ import ArticleTableOfContents, {
     ArticleMarkdownLayout,
 } from "@/components/shared/ArticleTableOfContents";
 import { remarkArticleHeadings } from "@/components/shared/articleHeadings";
+import MarkdownCallout from "@/components/shared/MarkdownCallout";
+import {
+    markdownCalloutVariants,
+    remarkMarkdownCallouts,
+    type MarkdownCalloutVariant,
+} from "@/components/shared/markdownCallouts";
 import { Separator } from "@/components/shared/primitives/Separator";
 import type { Element } from "hast";
 import type { PluggableList } from "unified";
@@ -56,6 +62,14 @@ function getHeadingLabel(node?: Element): string {
     return typeof label === "string" ? label : "";
 }
 
+function getCalloutVariant(node?: Element): MarkdownCalloutVariant | null {
+    const variant = node?.properties["data-callout-variant"];
+
+    return typeof variant === "string" && markdownCalloutVariants.includes(variant as MarkdownCalloutVariant)
+        ? (variant as MarkdownCalloutVariant)
+        : null;
+}
+
 function MarkdownHeadingContent({ children, id, node }: { children: React.ReactNode; id?: string; node?: Element }) {
     if (!id) {
         return <>{children}</>;
@@ -71,6 +85,16 @@ function MarkdownHeadingContent({ children, id, node }: { children: React.ReactN
 
 function createMarkdownComponents(measure: boolean): Components {
     const measureClassName = measure ? contentWidthStyles.readable : undefined;
+    const MarkdownBlockquote = ({ children }: { children: React.ReactNode }) => (
+        <blockquote
+            className={mergeClassNames(
+                "mb-6 border-l-4 border-primary bg-primary-light py-3 pl-5 italic text-text-secondary",
+                measureClassName,
+            )}
+        >
+            {children}
+        </blockquote>
+    );
 
     return {
         h1: ({ children, id, node }) => (
@@ -121,16 +145,7 @@ function createMarkdownComponents(measure: boolean): Components {
         ul: ({ children }) => <UnorderedList className={measureClassName}>{children}</UnorderedList>,
         ol: ({ children }) => <OrderedList className={measureClassName}>{children}</OrderedList>,
         li: ({ children }) => <ListItem>{children}</ListItem>,
-        blockquote: ({ children }) => (
-            <blockquote
-                className={mergeClassNames(
-                    "mb-6 border-l-4 border-primary bg-primary-light py-3 pl-5 italic text-text-secondary",
-                    measureClassName,
-                )}
-            >
-                {children}
-            </blockquote>
-        ),
+        blockquote: MarkdownBlockquote,
         code: ({ children, className }) => <CodeSnippet className={className}>{children}</CodeSnippet>,
         pre: ({ children }) => <MarkdownCodeBlock>{children}</MarkdownCodeBlock>,
         a: ({ href, children }) => <NewTabLink url={href ?? ""}>{children}</NewTabLink>,
@@ -157,6 +172,17 @@ function createMarkdownComponents(measure: boolean): Components {
             "article-markdown-layout": ArticleMarkdownLayout,
             "article-markdown-body": ArticleMarkdownBody,
             "article-table-of-contents": ArticleTableOfContents,
+            "markdown-callout": ({ children, node }: { children: React.ReactNode; node?: Element }) => {
+                const variant = getCalloutVariant(node);
+
+                return variant ? (
+                    <MarkdownCallout className={measureClassName} variant={variant}>
+                        {children}
+                    </MarkdownCallout>
+                ) : (
+                    <MarkdownBlockquote>{children}</MarkdownBlockquote>
+                );
+            },
         } as unknown as Components),
     };
 }
@@ -168,8 +194,8 @@ export default function MarkdownContent({
     articleNavigation = false,
 }: MarkdownContentProps) {
     const remarkPlugins: PluggableList = articleNavigation
-        ? [remarkGfm, [remarkArticleHeadings, { tableOfContents: true }]]
-        : [remarkGfm];
+        ? [remarkGfm, remarkMarkdownCallouts, [remarkArticleHeadings, { tableOfContents: true }]]
+        : [remarkGfm, remarkMarkdownCallouts];
 
     return (
         <div className={mergeClassNames("w-full", className)}>

--- a/src/src/components/shared/markdownCallouts.ts
+++ b/src/src/components/shared/markdownCallouts.ts
@@ -1,0 +1,68 @@
+import type { Blockquote, Paragraph, Root, Text } from "mdast";
+
+export const markdownCalloutVariants = ["note", "tip", "important", "warning", "caution"] as const;
+
+export type MarkdownCalloutVariant = (typeof markdownCalloutVariants)[number];
+
+const calloutMarkerPattern = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\](?:\n|$)/;
+
+function getCalloutMarker(
+    blockquote: Blockquote,
+): { paragraph: Paragraph; text: Text; variant: MarkdownCalloutVariant; remainingText: string } | null {
+    const firstChild = blockquote.children[0];
+    const firstContent = firstChild?.type === "paragraph" ? firstChild.children[0] : undefined;
+
+    if (firstContent?.type !== "text") {
+        return null;
+    }
+
+    const marker = calloutMarkerPattern.exec(firstContent.value);
+
+    if (!marker) {
+        return null;
+    }
+
+    return {
+        paragraph: firstChild,
+        text: firstContent,
+        variant: marker[1].toLowerCase() as MarkdownCalloutVariant,
+        remainingText: firstContent.value.slice(marker[0].length),
+    };
+}
+
+function removeMarker(blockquote: Blockquote, paragraph: Paragraph, text: Text, remainingText: string): void {
+    if (remainingText) {
+        text.value = remainingText;
+        return;
+    }
+
+    paragraph.children = paragraph.children.filter((child) => child !== text);
+
+    if (paragraph.children.length === 0) {
+        blockquote.children = blockquote.children.filter((child) => child !== paragraph);
+    }
+}
+
+export function remarkMarkdownCallouts() {
+    return (tree: Root): void => {
+        tree.children.forEach((node) => {
+            if (node.type !== "blockquote") {
+                return;
+            }
+
+            const callout = getCalloutMarker(node);
+
+            if (!callout) {
+                return;
+            }
+
+            removeMarker(node, callout.paragraph, callout.text, callout.remainingText);
+
+            node.data = {
+                ...node.data,
+                hName: "markdown-callout",
+                hProperties: { ...node.data?.hProperties, "data-callout-variant": callout.variant },
+            };
+        });
+    };
+}

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -91,15 +91,10 @@
     --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
     --color-info: var(--color-brand);
     --color-callout-note: oklch(48% 0.18 258);
-    --color-callout-note-subtle: oklch(96.5% 0.04 258);
     --color-callout-tip: oklch(43% 0.14 145);
-    --color-callout-tip-subtle: oklch(96.5% 0.05 145);
-    --color-callout-important: oklch(43% 0.13 205);
-    --color-callout-important-subtle: oklch(96.5% 0.05 205);
+    --color-callout-important: oklch(47% 0.18 305);
     --color-callout-warning: oklch(45% 0.13 75);
-    --color-callout-warning-subtle: oklch(96.5% 0.06 85);
     --color-callout-caution: oklch(48% 0.2 25);
-    --color-callout-caution-subtle: oklch(96.5% 0.04 25);
 
     /* Gradients */
     --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
@@ -175,15 +170,10 @@
     --color-ring: var(--color-brand);
     --color-ring-muted: var(--color-border-strong);
     --color-callout-note: oklch(74% 0.14 252);
-    --color-callout-note-subtle: oklch(24% 0.055 258);
     --color-callout-tip: oklch(76% 0.13 145);
-    --color-callout-tip-subtle: oklch(23.5% 0.05 145);
-    --color-callout-important: oklch(78% 0.12 205);
-    --color-callout-important-subtle: oklch(24% 0.05 205);
+    --color-callout-important: oklch(76% 0.16 305);
     --color-callout-warning: oklch(80% 0.14 78);
-    --color-callout-warning-subtle: oklch(25% 0.055 80);
     --color-callout-caution: oklch(72% 0.19 25);
-    --color-callout-caution-subtle: oklch(24.5% 0.055 25);
 
     --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.36), 0 12px 30px -26px oklch(72% 0.15 252 / 0.5);
     --shadow-card-hover: 0 22px 42px -28px oklch(0% 0 0 / 0.68), 0 12px 28px -22px oklch(77% 0.13 188 / 0.34);

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -91,10 +91,15 @@
     --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
     --color-info: var(--color-brand);
     --color-callout-note: oklch(48% 0.18 258);
-    --color-callout-tip: oklch(43% 0.12 162);
-    --color-callout-important: oklch(42% 0.11 188);
-    --color-callout-warning: oklch(45% 0.12 70);
+    --color-callout-note-subtle: oklch(96.5% 0.04 258);
+    --color-callout-tip: oklch(43% 0.14 145);
+    --color-callout-tip-subtle: oklch(96.5% 0.05 145);
+    --color-callout-important: oklch(43% 0.13 205);
+    --color-callout-important-subtle: oklch(96.5% 0.05 205);
+    --color-callout-warning: oklch(45% 0.13 75);
+    --color-callout-warning-subtle: oklch(96.5% 0.06 85);
     --color-callout-caution: oklch(48% 0.2 25);
+    --color-callout-caution-subtle: oklch(96.5% 0.04 25);
 
     /* Gradients */
     --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
@@ -170,10 +175,15 @@
     --color-ring: var(--color-brand);
     --color-ring-muted: var(--color-border-strong);
     --color-callout-note: oklch(74% 0.14 252);
-    --color-callout-tip: oklch(76% 0.13 162);
-    --color-callout-important: oklch(78% 0.12 188);
+    --color-callout-note-subtle: oklch(24% 0.055 258);
+    --color-callout-tip: oklch(76% 0.13 145);
+    --color-callout-tip-subtle: oklch(23.5% 0.05 145);
+    --color-callout-important: oklch(78% 0.12 205);
+    --color-callout-important-subtle: oklch(24% 0.05 205);
     --color-callout-warning: oklch(80% 0.14 78);
+    --color-callout-warning-subtle: oklch(25% 0.055 80);
     --color-callout-caution: oklch(72% 0.19 25);
+    --color-callout-caution-subtle: oklch(24.5% 0.055 25);
 
     --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.36), 0 12px 30px -26px oklch(72% 0.15 252 / 0.5);
     --shadow-card-hover: 0 22px 42px -28px oklch(0% 0 0 / 0.68), 0 12px 28px -22px oklch(77% 0.13 188 / 0.34);

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -90,6 +90,11 @@
     --color-warning: oklch(76.9% 0.188 70.08); /* amber-500 */
     --color-error: oklch(63.7% 0.237 25.331); /* red-500 */
     --color-info: var(--color-brand);
+    --color-callout-note: oklch(48% 0.18 258);
+    --color-callout-tip: oklch(43% 0.12 162);
+    --color-callout-important: oklch(42% 0.11 188);
+    --color-callout-warning: oklch(45% 0.12 70);
+    --color-callout-caution: oklch(48% 0.2 25);
 
     /* Gradients */
     --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
@@ -164,6 +169,11 @@
     --color-muted-foreground: var(--color-text-muted);
     --color-ring: var(--color-brand);
     --color-ring-muted: var(--color-border-strong);
+    --color-callout-note: oklch(74% 0.14 252);
+    --color-callout-tip: oklch(76% 0.13 162);
+    --color-callout-important: oklch(78% 0.12 188);
+    --color-callout-warning: oklch(80% 0.14 78);
+    --color-callout-caution: oklch(72% 0.19 25);
 
     --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.36), 0 12px 30px -26px oklch(72% 0.15 252 / 0.5);
     --shadow-card-hover: 0 22px 42px -28px oklch(0% 0 0 / 0.68), 0 12px 28px -22px oklch(77% 0.13 188 / 0.34);

--- a/src/src/globals.css
+++ b/src/src/globals.css
@@ -95,6 +95,7 @@
     --color-callout-important: oklch(47% 0.18 305);
     --color-callout-warning: oklch(45% 0.13 75);
     --color-callout-caution: oklch(48% 0.2 25);
+    --color-callout-link: oklch(54% 0.19 258);
 
     /* Gradients */
     --gradient-brand: linear-gradient(135deg, var(--color-brand) 0%, var(--color-accent) 100%);
@@ -174,6 +175,7 @@
     --color-callout-important: oklch(76% 0.16 305);
     --color-callout-warning: oklch(80% 0.14 78);
     --color-callout-caution: oklch(72% 0.19 25);
+    --color-callout-link: var(--color-brand);
 
     --shadow-card: 0 1px 2px 0 oklch(0% 0 0 / 0.36), 0 12px 30px -26px oklch(72% 0.15 252 / 0.5);
     --shadow-card-hover: 0 22px 42px -28px oklch(0% 0 0 / 0.68), 0 12px 28px -22px oklch(77% 0.13 188 / 0.34);

--- a/src/src/pages/MarkdownCalloutsShowcasePage.tsx
+++ b/src/src/pages/MarkdownCalloutsShowcasePage.tsx
@@ -1,0 +1,46 @@
+import MarkdownContent from "@/components/shared/MarkdownContent";
+import { Heading1, Text } from "@/components/shared/typography";
+
+const showcaseMarkdown = `
+> [!NOTE]
+> Useful context can include \`inline code\` and **strong emphasis**.
+>
+> A second paragraph confirms that longer callouts keep a comfortable reading rhythm.
+
+> [!TIP]
+> A practical suggestion can include a short checklist:
+>
+> - Keep the marker on its own line.
+> - Write the body with normal Markdown.
+
+> [!IMPORTANT]
+> Read the [Markdown rendering specification](https://example.com/docs/markdown-rendering/with/a/deliberately/long/path/that/needs/to/wrap) before changing the shared pipeline.
+
+> [!WARNING]
+> Review *theme contrast* and narrow layouts before publishing VeryLongUnbrokenCalloutContentThatMustWrapWithoutForcingPageLevelHorizontalScrolling1234567890.
+
+> [!CAUTION]
+> Raw HTML and nested callouts are intentionally outside this authoring contract.
+
+> This remains an ordinary quotation and keeps the existing italic treatment.
+
+> [!ALERT]
+> Unsupported markers stay visible as ordinary blockquote content.
+
+> [!NOTE] A marker with content on the same line is malformed and also stays visible.
+`.trim();
+
+export default function MarkdownCalloutsShowcasePage() {
+    return (
+        <>
+            <title>Markdown Callouts Showcase - Development</title>
+            <section className="py-8 md:py-10">
+                <Heading1 className="mb-4">Markdown callouts</Heading1>
+                <Text className="mb-8 max-w-[72ch]">
+                    Development-only review surface for every supported callout and its fallback states.
+                </Text>
+                <MarkdownContent content={showcaseMarkdown} measure />
+            </section>
+        </>
+    );
+}

--- a/src/src/pages/MarkdownCalloutsShowcasePage.tsx
+++ b/src/src/pages/MarkdownCalloutsShowcasePage.tsx
@@ -22,7 +22,7 @@ const showcaseMarkdown = `
 > [!CAUTION]
 > Raw HTML and nested callouts are intentionally outside this authoring contract.
 
-> This remains an ordinary quotation and keeps the existing italic treatment.
+> This remains an ordinary quotation and uses the editorial quote treatment.
 
 > [!ALERT]
 > Unsupported markers stay visible as ordinary blockquote content.
@@ -37,7 +37,8 @@ export default function MarkdownCalloutsShowcasePage() {
             <section className="py-8 md:py-10">
                 <Heading1 className="mb-4">Markdown callouts</Heading1>
                 <Text className="mb-8 max-w-[72ch]">
-                    Development-only review surface for every supported callout and its fallback states.
+                    Development-only review surface for every supported callout, ordinary quotations, and fallback
+                    states.
                 </Text>
                 <MarkdownContent content={showcaseMarkdown} measure />
             </section>

--- a/src/src/routes.test.tsx
+++ b/src/src/routes.test.tsx
@@ -1,0 +1,22 @@
+import { matchRoutes } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { createRoutes, getStaticRoutes, markdownCalloutsShowcasePath } from "./routes";
+
+describe("routes", () => {
+    it("includes the Markdown callout showcase in development", () => {
+        const developmentRoute = createRoutes(true).find((route) => route.path === markdownCalloutsShowcasePath);
+
+        expect(developmentRoute).toBeTruthy();
+    });
+
+    it("routes the Markdown callout showcase to not found in production", () => {
+        const matches = matchRoutes(createRoutes(false), markdownCalloutsShowcasePath);
+
+        expect(matches?.at(-1)?.route.path).toBe("*");
+    });
+
+    it("excludes the Markdown callout showcase from static routes", () => {
+        expect(getStaticRoutes()).not.toContain(markdownCalloutsShowcasePath);
+    });
+});

--- a/src/src/routes.tsx
+++ b/src/src/routes.tsx
@@ -1,4 +1,5 @@
-import { RouteObject } from "react-router";
+import { lazy, Suspense } from "react";
+import type { RouteObject } from "react-router";
 import { getArticleSlugs } from "@/core/articles";
 import HomePage from "@/pages/HomePage";
 import AboutPage from "@/pages/AboutPage";
@@ -6,13 +7,38 @@ import ArticlesPage from "@/pages/ArticlesPage";
 import ArticlePage from "@/pages/ArticlePage";
 import NotFoundPage from "@/pages/NotFoundPage";
 
-export const routes: RouteObject[] = [
-    { path: "/", element: <HomePage /> },
-    { path: "/about", element: <AboutPage /> },
-    { path: "/articles", element: <ArticlesPage /> },
-    { path: "/articles/:slug", element: <ArticlePage /> },
-    { path: "*", element: <NotFoundPage /> },
-];
+export const markdownCalloutsShowcasePath = "/_dev/markdown-callouts";
+
+const MarkdownCalloutsShowcasePage = import.meta.env.DEV
+    ? lazy(() => import("@/pages/MarkdownCalloutsShowcasePage"))
+    : null;
+
+export function createRoutes(includeDevelopmentRoutes: boolean): RouteObject[] {
+    const developmentRoutes =
+        includeDevelopmentRoutes && MarkdownCalloutsShowcasePage
+            ? [
+                  {
+                      path: markdownCalloutsShowcasePath,
+                      element: (
+                          <Suspense fallback={null}>
+                              <MarkdownCalloutsShowcasePage />
+                          </Suspense>
+                      ),
+                  },
+              ]
+            : [];
+
+    return [
+        { path: "/", element: <HomePage /> },
+        { path: "/about", element: <AboutPage /> },
+        { path: "/articles", element: <ArticlesPage /> },
+        { path: "/articles/:slug", element: <ArticlePage /> },
+        ...developmentRoutes,
+        { path: "*", element: <NotFoundPage /> },
+    ];
+}
+
+export const routes = createRoutes(import.meta.env.DEV);
 
 export const getStaticRoutes = (): string[] => [
     "/",

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -73,6 +73,7 @@ export default {
                     important: "var(--color-callout-important)",
                     warning: "var(--color-callout-warning)",
                     caution: "var(--color-callout-caution)",
+                    link: "var(--color-callout-link)",
                 },
             },
             backgroundImage: {

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -69,10 +69,15 @@ export default {
                 info: "var(--color-info)",
                 callout: {
                     note: "var(--color-callout-note)",
+                    "note-subtle": "var(--color-callout-note-subtle)",
                     tip: "var(--color-callout-tip)",
+                    "tip-subtle": "var(--color-callout-tip-subtle)",
                     important: "var(--color-callout-important)",
+                    "important-subtle": "var(--color-callout-important-subtle)",
                     warning: "var(--color-callout-warning)",
+                    "warning-subtle": "var(--color-callout-warning-subtle)",
                     caution: "var(--color-callout-caution)",
+                    "caution-subtle": "var(--color-callout-caution-subtle)",
                 },
             },
             backgroundImage: {

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -69,15 +69,10 @@ export default {
                 info: "var(--color-info)",
                 callout: {
                     note: "var(--color-callout-note)",
-                    "note-subtle": "var(--color-callout-note-subtle)",
                     tip: "var(--color-callout-tip)",
-                    "tip-subtle": "var(--color-callout-tip-subtle)",
                     important: "var(--color-callout-important)",
-                    "important-subtle": "var(--color-callout-important-subtle)",
                     warning: "var(--color-callout-warning)",
-                    "warning-subtle": "var(--color-callout-warning-subtle)",
                     caution: "var(--color-callout-caution)",
-                    "caution-subtle": "var(--color-callout-caution-subtle)",
                 },
             },
             backgroundImage: {

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -67,6 +67,13 @@ export default {
                 warning: "var(--color-warning)",
                 error: "var(--color-error)",
                 info: "var(--color-info)",
+                callout: {
+                    note: "var(--color-callout-note)",
+                    tip: "var(--color-callout-tip)",
+                    important: "var(--color-callout-important)",
+                    warning: "var(--color-callout-warning)",
+                    caution: "var(--color-callout-caution)",
+                },
             },
             backgroundImage: {
                 "gradient-brand": "var(--gradient-brand)",


### PR DESCRIPTION
## Summary

- add a typed remark transform for the five GitHub-compatible callout markers while preserving ordinary and malformed blockquotes
- render labeled, theme-aware callouts on one quiet neutral surface, with distinct blue, green, violet, amber, and red icon/title accents, unique icons, standard article sizing, responsive wrapping, and no live-region semantics
- modernize ordinary blockquotes with an editorial opening mark, subtle horizontal hairlines, and the same responsive upright typography as surrounding body text
- add a development-only `/_dev/markdown-callouts` showcase for every callout, ordinary quotations, and fallback state, while keeping it out of the production route table and build output
- cover marker variants, rich body Markdown, fallback cases, nested attempts, visual treatment, accessibility semantics, SSR output, responsive containment, and route exclusion
- document the authoring contract, callout and blockquote presentation, accessibility behavior, theme contrast checks, and development showcase

## Why

`MarkdownContent` previously rendered every blockquote as the same tinted quotation, so callout markers were exposed as article text and authors had no safe, portable way to emphasize notes, tips, important information, warnings, or cautions. This keeps the existing Markdown pipeline, adds no dependency, gives callouts a light color-accessible hierarchy, and makes ordinary quotations distinct through a restrained editorial treatment.

Closes #213

## Validation

- `npm run format:check` ✅
- `npm run lint` ✅ (one pre-existing warning remains in `ChevronToggleButton.tsx`)
- `npm run test` ✅ (34 files, 214 tests)
- `npm run build` ✅
- `npm run accessibility` ✅ (all four configured routes; GitHub Lighthouse check also passes)
- preview smoke suite ✅
- verified no showcase path, text, HTML, or asset is present in the production `dist` output ✅
- manually reviewed all callouts, quotations, and fallback states in light and dark themes at 320px, 768px, and 1440px, plus 400%-equivalent reflow ✅
- verified long links, inline code, lists, multiple paragraphs, and unbroken content wrap without clipping, collision, or page-level horizontal overflow ✅
