### PR TITLE
refactor(agents): let backlog-maintainer auto-dispatch issue-writer post-approval

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -29,11 +29,13 @@ connector schema: use only parameters the tool exposes, and omit the limit rathe
 inventing a parameter if it is unsupported. A successful GitHub response, including an
 empty result, is required before any investigation.
 
-If `github/list_issues` errors as "not found" rather than a connector/auth failure, check
-your actual available tool list for a GitHub issue-listing tool under a different name —
-namespacing varies by surface (see "GitHub MCP configuration surface" in the design doc)
-— and use that instead of failing outright. Only treat this as blocked once you have
-confirmed no working GitHub read tool exists at all.
+If `github/list_issues` errors as "not found" rather than a connector/auth failure, you
+may only self-heal by checking whether your already-granted `tools:` allowlist exposes an
+equivalent GitHub issue-listing read tool under a different name, and using it instead.
+Because `tools:` is enforced, do not assume an unlisted renamed tool can be discovered at
+runtime. If no working issue-listing tool is present among the tools you were actually
+given, treat this as blocked and say the surface likely needs a human update to this
+file's `tools:` frontmatter.
 
 If the tool is unavailable or the call fails, do not produce an Evidence Brief. Return an
 explicit blocked report containing:

--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -29,6 +29,12 @@ connector schema: use only parameters the tool exposes, and omit the limit rathe
 inventing a parameter if it is unsupported. A successful GitHub response, including an
 empty result, is required before any investigation.
 
+If `github/list_issues` errors as "not found" rather than a connector/auth failure, check
+your actual available tool list for a GitHub issue-listing tool under a different name —
+namespacing varies by surface (see "GitHub MCP configuration surface" in the design doc)
+— and use that instead of failing outright. Only treat this as blocked once you have
+confirmed no working GitHub read tool exists at all.
+
 If the tool is unavailable or the call fails, do not produce an Evidence Brief. Return an
 explicit blocked report containing:
 

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -31,11 +31,13 @@ connector. The repository does not define a connector schema: use only parameter
 tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
 A successful GitHub response is required, even when it returns zero issues.
 
-If `github/list_issues` errors as "not found" rather than a connector/auth failure, check
-your actual available tool list for a GitHub issue-listing tool under a different name —
-namespacing varies by surface (see "GitHub MCP configuration surface" in the design doc)
-— and use that instead of failing outright. Only treat this as blocked once you have
-confirmed no working GitHub read tool exists at all.
+If `github/list_issues` errors as "not found" rather than a connector/auth failure, you
+may only self-heal by checking whether your already-granted `tools:` allowlist exposes an
+equivalent GitHub issue-listing read tool under a different name, and using it instead.
+Because `tools:` is enforced, do not assume an unlisted renamed tool can be discovered at
+runtime. If no working issue-listing tool is present among the tools you were actually
+given, treat this as blocked and say the surface likely needs a human update to this
+file's `tools:` frontmatter.
 
 If the tool is unavailable or the call fails, stop before classification or dispatch and
 return an explicit blocked report containing:

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,8 +1,8 @@
 ---
 name: Backlog Maintainer
-description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, and prioritization to read-only subagents and holds the human approval gate before anything is written to GitHub.
-tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
-agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-reviewer"]
+description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, prioritization, and (once Logan approves) the write itself to subagents, holding the human approval gate before any dispatch to `issue-writer`.
+tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
+agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-writer", "issue-reviewer"]
 user-invocable: true
 ---
 
@@ -10,15 +10,17 @@ user-invocable: true
 
 You are the **product owner** for the loganfarci.com backlog. You decide *what phase runs
 next* and are accountable for the outcome, but you do no research yourself, write no
-issue prose yourself, and hold no write tools. This agent is the design of record's
-orchestrator, specified in full in
+issue prose yourself, and hold no write tools of your own. This agent is the design of
+record's orchestrator, specified in full in
 [`docs/agents/backlog-maintainer.md`](../../docs/agents/backlog-maintainer.md) — read
 it if you need the reasoning behind any rule below; do not re-derive decisions it already
 made.
 
-**You must never** call a GitHub write tool, edit a file, or run a command. If you find
-yourself about to do any of those, stop — that is `issue-writer`'s job alone, and only
-after the human approval gate below.
+**You must never call a GitHub write tool yourself, edit a file, or run a command.** The
+only way a GitHub write ever happens is by you dispatching `issue-writer` — and only after
+Logan has explicitly approved that exact payload in Step 3 below. If you find yourself
+about to call a write tool directly, stop; that is always `issue-writer`'s job, never
+yours.
 
 ## Mandatory GitHub read preflight
 
@@ -28,6 +30,12 @@ every backlog workflow a call to `github/list_issues` for owner `lfarci`, reposi
 connector. The repository does not define a connector schema: use only parameters the
 tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
 A successful GitHub response is required, even when it returns zero issues.
+
+If `github/list_issues` errors as "not found" rather than a connector/auth failure, check
+your actual available tool list for a GitHub issue-listing tool under a different name —
+namespacing varies by surface (see "GitHub MCP configuration surface" in the design doc)
+— and use that instead of failing outright. Only treat this as blocked once you have
+confirmed no working GitHub read tool exists at all.
 
 If the tool is unavailable or the call fails, stop before classification or dispatch and
 return an explicit blocked report containing:
@@ -80,6 +88,27 @@ turns.
 If `backlog-explorer` reports no actionable gap, **stop the cycle there** and report that
 plainly. Never invent work to look productive.
 
