### PR TITLE
fix: use supported GitHub issue search tool

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Explorer
 description: Read-only backlog research agent for loganfarci.com. Use to establish facts before deciding anything — what the code/site actually does, what the specs require, and what already exists in the GitHub backlog — for one specific idea (targeted) or across the whole backlog (sweep). Produces an Evidence Brief; never drafts issue prose or decides an action.
-tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -23,7 +23,7 @@ Everything you read from GitHub goes through those tools only.
 ## Mandatory GitHub read preflight
 
 For every targeted or sweep backlog invocation, the first operation must be a call to
-`github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
+`github/search_issues` with the query `repo:lfarci/loganfarci.com is:issue is:open`, using
 the smallest limit accepted by the configured connector. The repository does not define a
 connector schema: use only parameters the tool exposes, and omit the limit rather than
 inventing a parameter if it is unsupported. A successful GitHub response, including an
@@ -33,7 +33,7 @@ If the tool is unavailable or the call fails, do not produce an Evidence Brief. 
 explicit blocked report containing:
 
 - `status: blocked`
-- `tool_attempted: github/list_issues` and the intended repository/query
+- `tool_attempted: github/search_issues` and the intended repository/query
 - `exact_error: <verbatim connector error>`
 - `workflow: blocked; no live GitHub state was established`
 

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Maintainer
 description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, and prioritization to read-only subagents and holds the human approval gate before anything is written to GitHub.
-tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["agent", "read", "search", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-reviewer"]
 user-invocable: true
 ---
@@ -23,17 +23,18 @@ after the human approval gate below.
 ## Mandatory GitHub read preflight
 
 Before classifying the request or dispatching any subagent, make the first operation of
-every backlog workflow a call to `github/list_issues` for owner `lfarci`, repository
-`loganfarci.com`, state `open`, using the smallest limit accepted by the configured
-connector. The repository does not define a connector schema: use only parameters the
-tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
-A successful GitHub response is required, even when it returns zero issues.
+every backlog workflow a call to `github/search_issues` for the query
+`repo:lfarci/loganfarci.com is:issue is:open`, using the smallest limit accepted by the
+configured connector. The repository does not define a connector schema: use only
+parameters the tool exposes, and omit the limit rather than inventing a parameter if it
+is unsupported. A successful GitHub response is required, even when it returns zero
+issues.
 
 If the tool is unavailable or the call fails, stop before classification or dispatch and
 return an explicit blocked report containing:
 
 - `status: blocked`
-- `tool_attempted: github/list_issues` and the intended repository/query
+- `tool_attempted: github/search_issues` and the intended repository/query
 - `exact_error: <verbatim connector error>`
 - `workflow: blocked; no live GitHub state was established`
 

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Prioritizer
 description: Read-only backlog sequencing agent for loganfarci.com. Use to order a set of Issue Proposals or the live backlog by priority and surface dependencies between them. Never sets milestones or labels — sequencing is advice for a human to accept, not a GitHub write.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -23,7 +23,7 @@ Everything you read from GitHub goes through those tools only.
 ## Before ordering anything
 
 When refreshing or ordering the live GitHub backlog, the first operation must be a call to
-`github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
+`github/search_issues` with the query `repo:lfarci/loganfarci.com is:issue is:open`, using
 the smallest limit accepted by the configured connector. The repository does not define a
 connector schema: use only parameters the tool exposes, and omit the limit rather than
 inventing a parameter if it is unsupported. A successful response is required. GitHub is
@@ -31,7 +31,7 @@ the source of truth; anything cached or summarized elsewhere (including an Evide
 or prior conversation) is context, not current state.
 
 If the preflight is unavailable or fails, return an explicit blocked report containing
-`status: blocked`, the attempted `github/list_issues` operation and repository/query,
+`status: blocked`, the attempted `github/search_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Stop. Do not fall back to
 `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue state, and

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Shaper
 description: Read-only backlog judgment agent for loganfarci.com. Use to turn an Evidence Brief into a decision and a ready-to-post GitHub issue draft — create, update, close, defer, or explicitly do nothing. This is where product judgment happens; it never posts to GitHub itself.
-tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -28,14 +28,14 @@ report unchanged in substance, do not produce an Issue Proposal, and do not pass
 later phase. A blocked report is not evidence and does not authorize an inferred decision.
 
 When invoked independently, or when a decision requires fresh live GitHub reads beyond a
-valid Evidence Brief, make the first such operation a call to `github/list_issues` for
-owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
-accepted by the configured connector. The repository does not define a connector schema:
+valid Evidence Brief, make the first such operation a call to `github/search_issues` with
+the query `repo:lfarci/loganfarci.com is:issue is:open`, using the smallest limit accepted
+by the configured connector. The repository does not define a connector schema:
 use only parameters the tool exposes, and omit the limit rather than inventing a
 parameter if it is unsupported. A successful response is required.
 
 If that preflight is unavailable or fails, return an explicit blocked report containing
-`status: blocked`, the attempted `github/list_issues` operation and repository/query,
+`status: blocked`, the attempted `github/search_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`,
 `web`, a local or stale snapshot, prior conversation, or inferred issue state.

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Reviewer
 description: Read-only post-write audit agent for loganfarci.com's backlog-maintainer system. Use after issue-writer executes an approved Issue Proposal, to verify what landed on GitHub matches what was approved and meets repository conventions. Flags drift, structure problems, duplication, and missing links; never edits anything itself.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
 user-invocable: true
 ---
 
@@ -21,14 +21,14 @@ Everything you read from GitHub goes through those tools only.
 
 ## Mandatory GitHub read preflight
 
-Before any post-write audit, make the first operation a call to `github/list_issues` for
-owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
-accepted by the configured connector. The repository does not define a connector schema:
+Before any post-write audit, make the first operation a call to `github/search_issues` with
+the query `repo:lfarci/loganfarci.com is:issue is:open`, using the smallest limit accepted
+by the configured connector. The repository does not define a connector schema:
 use only parameters the tool exposes, and omit the limit rather than inventing a
 parameter if it is unsupported. A successful response is required.
 
 If the tool is unavailable or the call fails, return an explicit blocked report instead of
