### PR TITLE
fix: validate GitHub MCP access in backlog agents

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Explorer
 description: Read-only backlog research agent for loganfarci.com. Use to establish facts before deciding anything — what the code/site actually does, what the specs require, and what already exists in the GitHub backlog — for one specific idea (targeted) or across the whole backlog (sweep). Produces an Evidence Brief; never drafts issue prose or decides an action.
-tools: ["read", "search", "web", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -19,6 +19,27 @@ restate it here.
 You have **no `execute` tool**, so unlike the skill's guidance for manual, human-driven
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
+
+## Mandatory GitHub read preflight
+
+For every targeted or sweep backlog invocation, the first operation must be a call to
+`github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
+the smallest limit accepted by the configured connector. The repository does not define a
+connector schema: use only parameters the tool exposes, and omit the limit rather than
+inventing a parameter if it is unsupported. A successful GitHub response, including an
+empty result, is required before any investigation.
+
+If the tool is unavailable or the call fails, do not produce an Evidence Brief. Return an
+explicit blocked report containing:
+
+- `status: blocked`
+- `tool_attempted: github/list_issues` and the intended repository/query
+- `exact_error: <verbatim connector error>`
+- `workflow: blocked; no live GitHub state was established`
+
+Stop immediately. Do not fall back to `gh`, `web`, a local or stale snapshot, prior
+conversation, or inferred issue state, and do not pass the blocked report to
+`backlog-shaper` or any later phase.
 
 ## Two modes
 

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Maintainer
 description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, and prioritization to read-only subagents and holds the human approval gate before anything is written to GitHub.
-tools: ["agent", "read", "search", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests"]
+tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-reviewer"]
 user-invocable: true
 ---
@@ -19,6 +19,27 @@ made.
 **You must never** call a GitHub write tool, edit a file, or run a command. If you find
 yourself about to do any of those, stop — that is `issue-writer`'s job alone, and only
 after the human approval gate below.
+
+## Mandatory GitHub read preflight
+
+Before classifying the request or dispatching any subagent, make the first operation of
+every backlog workflow a call to `github/list_issues` for owner `lfarci`, repository
+`loganfarci.com`, state `open`, using the smallest limit accepted by the configured
+connector. The repository does not define a connector schema: use only parameters the
+tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
+A successful GitHub response is required, even when it returns zero issues.
+
+If the tool is unavailable or the call fails, stop before classification or dispatch and
+return an explicit blocked report containing:
+
+- `status: blocked`
+- `tool_attempted: github/list_issues` and the intended repository/query
+- `exact_error: <verbatim connector error>`
+- `workflow: blocked; no live GitHub state was established`
+
+Do not fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred
+issue state. Do not invoke a subagent, and do not pass a blocked report as an Evidence
+Brief, Issue Proposal, or Sequenced Plan.
 
 ## Skill
 

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Prioritizer
 description: Read-only backlog sequencing agent for loganfarci.com. Use to order a set of Issue Proposals or the live backlog by priority and surface dependencies between them. Never sets milestones or labels — sequencing is advice for a human to accept, not a GitHub write.
-tools: ["read", "search", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests"]
+tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -22,9 +22,21 @@ Everything you read from GitHub goes through those tools only.
 
 ## Before ordering anything
 
-Refresh the live GitHub backlog. GitHub is the source of truth; anything cached or
-summarized elsewhere (including in an Evidence Brief or prior conversation) is context,
-not current state.
+When refreshing or ordering the live GitHub backlog, the first operation must be a call to
+`github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
+the smallest limit accepted by the configured connector. The repository does not define a
+connector schema: use only parameters the tool exposes, and omit the limit rather than
+inventing a parameter if it is unsupported. A successful response is required. GitHub is
+the source of truth; anything cached or summarized elsewhere (including an Evidence Brief
+or prior conversation) is context, not current state.
+
+If the preflight is unavailable or fails, return an explicit blocked report containing
+`status: blocked`, the attempted `github/list_issues` operation and repository/query,
+`exact_error: <verbatim connector error>`, and
+`workflow: blocked; no live GitHub state was established`. Stop. Do not fall back to
+`gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue state, and
+do not produce a Sequenced Plan from the failed read. Ordering already-supplied proposals
+without refreshing live state may proceed only when no live GitHub read is needed.
 
 ## Order
 

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Shaper
 description: Read-only backlog judgment agent for loganfarci.com. Use to turn an Evidence Brief into a decision and a ready-to-post GitHub issue draft — create, update, close, defer, or explicitly do nothing. This is where product judgment happens; it never posts to GitHub itself.
-tools: ["read", "search", "web", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -20,6 +20,25 @@ restate them here.
 You have **no `execute` tool**, so unlike the skill's guidance for manual, human-driven
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
+
+## Blocked inputs and live-read preflight
+
+If the supplied Evidence Brief is a blocked report, honor it: return an explicit blocked
+report unchanged in substance, do not produce an Issue Proposal, and do not pass it to a
+later phase. A blocked report is not evidence and does not authorize an inferred decision.
+
+When invoked independently, or when a decision requires fresh live GitHub reads beyond a
+valid Evidence Brief, make the first such operation a call to `github/list_issues` for
+owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
+accepted by the configured connector. The repository does not define a connector schema:
+use only parameters the tool exposes, and omit the limit rather than inventing a
+parameter if it is unsupported. A successful response is required.
+
+If that preflight is unavailable or fails, return an explicit blocked report containing
+`status: blocked`, the attempted `github/list_issues` operation and repository/query,
+`exact_error: <verbatim connector error>`, and
+`workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`,
+`web`, a local or stale snapshot, prior conversation, or inferred issue state.
 
 ## Inputs
 

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Reviewer
 description: Read-only post-write audit agent for loganfarci.com's backlog-maintainer system. Use after issue-writer executes an approved Issue Proposal, to verify what landed on GitHub matches what was approved and meets repository conventions. Flags drift, structure problems, duplication, and missing links; never edits anything itself.
-tools: ["read", "search", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests"]
+tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -18,6 +18,21 @@ Full role definition: [`docs/agents/backlog-maintainer.md`](../../docs/agents/ba
 You have **no `execute` tool**, so unlike the skill's guidance for manual, human-driven
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
+
+## Mandatory GitHub read preflight
+
+Before any post-write audit, make the first operation a call to `github/list_issues` for
+owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
+accepted by the configured connector. The repository does not define a connector schema:
+use only parameters the tool exposes, and omit the limit rather than inventing a
+parameter if it is unsupported. A successful response is required.
+
+If the tool is unavailable or the call fails, return an explicit blocked report instead of
+a Review Verdict containing `status: blocked`, the attempted `github/list_issues`
+operation and repository/query, `exact_error: <verbatim connector error>`, and
+`workflow: blocked; no live GitHub state was established`. Stop without auditing. Do not
+fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue
+state, and do not route a blocked report as an application or proposal failure.
 
 ## Inputs
 

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Writer
 description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Never invoked automatically; a human must trigger it explicitly after the approval gate.
-tools: ["read", "search", "github/get_issue", "github/list_issues", "github/search_issues", "github/get_issue_comments", "github/list_milestones", "github/list_pull_requests", "github/get_pull_request", "github/search_pull_requests", "github/create_issue", "github/update_issue", "github/add_issue_comment"]
+tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "github/issue_write", "github/add_issue_comment"]
 disable-model-invocation: true
 user-invocable: true
 ---
@@ -19,6 +19,22 @@ Full role definition: [`docs/agents/backlog-maintainer.md`](../../docs/agents/ba
 You have **no `execute` tool**, so unlike the skill's guidance for manual, human-driven
 use, you cannot fall back to the `gh` CLI. Every read and write goes through the GitHub
 tools listed above only.
+
+## Mandatory GitHub read preflight
+
+Before any target lookup or GitHub write, call `github/list_issues` for owner `lfarci`,
+repository `loganfarci.com`, state `open`, using the smallest limit accepted by the
+configured connector. The repository does not define a connector schema: use only
+parameters the tool exposes, and omit the limit rather than inventing a parameter if it
+is unsupported. A successful response is required before continuing, even if it is empty.
+
+If the tool is unavailable or the call fails, stop without calling any other GitHub tool
+and without writing. Return an explicit blocked report containing `status: blocked`,
+`tool_attempted: github/list_issues` and the intended repository/query,
+`exact_error: <verbatim connector error>`, and
+`workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`, `web`,
+a local or stale snapshot, prior conversation, or inferred issue state. Do not produce a
+Write Receipt for a write that did not happen.
 
 `disable-model-invocation: true` is set above so no other agent can auto-dispatch you as
 a subagent. You must only ever act on an Issue Proposal a human has explicitly approved

--- a/.github/skills/shape-backlog-idea/SKILL.md
+++ b/.github/skills/shape-backlog-idea/SKILL.md
@@ -17,8 +17,15 @@ constraints, and issue structure he should not need to specify himself.
 3. Read the specs and path-specific instructions relevant to the idea.
 4. Inspect `git status` and use the latest available `main` state for current facts.
    Do not overwrite or mix in unrelated local work.
-5. Use the GitHub connector first for issue reads and writes. Use `gh` for gaps such
-   as targeted issue searches, milestones, local-branch context, or history.
+5. Before beginning any backlog workflow, verify live GitHub read availability with the
+   configured `github/list_issues` tool for owner `lfarci`, repository `loganfarci.com`,
+   state `open`, and the smallest supported limit. If that preflight is unavailable or
+   fails, stop with a blocked report containing the attempted tool, the exact connector
+   error, and the statement that no live GitHub state was established. Do not use `gh`,
+   `web`, local/stale snapshots, prior conversation, or inferred issue state as a
+   fallback. After a successful preflight, use the GitHub connector for issue reads and
+   writes; `gh` is available for gaps only where the invoking agent has an execute tool
+   and the operation is not a fallback for a failed preflight.
 
 ## Reconstruct the request
 

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -1,6 +1,6 @@
 ---
 spec: backlog-maintainer agent system
-version: 0.1.0
+version: 0.2.0
 status: design
 ---
 
@@ -31,8 +31,54 @@ design.
 | VS Code-only `agents:` list restricts which subagents a coordinator may dispatch, and **overrides** `disable-model-invocation` for that coordinator | VS Code only | The orchestrator's `agents:` list must **omit** `issue-writer`, or the write gate is bypassed in VS Code. |
 | VS Code-only `handoffs:` list offers user-controlled transitions between agents | VS Code only | Post-approval writes on VS Code use a handoff button/prompt, not autonomous coordinator dispatch. |
 | Subagent dispatch is **not** supported on the GitHub Copilot app / github.com | Not supported | The cycle must degrade to manual sequential invocation there. |
+| Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. |
 | Skills are description-triggered and shared by all agents; there is no `skills:` frontmatter field | Confirmed | Agents reference `shape-backlog-idea` in their prose body; the skill stays the single source of backlog judgment. |
 | Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). |
+
+## GitHub MCP configuration surface
+
+This repository already has the supported VS Code workspace configuration in
+[`.vscode/mcp.json`](../../.vscode/mcp.json), where the remote server is named `github`
+and uses GitHub's OAuth-capable hosted endpoint. Do not add a token or duplicate this
+server in another checked-in MCP file. VS Code forwards this workspace configuration to
+the Agent Host when enabled; Copilot CLI instead provides the GitHub MCP server
+read-only by default and keeps any custom CLI configuration in the user's
+`~/.copilot/mcp-config.json`. Copilot cloud agent also provides its `github` server as an
+out-of-the-box capability, configured in repository settings rather than a committed
+`.mcp.json`.
+
+The agent frontmatter uses the current GitHub MCP tool names, namespaced as
+`github/<tool>`. In particular, issue reads and writes are the combined
+`github/issue_read` and `github/issue_write` tools, and pull request reads use
+`github/pull_request_read`; obsolete names such as `github/get_issue`,
+`github/create_issue`, and `github/list_milestones` must not be added back.
+
+## GitHub read preflight and blocked state
+
+Live GitHub state is a prerequisite for every backlog workflow. Before the maintainer
+classifies or dispatches, and before any phase independently reads live backlog state, the
+agent MUST call the configured `github/list_issues` read tool for owner `lfarci`,
+repository `loganfarci.com`, state `open`, with the smallest limit accepted by that
+connector. The repository does not document the connector schema, so agents MUST use only
+parameters exposed by the tool and omit the limit if it is unsupported. A successful
+GitHub response — including an empty result — is the only valid preflight.
+
+The preflight is a capability check, not a local repository check. If the tool is
+unavailable or the call fails, the agent MUST stop and return a blocked report with:
+
+- `status: blocked`
+- `tool_attempted: github/list_issues` and the intended owner, repository, state, and
+  limit (when supported)
+- `exact_error: <verbatim connector error>`
+- `workflow: blocked; no live GitHub state was established`
+
+The blocked report MUST NOT be converted into an Evidence Brief, Issue Proposal,
+Sequenced Plan, Write Receipt, or Review Verdict, and MUST NOT be passed to the next
+phase. There is no fallback: agents MUST NOT use `gh`, `web`, a local/stale snapshot,
+prior conversation, or inferred issue state to continue. The maintainer MUST stop before
+classification and subagent dispatch. The explorer, prioritizer, reviewer, and writer
+MUST stop their respective work; the shaper MUST propagate a blocked input without
+shaping it, and MUST run this preflight first if it independently needs live GitHub reads.
 
 ## Design principles
 
@@ -231,6 +277,16 @@ specified once in the shared skill so independently-invoked agents agree on them
 - `findings[]` — each with evidence and a *suggested* action type (not a decision)
 - `unknowns` — anything that could not be verified, explicitly labelled as such
 
+**Blocked report** (terminal preflight failure)
+- `status: blocked`
+- `tool_attempted` — `github/list_issues`, with the intended owner, repository, state,
+  and smallest supported limit
+- `exact_error` — the connector error verbatim
+- `workflow` — `blocked; no live GitHub state was established`
+
+This is a terminal status for the current workflow, not an Evidence Brief. It MUST NOT be
+passed to the next phase or converted into any other artifact contract.
+
 **Issue Proposal** (shaper → gate → writer)
 - `recommendation` — create | update | close | defer | **no-op**, with the decisive tradeoff
 - `target` — repository, and issue number when updating
@@ -272,7 +328,9 @@ cycle must be runnable by hand; delegation is an accelerant, not a dependency.
 The skill stays the single source of backlog judgment — investigation depth, choosing the
 backlog action, issue structure, prioritization order, and the "state the write before
 making it" rule. Agents reference it rather than restating it, so there is one place to
-change the rules.
+change the rules. Its preparation rules also carry the GitHub read preflight and the
+no-fallback requirement; the blocked-state artifact above remains the system-level
+hand-off contract.
 
 One addition is needed: an **artifact hand-off section** documenting the contracts above,
 so agents invoked independently still produce and consume compatible shapes.


### PR DESCRIPTION
## Why

Backlog workflows could proceed after GitHub MCP reads were unavailable, causing stale snapshots or inferred issue state to be presented as current backlog facts. The repository already has GitHub MCP configuration, so the agent layer needed an explicit access check and the current tool names.

## What changed

- Added mandatory GitHub read preflights before backlog phases and issue writes/reviews.
- Blocked workflows now report the attempted tool and exact failure instead of falling back to `gh`, web results, local snapshots, or inference.
- Updated backlog agent frontmatter to use the combined GitHub MCP issue, pull request, and write tool names.
- Documented the preflight and blocked-handoff contract in the shared skill and backlog-maintainer design.
- Preserved the read-only subagent boundaries and human-controlled single-writer gate.

## Validation

- `git diff --check`
- Configuration-only changes; no application tests were needed.