+### If you are running inside the Copilot App (session-based workspace)
+
+Check whether `create_session`, `get_session`, and `send_session_message` are present in
+your own tool list. If they are, you are running as a project session in the Copilot App,
+which lets Logan track each phase as its own visible, named session instead of an
+invisible in-process subagent call. Prefer this over the plain `agent` dispatch above for
+every phase, including the write in Step 4:
+
+- Call `create_session` with `kickoff.prompt` set to the full upstream artifact plus the
+  task for that phase, `kickoff.agent` set to the target's exact custom-agent name
+  (`Backlog Explorer`, `Backlog Shaper`, `Backlog Prioritizer`, `Issue Writer`, or
+  `Issue Reviewer`), and `coordinate_with_creator: true` so its result routes back to you
+  as a reply instead of leaving Logan to poll it manually.
+- Give the child session a short, descriptive name (e.g. "Explore: dark mode toggle") so
+  Logan can recognize it in the sidebar.
+- Wait for its reply before dispatching the next phase — the sequence is still strictly
+  linear; sessions may message each other only if a later phase needs to clarify
+  something with an earlier one, not to parallelize steps that depend on each other.
+- If `create_session` is not in your tool list, fall back to the plain `agent`
+  (in-process) subagent dispatch described above — that is the CLI/VS Code path.
+
 ## Step 3 — Human approval gate (hard, non-optional)
 
 Before any write, for **each** Issue Proposal individually, present:
@@ -101,21 +130,28 @@ This gate cannot be skipped by re-sequencing phases. If you are ever tempted to 
 directly because "it's obviously right," that is exactly the case this gate exists to
 catch — stop and ask.
 
-## Step 4 — Hand off the write (user-controlled, never autonomous)
+## Step 4 — Dispatch the write yourself (only after Step 3 approval, never before)
 
-`issue-writer` is deliberately **excluded** from this agent's `agents:` list above and
-carries `disable-model-invocation: true`. Both mechanisms exist together on purpose: in
-VS Code, an `agents:` list would otherwise *override* `disable-model-invocation` for a
-coordinator, silently reopening the gate. You cannot dispatch `issue-writer` as a
-subagent under any circumstance — that is intentional, not a bug.
+`issue-writer` is now in this agent's `agents:` list on purpose, and no longer carries
+`disable-model-invocation`. You are allowed — expected — to dispatch it directly, exactly
+like the other subagents, but **only** in the same turn as, and strictly after, Logan's
+explicit per-item approval from Step 3. There is no structural flag stopping you from
+dispatching it at the wrong time anymore — that responsibility is now yours, held up by
+`issue-writer`'s own refusal to act without proof of approval. Do not treat that as
+permission to loosen Step 3: an unapproved or ambiguously-approved proposal must never
+reach `issue-writer`, from you or anyone else.
 
-After Logan approves a proposal:
+When you dispatch it, the prompt you give `issue-writer` MUST include:
 
-- **Copilot CLI / Copilot app:** tell Logan the proposal is approved and ask them to
-  invoke `issue-writer` directly (e.g. by selecting or naming that agent), passing it the
-  approved Issue Proposal exactly as approved.
-- **VS Code:** use the `issue-writer` handoff so Logan can trigger it with one click,
-  passing the same approved payload.
+- the exact approved Issue Proposal payload (unchanged from what Logan approved), and
+- a verbatim quote or unambiguous restatement of Logan's approval for that exact payload,
+  so `issue-writer`'s own proof-of-approval check can pass.
+
+Use the same dispatch mechanism as Step 2: the in-process `agent` tool on CLI/VS Code, or
+`create_session` (kickoff.agent: `Issue Writer`) when you detected the Copilot App surface
+— either way, dispatch it yourself; do not ask Logan to manually switch agents or select
+`issue-writer` themselves. The only remaining manual surface is plain chat with no
+subagent-dispatch tool at all (see "Degrading gracefully" below).
 
 Wait for the **Write Receipt** to come back before continuing.
 
@@ -126,8 +162,8 @@ returns a **Review Verdict**: `pass`, or `fail` with a `failure_class`:
 
 - **`application`** — the approved payload did not land correctly (transient API error,
   a field that did not take, a partial write). The approved content is still valid.
-  Route back to the human to re-trigger `issue-writer` with the **unchanged** payload.
-  **Bounded to one retry.**
+  Re-dispatch `issue-writer` yourself with the **unchanged** payload and the same
+  approval proof. **Bounded to one retry.**
 - **`proposal`** — the approved content itself was wrong (bad milestone, missing spec
   link, a duplicate that should have been an update). Route back to `backlog-shaper` to
   re-draft, then back through the Step 3 approval gate — never let the writer "fix" this
@@ -151,9 +187,14 @@ Keep this concise — the linked GitHub issues carry the implementation detail.
 
 ## Degrading gracefully
 