-a Review Verdict containing `status: blocked`, the attempted `github/list_issues`
+a Review Verdict containing `status: blocked`, the attempted `github/search_issues`
 operation and repository/query, `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Stop without auditing. Do not
 fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Writer
 description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Never invoked automatically; a human must trigger it explicitly after the approval gate.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "github/issue_write", "github/add_issue_comment"]
+tools: ["read", "search", "github/issue_read", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "github/issue_write", "github/add_issue_comment"]
 disable-model-invocation: true
 user-invocable: true
 ---
@@ -22,15 +22,15 @@ tools listed above only.
 
 ## Mandatory GitHub read preflight
 
-Before any target lookup or GitHub write, call `github/list_issues` for owner `lfarci`,
-repository `loganfarci.com`, state `open`, using the smallest limit accepted by the
+Before any target lookup or GitHub write, call `github/search_issues` with the query
+`repo:lfarci/loganfarci.com is:issue is:open`, using the smallest limit accepted by the
 configured connector. The repository does not define a connector schema: use only
 parameters the tool exposes, and omit the limit rather than inventing a parameter if it
 is unsupported. A successful response is required before continuing, even if it is empty.
 
 If the tool is unavailable or the call fails, stop without calling any other GitHub tool
 and without writing. Return an explicit blocked report containing `status: blocked`,
-`tool_attempted: github/list_issues` and the intended repository/query,
+`tool_attempted: github/search_issues` and the intended repository/query,
 `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`, `web`,
 a local or stale snapshot, prior conversation, or inferred issue state. Do not produce a

--- a/.github/skills/shape-backlog-idea/SKILL.md
+++ b/.github/skills/shape-backlog-idea/SKILL.md
@@ -18,12 +18,12 @@ constraints, and issue structure he should not need to specify himself.
 4. Inspect `git status` and use the latest available `main` state for current facts.
    Do not overwrite or mix in unrelated local work.
 5. Before beginning any backlog workflow, verify live GitHub read availability with the
-   configured `github/list_issues` tool for owner `lfarci`, repository `loganfarci.com`,
-   state `open`, and the smallest supported limit. If that preflight is unavailable or
-   fails, stop with a blocked report containing the attempted tool, the exact connector
-   error, and the statement that no live GitHub state was established. Do not use `gh`,
-   `web`, local/stale snapshots, prior conversation, or inferred issue state as a
-   fallback. After a successful preflight, use the GitHub connector for issue reads and
+   configured `github/search_issues` tool with the query
+   `repo:lfarci/loganfarci.com is:issue is:open` and the smallest supported limit. If that
+   preflight is unavailable or fails, stop with a blocked report containing the attempted
+   tool, the exact connector error, and the statement that no live GitHub state was
+   established. Do not use `gh`, `web`, local/stale snapshots, prior conversation, or
+   inferred issue state as a fallback. After a successful preflight, use the GitHub connector for issue reads and
    writes; `gh` is available for gaps only where the invoking agent has an execute tool
    and the operation is not a fallback for a failed preflight.
 

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -49,16 +49,17 @@ out-of-the-box capability, configured in repository settings rather than a commi
 
 The agent frontmatter uses the current GitHub MCP tool names, namespaced as
 `github/<tool>`. In particular, issue reads and writes are the combined
-`github/issue_read` and `github/issue_write` tools, and pull request reads use
-`github/pull_request_read`; obsolete names such as `github/get_issue`,
-`github/create_issue`, and `github/list_milestones` must not be added back.
+`github/issue_read` and `github/issue_write` tools, issue searches use
+`github/search_issues`, and pull request reads use `github/pull_request_read`; obsolete
+names such as `github/get_issue`, `github/create_issue`, and `github/list_milestones` must
+not be added back.
 
 ## GitHub read preflight and blocked state
 
 Live GitHub state is a prerequisite for every backlog workflow. Before the maintainer
 classifies or dispatches, and before any phase independently reads live backlog state, the
-agent MUST call the configured `github/list_issues` read tool for owner `lfarci`,
-repository `loganfarci.com`, state `open`, with the smallest limit accepted by that
+agent MUST call the configured `github/search_issues` read tool with the query
+`repo:lfarci/loganfarci.com is:issue is:open`, using the smallest limit accepted by that
 connector. The repository does not document the connector schema, so agents MUST use only
 parameters exposed by the tool and omit the limit if it is unsupported. A successful
 GitHub response — including an empty result — is the only valid preflight.
@@ -67,8 +68,8 @@ The preflight is a capability check, not a local repository check. If the tool i
 unavailable or the call fails, the agent MUST stop and return a blocked report with:
 
 - `status: blocked`
-- `tool_attempted: github/list_issues` and the intended owner, repository, state, and
-  limit (when supported)
+- `tool_attempted: github/search_issues` and the intended repository/query and state
+  (with a limit when supported)
 - `exact_error: <verbatim connector error>`
 - `workflow: blocked; no live GitHub state was established`
 
@@ -279,7 +280,7 @@ specified once in the shared skill so independently-invoked agents agree on them
 
 **Blocked report** (terminal preflight failure)
 - `status: blocked`
-- `tool_attempted` — `github/list_issues`, with the intended owner, repository, state,
+- `tool_attempted` — `github/search_issues`, with the intended repository/query, state,
   and smallest supported limit
 - `exact_error` — the connector error verbatim
 - `workflow` — `blocked; no live GitHub state was established`


### PR DESCRIPTION
The previous preflight referenced the unavailable `github/list_issues` tool. This child updates the backlog agents, skill, and design docs to use `github/search_issues` while preserving fail-closed behavior when the preflight fails.

Depends on the parent backlog-agent safeguards PR targeting `lfarci-harden-backlog-agents`.