### PR TITLE
docs: prefer MCP tools over gh CLI for GitHub operations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,5 +124,9 @@ Data model shapes for `content/data/*.json` and `src/src/types/` live in
 - Use the provided scripts in `scripts/` for environment management.
 - Keep dependencies up to date and review for security regularly.
 
+## GitHub Operations Preference
+
+For GitHub operations (issues, pull requests, repositories, workflow runs, etc.), prefer MCP tools over the `gh` CLI. MCP tools provide structured output and better integration with the Copilot ecosystem.
+
 ---
 For questions or improvements, open an issue or pull request.


### PR DESCRIPTION
## Summary

Updates the GitHub operations preference in `.github/copilot-instructions.md` to prioritize MCP tools over the `gh` CLI for all GitHub operations.

## Why

MCP tools provide structured output and better integration with the Copilot ecosystem, making them the preferred choice for GitHub operations like issues, pull requests, and workflow runs.

## Changes

- Added a new "GitHub Operations Preference" section to `.github/copilot-instructions.md`
- States that MCP tools should be preferred over `gh` CLI for GitHub operations