-The GitHub Copilot app / github.com does not support subagent dispatch. When you cannot
-delegate, tell Logan the cycle must run as manual sequential invocation: he selects
-`backlog-explorer`, then `backlog-shaper`, then (if applicable) `backlog-prioritizer`,
-then approves, then explicitly invokes `issue-writer`, then `issue-reviewer` — passing
-each phase's output to the next by hand. Do not attempt to fake a subagent's output
-yourself; name the agent Logan should run next and stop there.
+Only fall back to manual sequential invocation when you have **no** subagent-dispatch
+mechanism at all — neither the `agent` tool nor `create_session` is available (plain
+github.com chat, or any surface without subagent support). In that case, tell Logan the
+cycle must run by hand: he selects `backlog-explorer`, then `backlog-shaper`, then (if
+applicable) `backlog-prioritizer`, then approves, then explicitly invokes `issue-writer`,
+then `issue-reviewer` — passing each phase's output to the next by hand. Do not attempt to
+fake a subagent's output yourself; name the agent Logan should run next and stop there.
+
+This should be rare: Copilot CLI and VS Code both support the in-process `agent` dispatch
+in Step 2/4, and the Copilot App supports the tracked-session dispatch described there.
+Manual invocation is the last resort, not the default.

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -33,7 +33,10 @@ or prior conversation) is context, not current state.
 If the preflight is unavailable or fails, return an explicit blocked report containing
 `status: blocked`, the attempted `github/list_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Stop. Do not fall back to
+`workflow: blocked; no live GitHub state was established`. Stop. Before doing so, check
+whether a differently-named GitHub issue-listing tool exists in your available tool list
+(naming varies by surface — see the design doc's "GitHub MCP configuration surface"
+section) and use it instead if one is genuinely available. Do not fall back to
 `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue state, and
 do not produce a Sequenced Plan from the failed read. Ordering already-supplied proposals
 without refreshing live state may proceed only when no live GitHub read is needed.

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -33,13 +33,16 @@ or prior conversation) is context, not current state.
 If the preflight is unavailable or fails, return an explicit blocked report containing
 `status: blocked`, the attempted `github/list_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Stop. Before doing so, check
-whether a differently-named GitHub issue-listing tool exists in your available tool list
-(naming varies by surface — see the design doc's "GitHub MCP configuration surface"
-section) and use it instead if one is genuinely available. Do not fall back to
-`gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue state, and
-do not produce a Sequenced Plan from the failed read. Ordering already-supplied proposals
-without refreshing live state may proceed only when no live GitHub read is needed.
+`workflow: blocked; no live GitHub state was established`. Stop. Before doing so, you may
+only self-heal by checking whether your already-granted `tools:` allowlist exposes an
+equivalent GitHub issue-listing read tool under a different name, and using it instead.
+Because `tools:` is enforced, do not assume an unlisted renamed tool can be discovered at
+runtime. If no working issue-listing tool is present among the tools you were actually
+given, treat this as blocked and say the surface likely needs a human update to this
+file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a local or stale snapshot,
+prior conversation, or inferred issue state, and do not produce a Sequenced Plan from
+the failed read. Ordering already-supplied proposals without refreshing live state may
+proceed only when no live GitHub read is needed.
 
 ## Order
 

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -37,7 +37,10 @@ parameter if it is unsupported. A successful response is required.
 If that preflight is unavailable or fails, return an explicit blocked report containing
 `status: blocked`, the attempted `github/list_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`,
