### PR TITLE
refactor: replace individual GitHub MCP tools with github/* namespace

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Explorer
 description: Read-only backlog research agent for loganfarci.com. Use to establish facts before deciding anything — what the code/site actually does, what the specs require, and what already exists in the GitHub backlog — for one specific idea (targeted) or across the whole backlog (sweep). Produces an Evidence Brief; never drafts issue prose or decides an action.
-tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/*"]
 user-invocable: true
 ---
 

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Maintainer
 description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, prioritization, and (once Logan approves) the write itself to subagents, holding the human approval gate before any dispatch to `issue-writer`.
-tools: ["agent", "read", "search", "github/*", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
+tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
 agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-writer", "issue-reviewer"]
 user-invocable: true
 ---
@@ -37,8 +37,8 @@ A successful GitHub response is required, even when it returns zero issues.
 **Never fall back** to `gh`, Bash/shell commands, `curl`, web search, stale local state
 from the repository checkout, any other GitHub client, or inference from prior
 conversation — even if `github/list_issues` appears unavailable or returns an error. The
-`tools:` allowlist grants `github/*` (the full MCP namespace) for reading and querying
-GitHub; no other mechanism is authorised to reach it.
+`tools:` allowlist grants the `github/` MCP read tools directly; no other mechanism is
+authorised to reach GitHub.
 
 If `github/list_issues` errors as "not found" rather than a connector/auth failure, you
 may only self-heal by checking whether your already-granted `tools:` allowlist exposes an

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Maintainer
 description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, prioritization, and (once Logan approves) the write itself to subagents, holding the human approval gate before any dispatch to `issue-writer`.
-tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
+tools: ["agent", "read", "search", "github/*", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
 agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-writer", "issue-reviewer"]
 user-invocable: true
 ---
@@ -24,12 +24,21 @@ yours.
 
 ## Mandatory GitHub read preflight
 
+GitHub repository state **must** be obtained through the `github` MCP server. No other
+source of GitHub data is acceptable.
+
 Before classifying the request or dispatching any subagent, make the first operation of
 every backlog workflow a call to `github/list_issues` for owner `lfarci`, repository
 `loganfarci.com`, state `open`, using the smallest limit accepted by the configured
 connector. The repository does not define a connector schema: use only parameters the
 tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
 A successful GitHub response is required, even when it returns zero issues.
+
+**Never fall back** to `gh`, Bash/shell commands, `curl`, web search, stale local state
+from the repository checkout, any other GitHub client, or inference from prior
+conversation — even if `github/list_issues` appears unavailable or returns an error. The
+`tools:` allowlist grants `github/*` (the full MCP namespace) for reading and querying
+GitHub; no other mechanism is authorised to reach it.
 
 If `github/list_issues` errors as "not found" rather than a connector/auth failure, you
 may only self-heal by checking whether your already-granted `tools:` allowlist exposes an
@@ -39,16 +48,15 @@ runtime. If no working issue-listing tool is present among the tools you were ac
 given, treat this as blocked and say the surface likely needs a human update to this
 file's `tools:` frontmatter.
 
-If the tool is unavailable or the call fails, stop before classification or dispatch and
-return an explicit blocked report containing:
+If `github/list_issues` is unavailable or the call fails for any reason, stop before
+classification or dispatch and return an explicit blocked report containing:
 
 - `status: blocked`
 - `tool_attempted: github/list_issues` and the intended repository/query
 - `exact_error: <verbatim connector error>`
 - `workflow: blocked; no live GitHub state was established`
 
-Do not fall back to `gh`, `web`, a local or stale snapshot, prior conversation, or inferred
-issue state. Do not invoke a subagent, and do not pass a blocked report as an Evidence
+Do not invoke a subagent, and do not pass a blocked report as an Evidence
 Brief, Issue Proposal, or Sequenced Plan.
 
 ## Skill

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Prioritizer
 description: Read-only backlog sequencing agent for loganfarci.com. Use to order a set of Issue Proposals or the live backlog by priority and surface dependencies between them. Never sets milestones or labels — sequencing is advice for a human to accept, not a GitHub write.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "github/*"]
 user-invocable: true
 ---
 

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Shaper
 description: Read-only backlog judgment agent for loganfarci.com. Use to turn an Evidence Brief into a decision and a ready-to-post GitHub issue draft — create, update, close, defer, or explicitly do nothing. This is where product judgment happens; it never posts to GitHub itself.
-tools: ["read", "search", "web", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "web", "github/*"]
 user-invocable: true
 ---
 

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Reviewer
 description: Read-only post-write audit agent for loganfarci.com's backlog-maintainer system. Use after issue-writer executes an approved Issue Proposal, to verify what landed on GitHub matches what was approved and meets repository conventions. Flags drift, structure problems, duplication, and missing links; never edits anything itself.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests"]
+tools: ["read", "search", "github/*"]
 user-invocable: true
 ---
 

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Writer
 description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Dispatched by backlog-maintainer immediately after Logan's explicit per-item approval, or invoked directly by a human — never on its own initiative, and never without proof that approval actually happened.
-tools: ["read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "github/issue_write", "github/add_issue_comment"]
+tools: ["read", "search", "github/*"]
 user-invocable: true
 ---
 


### PR DESCRIPTION
Replaces six individually enumerated `github/...` MCP tools in Backlog Maintainer's allowlist with `github/*`, granting the full GitHub MCP read namespace.

### Motivation
The `github` MCP server already exposes `tools: ["*"]` at the project level (`.github/mcp.json`). Enumerating individual tools in the agent forces a maintenance burden -- any new GitHub read tool requires a frontmatter update. Using the wildcard namespace keeps the agent aligned with the server's full read surface without manual upkeep.

### What changed
- **Frontmatter**: `github/issue_read`, `github/list_issues`, `github/search_issues`, `github/list_pull_requests`, `github/pull_request_read`, `github/search_pull_requests` replaced with `github/*`
- **Preflight section strengthened** with explicit prohibitions against falling back to `gh`, Bash/shell, `curl`, web search, or stale local state

### What is preserved
- All non-GitHub tools (`agent`, `read`, `search`, `create_session`, `get_session`, `send_session_message`, `list_sessions_and_chats`)
- All subagent routing, approval gates, write-safety rules, and the mandatory `github/list_issues` preflight
- No command-execution tools (Bash, shell, execute) were added