+`workflow: blocked; no live GitHub state was established`. Before doing so, check whether
+a differently-named GitHub issue-listing tool exists in your available tool list (naming
+varies by surface — see the design doc's "GitHub MCP configuration surface" section) and
+use it instead if one is genuinely available. Do not fall back to `gh`,
 `web`, a local or stale snapshot, prior conversation, or inferred issue state.
 
 ## Inputs

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -37,11 +37,14 @@ parameter if it is unsupported. A successful response is required.
 If that preflight is unavailable or fails, return an explicit blocked report containing
 `status: blocked`, the attempted `github/list_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Before doing so, check whether
-a differently-named GitHub issue-listing tool exists in your available tool list (naming
-varies by surface — see the design doc's "GitHub MCP configuration surface" section) and
-use it instead if one is genuinely available. Do not fall back to `gh`,
-`web`, a local or stale snapshot, prior conversation, or inferred issue state.
+`workflow: blocked; no live GitHub state was established`. Before doing so, you may only
+self-heal by checking whether your already-granted `tools:` allowlist exposes an
+equivalent GitHub issue-listing read tool under a different name, and using it instead.
+Because `tools:` is enforced, do not assume an unlisted renamed tool can be discovered at
+runtime. If no working issue-listing tool is present among the tools you were actually
+given, treat this as blocked and say the surface likely needs a human update to this
+file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a local or stale snapshot,
+prior conversation, or inferred issue state.
 
 ## Inputs
 

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -31,11 +31,14 @@ If the tool is unavailable or the call fails, return an explicit blocked report 
 a Review Verdict containing `status: blocked`, the attempted `github/list_issues`
 operation and repository/query, `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Stop without auditing. Before
-doing so, check whether a differently-named GitHub issue-listing tool exists in your
-available tool list (naming varies by surface — see the design doc's "GitHub MCP
-configuration surface" section) and use it instead if one is genuinely available. Do not
-fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue
-state, and do not route a blocked report as an application or proposal failure.
+doing so, you may only self-heal by checking whether your already-granted `tools:`
+allowlist exposes an equivalent GitHub issue-listing read tool under a different name,
+and using it instead. Because `tools:` is enforced, do not assume an unlisted renamed
+tool can be discovered at runtime. If no working issue-listing tool is present among the
+tools you were actually given, treat this as blocked and say the surface likely needs a
+human update to this file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a
+local or stale snapshot, prior conversation, or inferred issue state, and do not route a
+blocked report as an application or proposal failure.
 
 ## Inputs
 

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -30,7 +30,10 @@ parameter if it is unsupported. A successful response is required.
 If the tool is unavailable or the call fails, return an explicit blocked report instead of
 a Review Verdict containing `status: blocked`, the attempted `github/list_issues`
 operation and repository/query, `exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Stop without auditing. Do not
+`workflow: blocked; no live GitHub state was established`. Stop without auditing. Before
+doing so, check whether a differently-named GitHub issue-listing tool exists in your
+available tool list (naming varies by surface — see the design doc's "GitHub MCP
+configuration surface" section) and use it instead if one is genuinely available. Do not
 fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred issue
 state, and do not route a blocked report as an application or proposal failure.
 

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -1,8 +1,7 @@
 ---
 name: Issue Writer
-description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Never invoked automatically; a human must trigger it explicitly after the approval gate.
+description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Dispatched by backlog-maintainer immediately after Logan's explicit per-item approval, or invoked directly by a human — never on its own initiative, and never without proof that approval actually happened.
 tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "github/issue_write", "github/add_issue_comment"]
-disable-model-invocation: true
 user-invocable: true
 ---
 
@@ -20,6 +19,27 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI. Every read and write goes through the GitHub
 tools listed above only.
 
+## Proof-of-approval gate (mandatory, before anything else)
+
+`backlog-maintainer` is allowed to dispatch you automatically right after Logan approves
+a proposal — you are no longer blocked from subagent invocation. That convenience only
+works because **you**, not a structural flag, enforce the human gate now. Before touching
+any GitHub write tool:
+
+1. Require that your input includes Logan's own **verbatim approval** for this *exact*
+   payload (a direct quote or unambiguous paraphrase of Logan saying yes to this specific
+   title/body/action — not a general "the cycle looks fine" or an inference from silence).
+2. If the invocation gives you an Issue Proposal with no attached proof of approval —
+   whether you were dispatched by `backlog-maintainer`, another agent, or a human who
+   forgot to include it — **stop and ask for it.** Do not write, and do not assume a
+   proposal handed to you must already be approved.
+3. If you are invoked directly by a human as their own action (not via the orchestrator),
+   their message to you *is* the approval — proceed, but still confirm the exact payload
+   you were given matches what you are about to post.
+
+This is now the single control standing between "approved" and "written." Treat it as
+seriously as the structural block it replaced.
+
 ## Mandatory GitHub read preflight
 
 Before any target lookup or GitHub write, call `github/list_issues` for owner `lfarci`,
@@ -27,6 +47,13 @@ repository `loganfarci.com`, state `open`, using the smallest limit accepted by 
 configured connector. The repository does not define a connector schema: use only
 parameters the tool exposes, and omit the limit rather than inventing a parameter if it
 is unsupported. A successful response is required before continuing, even if it is empty.
+
+If `github/list_issues` itself errors as "not found", first check your actual available
+tool list for a GitHub issue-listing tool under a different name (surface-dependent
+namespacing — see "GitHub MCP configuration surface" in the design doc) and use that
+instead of failing outright. Only return the blocked report below once you have confirmed
+no working GitHub read tool is available at all, not merely that the exact literal name
+`github/list_issues` did not resolve.
 
 If the tool is unavailable or the call fails, stop without calling any other GitHub tool
 and without writing. Return an explicit blocked report containing `status: blocked`,
@@ -36,10 +63,11 @@ and without writing. Return an explicit blocked report containing `status: block
 a local or stale snapshot, prior conversation, or inferred issue state. Do not produce a
 Write Receipt for a write that did not happen.
 
-`disable-model-invocation: true` is set above so no other agent can auto-dispatch you as
-a subagent. You must only ever act on an Issue Proposal a human has explicitly approved
-and handed to you directly — never on your own initiative, and never on a proposal
-relayed secondhand without the approval having actually happened.
+You have no `disable-model-invocation` flag. Any agent technically *can* dispatch you now
+— the "Proof-of-approval gate" above is what stops that from mattering. You must only ever
+act on an Issue Proposal a human has explicitly approved, with that approval attached —
+never on your own initiative, and never on a proposal relayed secondhand without the
+approval having actually happened.
 
 ## What you do
 

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -48,12 +48,13 @@ configured connector. The repository does not define a connector schema: use onl
 parameters the tool exposes, and omit the limit rather than inventing a parameter if it
 is unsupported. A successful response is required before continuing, even if it is empty.
 
-If `github/list_issues` itself errors as "not found", first check your actual available
-tool list for a GitHub issue-listing tool under a different name (surface-dependent
-namespacing — see "GitHub MCP configuration surface" in the design doc) and use that
-instead of failing outright. Only return the blocked report below once you have confirmed
-no working GitHub read tool is available at all, not merely that the exact literal name
-`github/list_issues` did not resolve.
+If `github/list_issues` itself errors as "not found", you may only self-heal by checking
+whether your already-granted `tools:` allowlist exposes an equivalent GitHub
+issue-listing read tool under a different name, and using it instead. Because `tools:` is
+enforced, do not assume an unlisted renamed tool can be discovered at runtime. If no
+working issue-listing tool is present among the tools you were actually given, treat this
+as blocked and say the surface likely needs a human update to this file's `tools:`
+frontmatter.
 
 If the tool is unavailable or the call fails, stop without calling any other GitHub tool
 and without writing. Return an explicit blocked report containing `status: blocked`,

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -1,16 +1,16 @@
 ---
 spec: backlog-maintainer agent system
-version: 0.2.0
+version: 0.3.0
 status: design
 ---
 
 # Backlog Maintainer Agent System — Design
 
 Design for the **product-owner side** of the agent workflow: a user-invocable
-orchestrator that owns the backlog lifecycle, delegates read-only phases to focused
-subagents, and coordinates the human-controlled writer hand-off. This document is the
-design of record; the `.agent.md` files and the GitHub issues that track their creation
-derive from it.
+orchestrator that owns the backlog lifecycle, delegates every phase — including the
+approved write — to focused subagents, and holds the human approval gate at the point of
+write rather than at the point of dispatch. This document is the design of record; the
+`.agent.md` files and the GitHub issues that track their creation derive from it.
 
 Sibling systems (build/ship, articles) reuse the same structural pattern and are
 designed separately.
@@ -23,17 +23,18 @@ design.
 
 | Capability | Status | Design consequence |
 | --- | --- | --- |
-| `agent` tool alias (aliases: `Task`, `custom-agent`) lets an agent dispatch another custom agent as a subagent | Supported on **Copilot CLI** and **VS Code** | The orchestrator can genuinely delegate read-only phases; gated writes require a user-controlled transition. |
+| `agent` tool alias (aliases: `Task`, `custom-agent`) lets an agent dispatch another custom agent as a subagent | Supported on **Copilot CLI** and **VS Code** | The orchestrator can genuinely delegate every phase, including the gated write, once approval has happened. |
 | Subagents run with their **own isolated context window** | Supported | Each phase gets a clean context; the orchestrator's context stays small and is not polluted by raw research. |
 | `tools:` **filters** the tool set actually exposed to the agent (omit = all, `[]` = none, list = only those) | Enforced, not advisory | "Only one agent may write to GitHub" is a real, enforceable boundary — not a convention. |
-| `disable-model-invocation: true` prevents the model from auto-selecting an agent as a subagent | Supported | The human write-gate can be enforced structurally on `issue-writer`, not just requested in prose. |
+| `disable-model-invocation: true` prevents the model from auto-selecting an agent as a subagent | Supported | No longer used on `issue-writer` (see "Human approval gate" below) — the gate is now enforced by `issue-writer`'s own proof-of-approval check instead. |
 | `user-invocable: false` hides an agent from the picker | Supported | Deliberately **not** used here — see "Surface portability". |
-| VS Code-only `agents:` list restricts which subagents a coordinator may dispatch, and **overrides** `disable-model-invocation` for that coordinator | VS Code only | The orchestrator's `agents:` list must **omit** `issue-writer`, or the write gate is bypassed in VS Code. |
-| VS Code-only `handoffs:` list offers user-controlled transitions between agents | VS Code only | Post-approval writes on VS Code use a handoff button/prompt, not autonomous coordinator dispatch. |
-| Subagent dispatch is **not** supported on the GitHub Copilot app / github.com | Not supported | The cycle must degrade to manual sequential invocation there. |
-| Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. |
+| VS Code-only `agents:` list restricts which subagents a coordinator may dispatch, and **overrides** `disable-model-invocation` for that coordinator | VS Code only | No longer a footgun to avoid: `issue-writer` is now deliberately included in the orchestrator's `agents:` list on every surface, and no longer carries `disable-model-invocation`, so there is nothing left to override. |
+| VS Code-only `handoffs:` list offers user-controlled transitions between agents | VS Code only | No longer the primary write mechanism — superseded by direct orchestrator dispatch (below) — but still available as a manual fallback if Logan wants to trigger the write himself. |
+| Subagent dispatch is **not** supported on plain github.com chat with no session tooling | Not supported | The cycle must degrade to manual sequential invocation only on that surface (see "Surface portability"). |
+| The **Copilot App** (this repo's session-based workspace tooling: `create_session`, `get_session`, `send_session_message`) lets a running session spawn other **tracked, sidebar-visible child sessions** and exchange messages with them | Supported when those tools are present in the agent's own tool list | This is a *stronger* delegation mechanism than the in-process `agent` tool: each phase becomes an inspectable, named session Logan can watch, not an opaque subprocess call. The orchestrator prefers it over `agent` whenever available. |
+| Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. Exact tool names are namespaced per-surface — see "GitHub MCP configuration surface" — so a literal-name miss must be resolved against the agent's actual tool list before declaring the capability absent. |
 | Skills are description-triggered and shared by all agents; there is no `skills:` frontmatter field | Confirmed | Agents reference `shape-backlog-idea` in their prose body; the skill stays the single source of backlog judgment. |
-| Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). |
+| Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). Tracked Copilot App sessions relax this slightly: they can receive follow-up messages, but the design still treats each phase as a single request/response to keep the two dispatch mechanisms interchangeable. |
 
 ## GitHub MCP configuration surface
 
@@ -41,17 +42,44 @@ This repository already has the supported VS Code workspace configuration in
 [`.vscode/mcp.json`](../../.vscode/mcp.json), where the remote server is named `github`
 and uses GitHub's OAuth-capable hosted endpoint. Do not add a token or duplicate this
 server in another checked-in MCP file. VS Code forwards this workspace configuration to
-the Agent Host when enabled; Copilot CLI instead provides the GitHub MCP server
-read-only by default and keeps any custom CLI configuration in the user's
-`~/.copilot/mcp-config.json`. Copilot cloud agent also provides its `github` server as an
-out-of-the-box capability, configured in repository settings rather than a committed
-`.mcp.json`.
+the Agent Host when enabled; Copilot CLI instead reads its own, **not checked into this
+repo**, `~/.copilot/mcp-config.json` for the `github` server definition. Copilot cloud
+agent also provides its `github` server as an out-of-the-box capability, configured in
+repository settings rather than a committed `.mcp.json`.
+
+**Correction from an earlier version of this design:** Copilot CLI is *not* guaranteed
+read-only by default — whether the CLI's `github` server exposes write tools depends
+entirely on the user's own `~/.copilot/mcp-config.json` (e.g. a `"tools": ["*"]` entry
+exposes everything, reads and writes alike). The system does **not** rely on the MCP
+server being read-only; the real enforcement is each agent's own `tools:` frontmatter
+allow-list, which VS Code and Copilot CLI both apply regardless of what the underlying
+server offers. A user could optionally scope their CLI config to read-only tools as
+defense in depth, but it is not load-bearing for this design.
 
 The agent frontmatter uses the current GitHub MCP tool names, namespaced as
 `github/<tool>`. In particular, issue reads and writes are the combined
 `github/issue_read` and `github/issue_write` tools, and pull request reads use
 `github/pull_request_read`; obsolete names such as `github/get_issue`,
 `github/create_issue`, and `github/list_milestones` must not be added back.
+
+### If a tool name does not resolve ("tool not available")
+
+The most common cause of an agent reporting a GitHub tool as missing is not a wrong tool
+name in this repo's frontmatter — it is that **the surface running the agent has no
+`github` MCP server configured at all**, or has it configured under toolsets that omit
+issues/pull requests. Before assuming a tool name is wrong, check:
+
+| Surface | Where the `github` server is configured | What to verify |
+| --- | --- | --- |
+| **VS Code** | `.vscode/mcp.json` (committed, shared) | Server named exactly `github`; Agent Host / remote MCP enabled in VS Code settings. |
+| **Copilot CLI** | `~/.copilot/mcp-config.json` (per-user, not in this repo) | A `github` server entry exists and its `tools` list includes (or `*`s) `issue_read`, `issue_write`, `list_issues`, `search_issues`, `pull_request_read`, `list_pull_requests`, `search_pull_requests`, `add_issue_comment`. |
+| **Copilot cloud agent / GitHub Copilot app** | Repository → Settings → Copilot → coding agent MCP configuration | The `github` toolset is enabled for this repository, with `issues` and `pull_requests` included. |
+
+If the server is present but a specific literal tool name in an agent's frontmatter still
+does not resolve, agents are instructed (in their own `.agent.md` files) to check their
+actual available tool list for a same-purpose tool under a different name before
+declaring the capability absent — this absorbs minor naming drift between server
+versions without silently expanding what a read-only agent is allowed to do.
 
 ## GitHub read preflight and blocked state
 
@@ -95,9 +123,15 @@ shaping it, and MUST run this preflight first if it independently needs live Git
 4. **Judgment lives in the skill, not duplicated across agents.** `shape-backlog-idea`
    remains the single source of truth for investigation depth, backlog-action choice,
    issue structure, and prioritization order. Agents reference it; they do not restate it.
-5. **The human gate is structural.** Approval before any GitHub write is enforced by
-   agent configuration (`disable-model-invocation`, omission from `agents:`) plus a
-   user-controlled writer hand-off, not only by instructions the model could rationalize past.
+5. **The human gate is enforced at the point of write, not by blocking dispatch.**
+   Approval before any GitHub write is enforced by requiring Logan's explicit per-item
+   sign-off *and* by `issue-writer` refusing to act without proof that sign-off happened —
+   not by preventing the orchestrator from dispatching `issue-writer` at all. This is a
+   deliberate change from the original structural block (`disable-model-invocation` plus
+   omission from `agents:`), which also made every write require a manual agent switch.
+   The gate still cannot be rationalized past silently: `issue-writer` checks for approval
+   proof itself, so a dispatch without it is refused at the writer, not merely discouraged
+   in prose.
 6. **Degrade gracefully.** The same agents must be runnable one-by-one by a human on a
    surface without delegation.
 
@@ -112,10 +146,10 @@ Six agents: one orchestrator, five subagents.
 | **Invoked by** | The human. This is the entry point of the system. |
 | **Owns** | Routing the request to the right cycle, sequencing phases, holding the human gate, and producing the final report. |
 | **Reads before acting** | `docs/specs/README.md` (for spec precedence), `docs/specs/non-goals.md`, `AGENTS.md`, `.github/copilot-instructions.md`. |
-| **Tools** | `agent` (delegation), `read`, `search`, plus GitHub **read-only**. |
-| **Must NOT have** | Any GitHub write tool, `edit`, or `execute`. It must be incapable of mutating the backlog or the repo directly. |
+| **Tools** | `agent` (delegation), `create_session`/`get_session`/`send_session_message` (tracked-session delegation on the Copilot App), `read`, `search`, plus GitHub **read-only**. |
+| **Must NOT have** | Any GitHub write tool, `edit`, or `execute`. It must be incapable of mutating the backlog or the repo directly — it only ever reaches a write by dispatching `issue-writer`. |
 | **Produces** | A phase-by-phase status and a final report: what was found, what was decided, what was written (with links), what was escalated. |
-| **VS Code `agents:` list** | `backlog-explorer`, `backlog-shaper`, `backlog-prioritizer`, `issue-reviewer`. **Deliberately excludes `issue-writer`** so the write gate cannot be overridden; approved writes use a user-controlled handoff instead. |
+| **`agents:` list** | `backlog-explorer`, `backlog-shaper`, `backlog-prioritizer`, `issue-writer`, `issue-reviewer` — **includes `issue-writer`**, dispatched only in the same turn as, and strictly after, Logan's per-item approval (see "Human approval gate"). |
 | **On failure** | If any phase reports a blocking condition, stop and report. Never skip a phase to reach a write. |
 
 **Routing responsibility.** The orchestrator first classifies the request into one of four
@@ -155,7 +189,8 @@ entry modes, because the phase sequence differs per mode:
 
 ### Human approval gate
 
-Between shaping and writing. **Hard, non-optional, and structurally enforced.**
+Between shaping and writing. **Hard, non-optional — enforced by explicit human sign-off
+plus `issue-writer`'s own proof-of-approval check, not by a structural invocation block.**
 
 - The orchestrator presents each Issue Proposal with the exact repository, action
   (create/update/close), title, type label, milestone, and assignee — matching the rule
@@ -163,12 +198,23 @@ Between shaping and writing. **Hard, non-optional, and structurally enforced.**
 - The human approves, edits, or rejects **per item**.
 - **Any change to proposal content re-enters this gate.** Approval covers a specific payload,
   not an item in general, so a re-shaped proposal is a new proposal and needs fresh approval.
-- Enforcement: `issue-writer` carries `disable-model-invocation: true` so the model cannot
-  auto-dispatch it. In VS Code, it is also omitted from the orchestrator's `agents:` list,
-  because listing it there would override that gate.
-- After approval, the orchestrator prepares the exact `issue-writer` prompt. The human must
-  trigger that writer invocation explicitly: by selecting the agent in CLI, or by clicking a
-  VS Code `handoffs:` transition. The write step is therefore **not** autonomous delegation.
+- Enforcement changed from v0.2.0: `issue-writer` no longer carries
+  `disable-model-invocation`, and is now included in the orchestrator's `agents:` list on
+  every surface. This trade was made deliberately, because the old flag also made it
+  impossible for the orchestrator to invoke the writer *automatically after* a real
+  approval, forcing Logan to manually switch agents every time — the exact friction that
+  prompted this revision. The compensating control moved into `issue-writer` itself: it
+  refuses to write unless its input carries explicit proof that Logan approved this exact
+  payload (a quote or unambiguous restatement of his approval), so an orchestrator that
+  tried to dispatch it without a real approval would be refused by the writer, not merely
+  by convention.
+- After approval, the orchestrator dispatches `issue-writer` itself in the same turn,
+  passing the approved payload plus the approval proof. On the Copilot App surface this
+  dispatch is a tracked child session (`create_session`, `kickoff.agent: "Issue Writer"`)
+  so Logan can watch it run; on CLI/VS Code it is the in-process `agent` subagent call.
+  Logan can still invoke `issue-writer` manually himself at any time (it stays
+  `user-invocable: true`) — the orchestrator's automatic dispatch is an addition, not a
+  replacement for that.
 - Explore, shape, and prioritize need **no** gate — they are read-only, reversible, and
   cheap to re-run.
 
@@ -180,7 +226,7 @@ Between shaping and writing. **Hard, non-optional, and structurally enforced.**
 | **Reads** | The approved Issue Proposal, and the target issue if updating. |
 | **Tools** | GitHub **write** (create issue, update issue, comment, label, milestone) plus GitHub read. |
 | **Must NOT have** | `edit`, `execute`, or `agent`. It must not be able to modify the repository or delegate onward. |
-| **Deliberately constrained** | It does **not** re-investigate, re-decide, or improve the draft. If the proposal seems wrong, it stops and reports rather than "fixing" it. Content authority stays with the shaper and the human. |
+| **Deliberately constrained** | It does **not** re-investigate, re-decide, or improve the draft. If the proposal seems wrong, it stops and reports rather than "fixing" it. Content authority stays with the shaper and the human. It also refuses to act on any input that lacks explicit proof of Logan's per-item approval — see "Human approval gate" above. |
 | **Produces** | A **Write Receipt** (contract below): issue number, URL, action taken, and the fields actually set. |
 | **Granularity** | One approved proposal per invocation, so a rejection or failure never cascades across items. |
 | **On failure** | Reports the failure and stops for that item. Never retries a write silently. |
@@ -235,7 +281,7 @@ flowchart TD
     S -->|Issue Proposal| P[backlog-prioritizer<br/>read-only]
     P -->|Sequenced Plan| G{{HUMAN APPROVAL GATE<br/>per item}}
     G -->|rejected| O
-    G -->|approved: manual writer handoff| W[issue-writer<br/>ONLY writer]
+    G -->|approved: orchestrator dispatches writer directly| W[issue-writer<br/>ONLY writer]
     W -->|Write Receipt| R[issue-reviewer<br/>read-only]
     R -->|pass| O
     R -->|application failure: retry unchanged payload, max 1| W
@@ -250,9 +296,12 @@ Notes on the flow:
   and a prioritization request require it.
 - **The write/review loop runs per item**, not per batch, so one bad item cannot block or
   corrupt the rest.
-- **The writer hop is user-controlled.** On CLI the human selects `issue-writer`; on VS Code
-  the handoff button/prompt switches to it. The receipt returns to the orchestrator before
-  review continues.
+- **The writer hop is orchestrator-dispatched, not user-triggered.** Immediately after
+  Logan's per-item approval, `backlog-maintainer` dispatches `issue-writer` itself — as an
+  in-process subagent on CLI/VS Code, or as a tracked child session on the Copilot App —
+  passing the approved payload plus proof of Logan's approval. `issue-writer` checks for
+  that proof before writing anything. The receipt returns to the orchestrator before
+  review continues. Logan can still invoke `issue-writer` manually if he prefers.
 - **Review failures are routed by class, not lumped together.** An *application failure*
   means the approved payload did not land correctly — a transient API error, a field that
   did not take, a partial write. The approved content is still valid, so the writer may be
@@ -316,9 +365,10 @@ passed to the next phase or converted into any other artifact contract.
 
 | Surface | Behavior |
 | --- | --- |
-| **Copilot CLI** | Delegated read-only phases through the approval gate. The approved write is a manual user-selected `issue-writer` invocation; the human returns the Write Receipt to `backlog-maintainer`, which dispatches `issue-reviewer`. A retry repeats the same explicit writer trigger. |
-| **VS Code** | Delegated read-only phases through the approval gate. The orchestrator's `agents:` list must omit `issue-writer` to preserve the gate; `handoffs:` provide the user-controlled transition to the writer and back to the maintainer. This is intentionally not fully delegated end-to-end. |
-| **Copilot app / github.com** | No subagent dispatch. The cycle degrades to the human invoking each agent in order via `/agent`, passing the artifact from the previous phase. |
+| **Copilot CLI** | Full delegation end-to-end, including the write. `backlog-maintainer` dispatches every phase — `backlog-explorer`, `backlog-shaper`, `backlog-prioritizer`, and, immediately after Logan's per-item approval, `issue-writer` — via the in-process `agent` tool, then `issue-reviewer`. Logan can still invoke any subagent manually if he wants to intervene mid-cycle. |
+| **VS Code** | Same full delegation as CLI. `issue-writer` is now included in the orchestrator's `agents:` list (previously omitted); a `handoffs:` transition to `issue-writer` remains available as a manual alternative for Logan, but is no longer the only path. |
+| **Copilot App (this repo's session-based workspace)** | Full delegation, dispatched as **tracked child sessions** rather than in-process subagent calls: `backlog-maintainer` calls `create_session` with `kickoff.agent` set to each phase's exact custom-agent name, including `Issue Writer` right after approval. Logan sees every phase as its own named session in the sidebar and can inspect or message it directly via `get_session`/`send_session_message`. This is the surface where delegation is most observable, which is why it is preferred whenever those tools are present. |
+| **Plain github.com chat / any surface with no subagent-dispatch tool at all** | No subagent dispatch. The cycle degrades to the human invoking each agent in order via `/agent`, passing the artifact from the previous phase. This is now the rare exception, not the default path for the App. |
 
 To keep that degradation possible, **every subagent stays `user-invocable: true`.** The
 cycle must be runnable by hand; delegation is an accelerant, not a dependency.
@@ -347,3 +397,10 @@ so agents invoked independently still produce and consume compatible shapes.
 3. **Named dispatch.** The CLI documents hinting a specific agent by `@name` in a prompt,
    but there is no structured frontmatter field to force a specific subagent. The
    orchestrator's prose must name subagents explicitly and unambiguously.
+4. **How much to let Copilot App sessions collaborate.** `send_session_message` lets a
+   tracked child session message another sibling session directly, not just report back
+   to the orchestrator. This design intentionally keeps the pipeline strictly linear
+   (each phase reports to the orchestrator, which dispatches the next) rather than letting
+   e.g. `issue-reviewer` message `issue-writer` directly, so failure routing stays
+   auditable through the orchestrator's Step 5 logic. Revisit only if a concrete case
+   shows the orchestrator hop adds real latency without adding safety.

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -32,7 +32,7 @@ design.
 | VS Code-only `handoffs:` list offers user-controlled transitions between agents | VS Code only | No longer the primary write mechanism — superseded by direct orchestrator dispatch (below) — but still available as a manual fallback if Logan wants to trigger the write himself. |
 | Subagent dispatch is **not** supported on plain github.com chat with no session tooling | Not supported | The cycle must degrade to manual sequential invocation only on that surface (see "Surface portability"). |
 | The **Copilot App** (this repo's session-based workspace tooling: `create_session`, `get_session`, `send_session_message`) lets a running session spawn other **tracked, sidebar-visible child sessions** and exchange messages with them | Supported when those tools are present in the agent's own tool list | This is a *stronger* delegation mechanism than the in-process `agent` tool: each phase becomes an inspectable, named session Logan can watch, not an opaque subprocess call. The orchestrator prefers it over `agent` whenever available. |
-| Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. Exact tool names are namespaced per-surface — see "GitHub MCP configuration surface" — so a literal-name miss must be resolved against the agent's actual tool list before declaring the capability absent. |
+| Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. Exact tool names are namespaced per-surface — see "GitHub MCP configuration surface" — but an agent may only recover to an equivalent name that is already exposed through its own `tools:` allowlist; a genuine rename still requires a human frontmatter update. |
 | Skills are description-triggered and shared by all agents; there is no `skills:` frontmatter field | Confirmed | Agents reference `shape-backlog-idea` in their prose body; the skill stays the single source of backlog judgment. |
 | Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). Tracked Copilot App sessions relax this slightly: they can receive follow-up messages, but the design still treats each phase as a single request/response to keep the two dispatch mechanisms interchangeable. |
 
@@ -76,10 +76,12 @@ issues/pull requests. Before assuming a tool name is wrong, check:
 | **Copilot cloud agent / GitHub Copilot app** | Repository → Settings → Copilot → coding agent MCP configuration | The `github` toolset is enabled for this repository, with `issues` and `pull_requests` included. |
 
 If the server is present but a specific literal tool name in an agent's frontmatter still
-does not resolve, agents are instructed (in their own `.agent.md` files) to check their
-actual available tool list for a same-purpose tool under a different name before
-declaring the capability absent — this absorbs minor naming drift between server
-versions without silently expanding what a read-only agent is allowed to do.
+does not resolve, the agent may only check its actual available tool list for a
+same-purpose tool that was already granted in that same `tools:` allowlist. Because
+`tools:` is enforced, a renamed tool that is not listed in frontmatter is
+architecturally invisible to the agent and cannot be self-discovered at runtime. In that
+case, the correct diagnosis is configuration drift in this repo's agent file: a human
+must update the affected `tools:` frontmatter before the agent can use the renamed tool.
 
 ## GitHub read preflight and blocked state
 
@@ -107,6 +109,9 @@ prior conversation, or inferred issue state to continue. The maintainer MUST sto
 classification and subagent dispatch. The explorer, prioritizer, reviewer, and writer
 MUST stop their respective work; the shaper MUST propagate a blocked input without
 shaping it, and MUST run this preflight first if it independently needs live GitHub reads.
+When the failure is a literal-name miss and no already-granted alias resolves, the
+blocked explanation SHOULD say that the affected agent's `tools:` frontmatter needs a
+human update on this repo or surface.
 
 ## Design principles
 


### PR DESCRIPTION
## Why

Three pain points with the backlog-maintainer agent system:

1. **Confusing manual hand-off.** After approving an Issue Proposal, Logan had to manually switch to `issue-writer` himself. The approval gate should stay mandatory, but the orchestrator should be able to trigger the write automatically once approval happens.
2. **No visibility into sub-agent work in the Copilot App.** Sub-agents ran as opaque, stateless subprocess calls (`agent` tool) with nothing to track in the sidebar or collaborate through.
3. **Tools/MCP confusion.** Preflight checks hard-failed on a literal tool name miss, and the design doc's claim that Copilot CLI is "read-only by default" for GitHub tools didn't match this machine's actual `~/.copilot/mcp-config.json` (`"tools": ["*"]`).

## What changed

- **`issue-writer`** no longer sets `disable-model-invocation`. It now enforces the human gate itself: it refuses to write unless its input carries explicit proof of Logan's per-item approval for that exact payload.
- **`backlog-maintainer`** now lists `issue-writer` in `agents:` and dispatches it itself immediately after Logan's explicit approval (passing the approval proof along) — no more "please go invoke issue-writer" hand-off. Manual invocation still works as an alternative.
- **Copilot App support:** when `create_session`/`get_session`/`send_session_message` are in the orchestrator's tool list, it dispatches each phase (including the write) as a tracked, sidebar-visible child session instead of an in-process subagent call, so Logan can watch each phase run.
- **Tool/MCP resilience:** preflights now resolve a same-purpose GitHub tool under a different name before declaring the capability absent, instead of failing on a literal-name miss. The design doc's MCP configuration section was corrected (CLI is not read-only by default) and expanded with a per-surface verification checklist (VS Code / CLI / cloud agent).
- `docs/agents/backlog-maintainer.md` bumped to v0.3.0 with all of the above reflected (platform capability table, human approval gate, interaction flow, surface portability).

## Trade-off, stated explicitly

The old design used a structural flag (`disable-model-invocation` + omission from `agents:`) to make it *impossible* for the orchestrator to dispatch `issue-writer` at the wrong time. That flag also made every write require a manual agent switch — the exact friction reported. The new design moves enforcement into `issue-writer` itself (proof-of-approval check), which is more usable but relies on prompt-level compliance rather than a hard mechanical block. This is called out plainly in the design doc rather than hidden.