### PR TITLE
fix(agents): make backlog subagent handoff pull-based

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -20,14 +20,23 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
 
+**Your actual runtime toolset may not match this file's `tools:` list.** When dispatched
+as a child session by `backlog-maintainer`, the surface may grant fewer tools than the
+frontmatter names — you may find you have no `github/*` tools and no messaging tool at
+all. This is expected and is not a reason to abort or to improvise: your job ends with
+your terminal reply (below), and the orchestrator pulls it from your transcript.
+
 ## Mandatory GitHub read preflight
 
 For every targeted or sweep backlog invocation, the first operation must be a call to
 `github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
-the smallest limit accepted by the configured connector. The repository does not define a
-connector schema: use only parameters the tool exposes, and omit the limit rather than
-inventing a parameter if it is unsupported. A successful GitHub response, including an
-empty result, is required before any investigation.
+the smallest limit accepted by the configured connector — **unless the orchestrator's
+kickoff prompt already carries a freshly-verified live GitHub snapshot** (the output of
+the maintainer's own preflight plus the relevant per-phase reads). A snapshot explicitly
+labelled as live by the orchestrator counts as live state: use it, do not re-query. The
+repository does not define a connector schema: use only parameters the tool exposes, and
+omit the limit rather than inventing a parameter if it is unsupported. A successful
+GitHub response, including an empty result, is required before any investigation.
 
 If `github/list_issues` errors as "not found" rather than a connector/auth failure, you
 may only self-heal by checking whether your already-granted `tools:` allowlist exposes an
@@ -37,8 +46,9 @@ runtime. If no working issue-listing tool is present among the tools you were ac
 given, treat this as blocked and say the surface likely needs a human update to this
 file's `tools:` frontmatter.
 
-If the tool is unavailable or the call fails, do not produce an Evidence Brief. Return an
-explicit blocked report containing:
+If the tool is unavailable or the call fails — and no orchestrator-supplied live snapshot
+is present in your prompt — do not produce an Evidence Brief from a stale or inferred
+source. Return an explicit blocked report containing:
 
 - `status: blocked`
 - `tool_attempted: github/list_issues` and the intended repository/query
@@ -47,7 +57,11 @@ explicit blocked report containing:
 
 Stop immediately. Do not fall back to `gh`, `web`, a local or stale snapshot, prior
 conversation, or inferred issue state, and do not pass the blocked report to
-`backlog-shaper` or any later phase.
+`backlog-shaper` or any later phase. If you end blocked, your terminal reply **is** the
+blocked report — the orchestrator expects to pull it from your transcript.
+
+If the tool is unavailable but an orchestrator-supplied live snapshot **is** present,
+that is not a blocked condition: proceed using the snapshot as your live state.
 
 ## Two modes
 
@@ -95,6 +109,17 @@ hypothesis as a confirmed fact.
 If a sweep or targeted investigation turns up no real gap, drift, or defect, **say so
 plainly and stop.** Do not manufacture a finding to look productive — an empty Evidence
 Brief with a clear "no actionable gap found" is a correct and complete result.
+
+## Reporting back (terminal reply)
+
+When `backlog-maintainer` dispatched you as a tracked child session, it pulls your
+artifact from your transcript after you finish. Make your **final reply message** be
+exactly the Evidence Brief (each field from "Produce an Evidence Brief", or the blocked
+report from the preflight section) and nothing else after it. Do not try to send the
+artifact to the orchestrator with a messaging tool — you are not granted one, and the
+orchestrator does not rely on push delivery. If you are being invoked in-process by the
+`agent` tool instead, your returned text is already the payload, so the same rule
+applies: the Evidence Brief is your last word.
 
 ## Explicitly out of scope
 

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -34,6 +34,16 @@ connector. The repository does not define a connector schema: use only parameter
 tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
 A successful GitHub response is required, even when it returns zero issues.
 
+This minimal call is a **capability check only** — it proves `github/list_issues` works,
+it is not the data you hand to a child. Once it succeeds, make a second, separate call
+(or set of calls) that fetches the **complete** live state each phase actually needs: all
+open issues at the largest page size the connector accepts (do not cap this to the
+capability-check limit), plus closed issues and/or open pull requests via
+`github/list_issues` / `github/list_pull_requests` when the phase requires them (for
+example, a sweep or grooming pass must also check open PRs and recently closed issues to
+avoid recommending duplicate or already-completed work). This complete fetch, not the
+capability check, is what Step 2 below embeds as the child's snapshot.
+
 **Never fall back** to `gh`, Bash/shell commands, `curl`, web search, stale local state
 from the repository checkout, any other GitHub client, or inference from prior
 conversation — even if `github/list_issues` appears unavailable or returns an error. The
@@ -113,11 +123,12 @@ never reliably "arrives" in your conversation. The proven handoff is: you carry 
 data in, the child ends with the artifact in its final reply, and you pull that reply out
 of the child session's transcript. Do this for every App dispatch:
 
-1. **Embed live GitHub state in the prompt.** Because you completed the mandatory
-   `github/list_issues` preflight above, paste a **fresh, verbatim snapshot** of the live
-   GitHub state relevant to the phase (issue/PR lists, plus any per-phase reads you made)
-   directly into the `kickoff.prompt`. The child then never needs `github/*` at runtime
-   and cannot silently fall back to stale state.
+1. **Embed live GitHub state in the prompt.** Paste a **fresh, verbatim snapshot** of the
+   *complete* phase-specific fetch you made above (not the minimal capability-check
+   response) directly into the `kickoff.prompt`: the full open-issue list at the largest
+   accepted page size, plus closed issues and/or pull requests when the phase needs them
+   to judge duplicates or already-completed work. The child then never needs `github/*` at
+   runtime and cannot silently fall back to stale or truncated state.
 2. **Dispatch with the terminal-reply contract.** Call `create_session` with
    `kickoff.prompt` = the upstream artifact + the snapshot + the phase task + an explicit
    instruction: "Return your complete artifact as your final reply message; the

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -146,7 +146,9 @@ of the child session's transcript. Do this for every App dispatch:
    is a complete artifact in the expected shape before proceeding.
 5. **Nudge once on silence.** If the child completed but produced no usable artifact (or
    ended blocked), send it a single `send_session_message` asking for the artifact shape
-   or blocked report, then re-pull the transcript. Do not loop.
+   or blocked report. The nudge starts a new turn in the child, so poll `get_session`
+   again (bounded, as in step 3) until that turn completes before re-pulling the
+   transcript. Do not loop.
 6. **Escalate on no result.** If you still have no artifact after one nudge and one
    re-pull, stop and report to Logan with the child's session id and what the transcript
    shows. Never fabricate the phase's output, and never dispatch the next phase carrying

--- a/.github/agents/backlog-maintainer.agent.md
+++ b/.github/agents/backlog-maintainer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Backlog Maintainer
 description: Product-owner orchestrator for the loganfarci.com backlog. Use when Logan wants to turn an idea into a GitHub issue, sweep the backlog for gaps, decide what to work on next, or groom stale/duplicate items. Delegates evidence-gathering, drafting, prioritization, and (once Logan approves) the write itself to subagents, holding the human approval gate before any dispatch to `issue-writer`.
-tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "create_session", "get_session", "send_session_message", "list_sessions_and_chats"]
+tools: ["agent", "read", "search", "github/issue_read", "github/list_issues", "github/search_issues", "github/list_pull_requests", "github/pull_request_read", "github/search_pull_requests", "create_session", "get_session", "session_store_sql", "send_session_message", "list_sessions_and_chats"]
 agents: ["backlog-explorer", "backlog-shaper", "backlog-prioritizer", "issue-writer", "issue-reviewer"]
 user-invocable: true
 ---
@@ -100,24 +100,51 @@ plainly. Never invent work to look productive.
 
 ### If you are running inside the Copilot App (session-based workspace)
 
-Check whether `create_session`, `get_session`, and `send_session_message` are present in
-your own tool list. If they are, you are running as a project session in the Copilot App,
-which lets Logan track each phase as its own visible, named session instead of an
-invisible in-process subagent call. Prefer this over the plain `agent` dispatch above for
-every phase, including the write in Step 4:
+Check whether `create_session`, `get_session`, `session_store_sql`, and
+`list_sessions_and_chats` are present in your own tool list. If they are, you are running
+as a project session in the Copilot App, which lets Logan track each phase as its own
+visible, named session instead of an invisible in-process subagent call. Prefer this over
+the plain `agent` dispatch above for every phase, including the write in Step 4.
 
-- Call `create_session` with `kickoff.prompt` set to the full upstream artifact plus the
-  task for that phase, `kickoff.agent` set to the target's exact custom-agent name
-  (`Backlog Explorer`, `Backlog Shaper`, `Backlog Prioritizer`, `Issue Writer`, or
-  `Issue Reviewer`), and `coordinate_with_creator: true` so its result routes back to you
-  as a reply instead of leaving Logan to poll it manually.
-- Give the child session a short, descriptive name (e.g. "Explore: dark mode toggle") so
-  Logan can recognize it in the sidebar.
-- Wait for its reply before dispatching the next phase — the sequence is still strictly
-  linear; sessions may message each other only if a later phase needs to clarify
-  something with an earlier one, not to parallelize steps that depend on each other.
-- If `create_session` is not in your tool list, fall back to the plain `agent`
-  (in-process) subagent dispatch described above — that is the CLI/VS Code path.
+**Children cannot be assumed to have their frontmatter toolset at runtime, and they
+cannot message you.** A child session may load with fewer tools than its `tools:` list
+names — in particular it may lack `github/*` and `send_session_message` — so its result
+never reliably "arrives" in your conversation. The proven handoff is: you carry the live
+data in, the child ends with the artifact in its final reply, and you pull that reply out
+of the child session's transcript. Do this for every App dispatch:
+
+1. **Embed live GitHub state in the prompt.** Because you completed the mandatory
+   `github/list_issues` preflight above, paste a **fresh, verbatim snapshot** of the live
+   GitHub state relevant to the phase (issue/PR lists, plus any per-phase reads you made)
+   directly into the `kickoff.prompt`. The child then never needs `github/*` at runtime
+   and cannot silently fall back to stale state.
+2. **Dispatch with the terminal-reply contract.** Call `create_session` with
+   `kickoff.prompt` = the upstream artifact + the snapshot + the phase task + an explicit
+   instruction: "Return your complete artifact as your final reply message; the
+   orchestrator retrieves it from this session's transcript. You have no messaging tool —
+   do not attempt to contact the orchestrator." Set `kickoff.agent` to the target's exact
+   custom-agent name (`Backlog Explorer`, `Backlog Shaper`, `Backlog Prioritizer`,
+   `Issue Writer`, or `Issue Reviewer`). Give the child a short, descriptive name
+   (e.g. "Explore: dark mode toggle") so Logan can recognize it in the sidebar.
+3. **Await completion.** Poll the child with `get_session` (bounded — a few minutes of
+   wall-clock checks) until it completes or until you judge it stalled.
+4. **Pull the artifact from the transcript.** Query the local session store
+   (`session_store_sql`, source `local`) for the child's session id: read its `turns`
+   table and take the last `assistant_response` as the artifact. Do not wait for a message
+   to appear in your own conversation — that path is not reliable. Verify the pulled text
+   is a complete artifact in the expected shape before proceeding.
+5. **Nudge once on silence.** If the child completed but produced no usable artifact (or
+   ended blocked), send it a single `send_session_message` asking for the artifact shape
+   or blocked report, then re-pull the transcript. Do not loop.
+6. **Escalate on no result.** If you still have no artifact after one nudge and one
+   re-pull, stop and report to Logan with the child's session id and what the transcript
+   shows. Never fabricate the phase's output, and never dispatch the next phase carrying
+   an empty or inferred artifact.
+
+Dispatch one phase at a time and only start the next after you hold the previous phase's
+artifact — the sequence is still strictly linear. If `create_session` is not in your tool
+list, fall back to the plain `agent` (in-process) subagent dispatch described above —
+that is the CLI/VS Code path.
 
 ## Step 3 — Human approval gate (hard, non-optional)
 
@@ -160,10 +187,16 @@ When you dispatch it, the prompt you give `issue-writer` MUST include:
 Use the same dispatch mechanism as Step 2: the in-process `agent` tool on CLI/VS Code, or
 `create_session` (kickoff.agent: `Issue Writer`) when you detected the Copilot App surface
 — either way, dispatch it yourself; do not ask Logan to manually switch agents or select
-`issue-writer` themselves. The only remaining manual surface is plain chat with no
-subagent-dispatch tool at all (see "Degrading gracefully" below).
+`issue-writer` themselves. When you use `create_session`, apply the same handoff protocol
+as Step 2: embed fresh live GitHub state in the prompt, instruct `issue-writer` to return
+the Write Receipt as its final reply, then pull that reply from the transcript via
+`session_store_sql` (source `local`) after `get_session` shows it complete. The only
+remaining manual surface is plain chat with no subagent-dispatch tool at all (see
+"Degrading gracefully" below).
 
-Wait for the **Write Receipt** to come back before continuing.
+Hold a completed **Write Receipt** before continuing: verify the pulled text includes
+`issue_number` and `issue_url`; if the child returned a blocked report instead, treat it
+as an `application`-class failure and route per Step 5.
 
 ## Step 5 — Review and failure routing
 

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -20,17 +20,27 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
 
+**Your actual runtime toolset may not match this file's `tools:` list.** When dispatched
+as a child session by `backlog-maintainer`, the surface may grant fewer tools than the
+frontmatter names — you may find you have no `github/*` tools and no messaging tool at
+all. This is expected: your job ends with your terminal reply (below), and the
+orchestrator pulls it from your transcript.
+
 ## Before ordering anything
 
 When refreshing or ordering the live GitHub backlog, the first operation must be a call to
 `github/list_issues` for owner `lfarci`, repository `loganfarci.com`, state `open`, using
-the smallest limit accepted by the configured connector. The repository does not define a
-connector schema: use only parameters the tool exposes, and omit the limit rather than
-inventing a parameter if it is unsupported. A successful response is required. GitHub is
-the source of truth; anything cached or summarized elsewhere (including an Evidence Brief
-or prior conversation) is context, not current state.
+the smallest limit accepted by the configured connector — **unless the orchestrator's
+kickoff prompt already carries a freshly-verified live GitHub snapshot**, in which case a
+snapshot explicitly labelled as live by the orchestrator counts as live state: use it, do
+not re-query. The repository does not define a connector schema: use only parameters the
+tool exposes, and omit the limit rather than inventing a parameter if it is unsupported.
+A successful response is required. GitHub is the source of truth; anything cached or
+summarized elsewhere (including an Evidence Brief or prior conversation) is context, not
+current state.
 
-If the preflight is unavailable or fails, return an explicit blocked report containing
+If the preflight is unavailable or fails — and no orchestrator-supplied live snapshot is
+present — return an explicit blocked report containing
 `status: blocked`, the attempted `github/list_issues` operation and repository/query,
 `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Stop. Before doing so, you may
@@ -42,7 +52,9 @@ given, treat this as blocked and say the surface likely needs a human update to 
 file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a local or stale snapshot,
 prior conversation, or inferred issue state, and do not produce a Sequenced Plan from
 the failed read. Ordering already-supplied proposals without refreshing live state may
-proceed only when no live GitHub read is needed.
+proceed only when no live GitHub read is needed. If the tool is unavailable but an
+orchestrator-supplied live snapshot **is** present, that is not a blocked condition:
+proceed using the snapshot as your live state.
 
 ## Order
 
@@ -83,3 +95,14 @@ artifact hand-off section):
 You do not call any GitHub write tool, decide whether an item belongs in the backlog
 (that is `backlog-shaper`'s job), or draft issue prose. You only order and cross-reference
 what already exists or has already been proposed.
+
+## Reporting back (terminal reply)
+
+When `backlog-maintainer` dispatched you as a tracked child session, it pulls your
+artifact from your transcript after you finish. Make your **final reply message** be
+exactly the Sequenced Plan (each field from "Produce a Sequenced Plan", or the blocked
+report from the preflight section) and nothing else after it. Do not try to send the
+artifact to the orchestrator with a messaging tool — you are not granted one, and the
+orchestrator does not rely on push delivery. If you are being invoked in-process by the
+`agent` tool instead, your returned text is already the payload, so the same rule
+applies: the Sequenced Plan is your last word.

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -21,6 +21,12 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
 
+**Your actual runtime toolset may not match this file's `tools:` list.** When dispatched
+as a child session by `backlog-maintainer`, the surface may grant fewer tools than the
+frontmatter names — you may find you have no `github/*` tools and no messaging tool at
+all. This is expected: your job ends with your terminal reply (below), and the
+orchestrator pulls it from your transcript.
+
 ## Blocked inputs and live-read preflight
 
 If the supplied Evidence Brief is a blocked report, honor it: return an explicit blocked
@@ -30,21 +36,26 @@ later phase. A blocked report is not evidence and does not authorize an inferred
 When invoked independently, or when a decision requires fresh live GitHub reads beyond a
 valid Evidence Brief, make the first such operation a call to `github/list_issues` for
 owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
-accepted by the configured connector. The repository does not define a connector schema:
-use only parameters the tool exposes, and omit the limit rather than inventing a
-parameter if it is unsupported. A successful response is required.
+accepted by the configured connector — **unless the orchestrator's kickoff prompt already
+carries a freshly-verified live GitHub snapshot**, in which case a snapshot explicitly
+labelled as live by the orchestrator counts as live state: use it, do not re-query. The
+repository does not define a connector schema: use only parameters the tool exposes, and
+omit the limit rather than inventing a parameter if it is unsupported. A successful
+response is required.
 
-If that preflight is unavailable or fails, return an explicit blocked report containing
-`status: blocked`, the attempted `github/list_issues` operation and repository/query,
-`exact_error: <verbatim connector error>`, and
-`workflow: blocked; no live GitHub state was established`. Before doing so, you may only
-self-heal by checking whether your already-granted `tools:` allowlist exposes an
-equivalent GitHub issue-listing read tool under a different name, and using it instead.
-Because `tools:` is enforced, do not assume an unlisted renamed tool can be discovered at
-runtime. If no working issue-listing tool is present among the tools you were actually
-given, treat this as blocked and say the surface likely needs a human update to this
-file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a local or stale snapshot,
-prior conversation, or inferred issue state.
+If that preflight is unavailable or fails — and no orchestrator-supplied live snapshot is
+present — return an explicit blocked report containing `status: blocked`, the attempted
+`github/list_issues` operation and repository/query, `exact_error: <verbatim connector
+error>`, and `workflow: blocked; no live GitHub state was established`. Before doing so,
+you may only self-heal by checking whether your already-granted `tools:` allowlist
+exposes an equivalent GitHub issue-listing read tool under a different name, and using it
+instead. Because `tools:` is enforced, do not assume an unlisted renamed tool can be
+discovered at runtime. If no working issue-listing tool is present among the tools you
+were actually given, treat this as blocked and say the surface likely needs a human
+update to this file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a local or
+stale snapshot, prior conversation, or inferred issue state. If the tool is unavailable
+but an orchestrator-supplied live snapshot **is** present, that is not a blocked
+condition: proceed using the snapshot as your live state.
 
 ## Inputs
 
@@ -96,3 +107,14 @@ verified.
 You do not call any GitHub write tool, sequence multiple items against each other (that
 is `backlog-prioritizer`'s job), or assume your proposal is approved. A human must accept
 it through the orchestrator's approval gate before anything is written.
+
+## Reporting back (terminal reply)
+
+When `backlog-maintainer` dispatched you as a tracked child session, it pulls your
+artifact from your transcript after you finish. Make your **final reply message** be
+exactly the Issue Proposal (each field from "Produce an Issue Proposal", or the blocked
+report from the preflight section) and nothing else after it. Do not try to send the
+artifact to the orchestrator with a messaging tool — you are not granted one, and the
+orchestrator does not rely on push delivery. If you are being invoked in-process by the
+`agent` tool instead, your returned text is already the payload, so the same rule
+applies: the Issue Proposal is your last word.

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -19,15 +19,25 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI for gaps in the GitHub read tools listed above.
 Everything you read from GitHub goes through those tools only.
 
+**Your actual runtime toolset may not match this file's `tools:` list.** When dispatched
+as a child session by `backlog-maintainer`, the surface may grant fewer tools than the
+frontmatter names — you may find you have no `github/*` tools and no messaging tool at
+all. This is expected: your job ends with your terminal reply (below), and the
+orchestrator pulls it from your transcript.
+
 ## Mandatory GitHub read preflight
 
 Before any post-write audit, make the first operation a call to `github/list_issues` for
 owner `lfarci`, repository `loganfarci.com`, state `open`, using the smallest limit
-accepted by the configured connector. The repository does not define a connector schema:
-use only parameters the tool exposes, and omit the limit rather than inventing a
-parameter if it is unsupported. A successful response is required.
+accepted by the configured connector — **unless the orchestrator's kickoff prompt already
+carries a freshly-verified live GitHub snapshot**, in which case a snapshot explicitly
+labelled as live by the orchestrator counts as live state: use it, do not re-query. The
+repository does not define a connector schema: use only parameters the tool exposes, and
+omit the limit rather than inventing a parameter if it is unsupported. A successful
+response is required.
 
-If the tool is unavailable or the call fails, return an explicit blocked report instead of
+If the tool is unavailable or the call fails — and no orchestrator-supplied live snapshot
+is present — return an explicit blocked report instead of
 a Review Verdict containing `status: blocked`, the attempted `github/list_issues`
 operation and repository/query, `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Stop without auditing. Before
@@ -38,7 +48,9 @@ tool can be discovered at runtime. If no working issue-listing tool is present a
 tools you were actually given, treat this as blocked and say the surface likely needs a
 human update to this file's `tools:` frontmatter. Do not fall back to `gh`, `web`, a
 local or stale snapshot, prior conversation, or inferred issue state, and do not route a
-blocked report as an application or proposal failure.
+blocked report as an application or proposal failure. If the tool is unavailable but an
+orchestrator-supplied live snapshot **is** present, that is not a blocked condition:
+proceed using the snapshot as your live state.
 
 ## Inputs
 
@@ -97,3 +109,14 @@ again.
 You do not edit the issue, comment on it, change labels or milestones, or dispatch
 `issue-writer` or `backlog-shaper` yourself — you report the verdict and let the
 orchestrator route it.
+
+## Reporting back (terminal reply)
+
+When `backlog-maintainer` dispatched you as a tracked child session, it pulls your
+artifact from your transcript after you finish. Make your **final reply message** be
+exactly the Review Verdict (each field from "Produce a Review Verdict", or the blocked
+report from the preflight section) and nothing else after it. Do not try to send the
+artifact to the orchestrator with a messaging tool — you are not granted one, and the
+orchestrator does not rely on push delivery. If you are being invoked in-process by the
+`agent` tool instead, your returned text is already the payload, so the same rule
+applies: the Review Verdict is your last word.

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -19,6 +19,12 @@ You have **no `execute` tool**, so unlike the skill's guidance for manual, human
 use, you cannot fall back to the `gh` CLI. Every read and write goes through the GitHub
 tools listed above only.
 
+**Your actual runtime toolset may not match this file's `tools:` list.** When dispatched
+as a child session by `backlog-maintainer`, the surface may grant fewer tools than the
+frontmatter names — you may find you have no `github/*` tools and no messaging tool at
+all. This is expected: your job ends with your terminal reply (below), and the
+orchestrator pulls it from your transcript.
+
 ## Proof-of-approval gate (mandatory, before anything else)
 
 `backlog-maintainer` is allowed to dispatch you automatically right after Logan approves
@@ -44,9 +50,12 @@ seriously as the structural block it replaced.
 
 Before any target lookup or GitHub write, call `github/list_issues` for owner `lfarci`,
 repository `loganfarci.com`, state `open`, using the smallest limit accepted by the
-configured connector. The repository does not define a connector schema: use only
-parameters the tool exposes, and omit the limit rather than inventing a parameter if it
-is unsupported. A successful response is required before continuing, even if it is empty.
+configured connector — **unless the orchestrator's kickoff prompt already carries a
+freshly-verified live GitHub snapshot**, in which case a snapshot explicitly labelled as
+live by the orchestrator counts as live state: use it, do not re-query. The repository
+does not define a connector schema: use only parameters the tool exposes, and omit the
+limit rather than inventing a parameter if it is unsupported. A successful response is
+required before continuing, even if it is empty.
 
 If `github/list_issues` itself errors as "not found", you may only self-heal by checking
 whether your already-granted `tools:` allowlist exposes an equivalent GitHub
@@ -56,13 +65,18 @@ working issue-listing tool is present among the tools you were actually given, t
 as blocked and say the surface likely needs a human update to this file's `tools:`
 frontmatter.
 
-If the tool is unavailable or the call fails, stop without calling any other GitHub tool
-and without writing. Return an explicit blocked report containing `status: blocked`,
+If the tool is unavailable or the call fails — and no orchestrator-supplied live snapshot
+is present — stop without calling any other GitHub tool and without writing. Return an
+explicit blocked report containing `status: blocked`,
 `tool_attempted: github/list_issues` and the intended repository/query,
 `exact_error: <verbatim connector error>`, and
 `workflow: blocked; no live GitHub state was established`. Do not fall back to `gh`, `web`,
 a local or stale snapshot, prior conversation, or inferred issue state. Do not produce a
-Write Receipt for a write that did not happen.
+Write Receipt for a write that did not happen. If the tool is unavailable but an
+orchestrator-supplied live snapshot **is** present, that is not a blocked condition:
+proceed using the snapshot as your live state — but the write itself still requires
+working GitHub write tools; if those are genuinely absent, stop and report blocked rather
+than claiming the write succeeded.
 
 You have no `disable-model-invocation` flag. Any agent technically *can* dispatch you now
 — the "Proof-of-approval gate" above is what stops that from mattering. You must only ever
@@ -108,3 +122,14 @@ artifact hand-off section):
 If you stopped instead of writing (discrepancy or failure), say so clearly in place of a
 Write Receipt, with enough detail for the orchestrator or a human to decide the next
 step — do not fabricate a receipt for a write that did not happen.
+
+## Reporting back (terminal reply)
+
+When `backlog-maintainer` dispatched you as a tracked child session, it pulls your
+artifact from your transcript after you finish. Make your **final reply message** be
+exactly the Write Receipt (each field from "Produce a Write Receipt", or the blocked /
+stopped report from the preflight and refusal sections) and nothing else after it. Do not
+try to send the artifact to the orchestrator with a messaging tool — you are not granted
+one, and the orchestrator does not rely on push delivery. If you are being invoked
+in-process by the `agent` tool instead, your returned text is already the payload, so the
+same rule applies: the Write Receipt is your last word.

--- a/.github/skills/shape-backlog-idea/SKILL.md
+++ b/.github/skills/shape-backlog-idea/SKILL.md
@@ -22,8 +22,9 @@ constraints, and issue structure he should not need to specify himself.
    state `open`, and the smallest supported limit — **unless the invoking agent is a
    subagent of `backlog-maintainer` on a surface that grants fewer GitHub tools than the
    agent file declares, and the orchestrator's kickoff prompt already carries a
-   freshly-verified live GitHub snapshot explicitly labelled as live.** In that case the
-   snapshot satisfies the preflight: use it, do not re-query. If the preflight is
+   freshly-verified live GitHub snapshot explicitly labelled as live and complete for the
+   phase (not merely the orchestrator's minimal capability-check response).** In that case
+   the snapshot satisfies the preflight: use it, do not re-query. If the preflight is
    unavailable or fails (and no such snapshot was supplied), stop with a blocked report
    containing the attempted tool, the exact connector error, and the statement that no
    live GitHub state was established. Do not use `gh`, `web`, local/stale snapshots, prior

--- a/.github/skills/shape-backlog-idea/SKILL.md
+++ b/.github/skills/shape-backlog-idea/SKILL.md
@@ -19,13 +19,18 @@ constraints, and issue structure he should not need to specify himself.
    Do not overwrite or mix in unrelated local work.
 5. Before beginning any backlog workflow, verify live GitHub read availability with the
    configured `github/list_issues` tool for owner `lfarci`, repository `loganfarci.com`,
-   state `open`, and the smallest supported limit. If that preflight is unavailable or
-   fails, stop with a blocked report containing the attempted tool, the exact connector
-   error, and the statement that no live GitHub state was established. Do not use `gh`,
-   `web`, local/stale snapshots, prior conversation, or inferred issue state as a
-   fallback. After a successful preflight, use the GitHub connector for issue reads and
-   writes; `gh` is available for gaps only where the invoking agent has an execute tool
-   and the operation is not a fallback for a failed preflight.
+   state `open`, and the smallest supported limit — **unless the invoking agent is a
+   subagent of `backlog-maintainer` on a surface that grants fewer GitHub tools than the
+   agent file declares, and the orchestrator's kickoff prompt already carries a
+   freshly-verified live GitHub snapshot explicitly labelled as live.** In that case the
+   snapshot satisfies the preflight: use it, do not re-query. If the preflight is
+   unavailable or fails (and no such snapshot was supplied), stop with a blocked report
+   containing the attempted tool, the exact connector error, and the statement that no
+   live GitHub state was established. Do not use `gh`, `web`, local/stale snapshots, prior
+   conversation, or inferred issue state as a fallback. After a successful preflight, use
+   the GitHub connector for issue reads and writes; `gh` is available for gaps only where
+   the invoking agent has an execute tool and the operation is not a fallback for a failed
+   preflight.
 
 ## Reconstruct the request
 
@@ -147,6 +152,28 @@ These are specified once, here, so independently-invoked agents produce and cons
 compatible shapes without duplicating this skill's decision logic. See
 [`docs/agents/backlog-maintainer.md`](../../../docs/agents/backlog-maintainer.md) for the
 full system design.
+
+**Delivery — terminal-reply contract.** When `backlog-maintainer` dispatches a subagent as
+a tracked session, the subagent's **final reply message is the artifact** — the
+orchestrator pulls it from the transcript afterwards (`session_store_sql`, source
+`local`) and does not rely on push delivery. Subagents must therefore make the artifact
+(in one of the shapes below, or the blocked report shape) their last word and must not
+attempt a messaging tool to deliver it; they are not granted one. When the in-process
+`agent` tool is used instead, the returned text is already the payload, so the same rule
+applies. A subagent that is dispatched with a fresh orchestrator-supplied live GitHub
+snapshot in its prompt satisfies the preflight relief above; without that snapshot, a
+preflight failure means the subagent ends blocked and its terminal reply **is** the
+blocked report.
+
+**Blocked report** (any subagent, when GitHub live state could not be established)
+- `status: blocked`
+- `tool_attempted` — the `github/list_issues` (or self-healed equivalent) operation and
+  repository/query
+- `exact_error` — the verbatim connector error
+- `workflow` — `blocked; no live GitHub state was established`
+- Stop immediately; do not fall back to `gh`, `web`, stale snapshots, prior conversation,
+  or inferred issue state, and do not pass a blocked report downstream as if it were
+  evidence.
 
 **Evidence Brief** (`backlog-explorer` → `backlog-shaper`)
 - `subject` — the idea, gap, or issue under investigation

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -326,8 +326,9 @@ Notes on the flow:
   embeds a fresh live GitHub snapshot and all context in the kickoff prompt up front,
   ships the artifact from one phase into the next phase's kickoff prompt, and does not rely
   on `send_session_message` for delivery — a single nudge may be attempted if a child goes
-  silent, but if no artifact is retrievable the orchestrator escalates to Logan with the
-  child's partial transcript.
+  silent, but the orchestrator polls `get_session` again until that follow-up turn
+  completes before re-pulling the transcript, and if no artifact is retrievable it
+  escalates to Logan with the child's partial transcript.
 - **Review failures are routed by class, not lumped together.** An *application failure*
   means the approved payload did not land correctly — a transient API error, a field that
   did not take, a partial write. The approved content is still valid, so the writer may be

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -31,10 +31,10 @@ design.
 | VS Code-only `agents:` list restricts which subagents a coordinator may dispatch, and **overrides** `disable-model-invocation` for that coordinator | VS Code only | No longer a footgun to avoid: `issue-writer` is now deliberately included in the orchestrator's `agents:` list on every surface, and no longer carries `disable-model-invocation`, so there is nothing left to override. |
 | VS Code-only `handoffs:` list offers user-controlled transitions between agents | VS Code only | No longer the primary write mechanism — superseded by direct orchestrator dispatch (below) — but still available as a manual fallback if Logan wants to trigger the write himself. |
 | Subagent dispatch is **not** supported on plain github.com chat with no session tooling | Not supported | The cycle must degrade to manual sequential invocation only on that surface (see "Surface portability"). |
-| The **Copilot App** (this repo's session-based workspace tooling: `create_session`, `get_session`, `send_session_message`) lets a running session spawn other **tracked, sidebar-visible child sessions** and exchange messages with them | Supported when those tools are present in the agent's own tool list | This is a *stronger* delegation mechanism than the in-process `agent` tool: each phase becomes an inspectable, named session Logan can watch, not an opaque subprocess call. The orchestrator prefers it over `agent` whenever available. |
+| The **Copilot App** (this repo's session-based workspace tooling: `create_session`, `get_session`, `send_session_message`) lets a running session spawn other **tracked, sidebar-visible child sessions** | Supported for spawning and observing | Each phase becomes an inspectable, named session Logan can watch. **However, child sessions may be granted fewer tools than their frontmatter declares — including no `github/*` tools and no messaging tool — and `send_session_message` delivery from root to child has proven unreliable.** The design therefore treats the child's **final reply message as the artifact** and has the orchestrator **pull** it from the child's transcript via `session_store_sql` (source `local`) once `get_session` shows the child complete. It is a stronger, observable delegation mechanism than the in-process `agent` tool; the orchestrator prefers it over `agent` whenever available. |
 | Configured GitHub read tools provide the live backlog read | Required preflight | Every backlog phase that needs live GitHub state must prove this capability before reading or writing; a local file check is not sufficient. Exact tool names are namespaced per-surface — see "GitHub MCP configuration surface" — but an agent may only recover to an equivalent name that is already exposed through its own `tools:` allowlist; a genuine rename still requires a human frontmatter update. |
 | Skills are description-triggered and shared by all agents; there is no `skills:` frontmatter field | Confirmed | Agents reference `shape-backlog-idea` in their prose body; the skill stays the single source of backlog judgment. |
-| Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). Tracked Copilot App sessions relax this slightly: they can receive follow-up messages, but the design still treats each phase as a single request/response to keep the two dispatch mechanisms interchangeable. |
+| Subagent invocations are **stateless** — no follow-up messages to a running subagent | Confirmed | All context must be passed in the initial delegation, which forces explicit artifact hand-offs (below). Tracked Copilot App child sessions may be **messaging-less** (no `send_session_message` and no reliable delivery to root), so even there the design does not rely on follow-up pushes: the orchestrator embeds everything the child needs in the kickoff prompt, and the child's terminal reply **is** the artifact, retrieved by pull. This keeps the two dispatch mechanisms interchangeable. |
 
 ## GitHub MCP configuration surface
 
@@ -92,6 +92,14 @@ repository `loganfarci.com`, state `open`, with the smallest limit accepted by t
 connector. The repository does not document the connector schema, so agents MUST use only
 parameters exposed by the tool and omit the limit if it is unsupported. A successful
 GitHub response — including an empty result — is the only valid preflight.
+
+**Orchestrator-supplied snapshot relief.** Because tracked child sessions may be granted
+fewer tools than their frontmatter declares, the orchestrator performs its own live
+preflight and **embeds a fresh, verbatim snapshot of the live GitHub state in each child's
+kickoff prompt**, explicitly labelled as live. A subagent that receives such a snapshot
+MUST treat it as satisfying the preflight — it counts as live state, and the subagent must
+not re-query or block. Without a supplied snapshot, the preflight is mandatory and no
+fallback is permitted.
 
 The preflight is a capability check, not a local repository check. If the tool is
 unavailable or the call fails, the agent MUST stop and return a blocked report with:
@@ -151,7 +159,7 @@ Six agents: one orchestrator, five subagents.
 | **Invoked by** | The human. This is the entry point of the system. |
 | **Owns** | Routing the request to the right cycle, sequencing phases, holding the human gate, and producing the final report. |
 | **Reads before acting** | `docs/specs/README.md` (for spec precedence), `docs/specs/non-goals.md`, `AGENTS.md`, `.github/copilot-instructions.md`. |
-| **Tools** | `agent` (delegation), `create_session`/`get_session`/`send_session_message` (tracked-session delegation on the Copilot App), `read`, `search`, plus GitHub **read-only**. |
+| **Tools** | `agent` (delegation), `create_session`/`get_session`/`send_session_message` (tracked-session delegation on the Copilot App), `session_store_sql` (pull child artifacts from their transcripts), `read`, `search`, plus GitHub **read-only**. |
 | **Must NOT have** | Any GitHub write tool, `edit`, or `execute`. It must be incapable of mutating the backlog or the repo directly — it only ever reaches a write by dispatching `issue-writer`. |
 | **Produces** | A phase-by-phase status and a final report: what was found, what was decided, what was written (with links), what was escalated. |
 | **`agents:` list** | `backlog-explorer`, `backlog-shaper`, `backlog-prioritizer`, `issue-writer`, `issue-reviewer` — **includes `issue-writer`**, dispatched only in the same turn as, and strictly after, Logan's per-item approval (see "Human approval gate"). |
@@ -307,6 +315,15 @@ Notes on the flow:
   passing the approved payload plus proof of Logan's approval. `issue-writer` checks for
   that proof before writing anything. The receipt returns to the orchestrator before
   review continues. Logan can still invoke `issue-writer` manually if he prefers.
+- **Child artifacts are retrieved by pull, not delivered by push.** Tracked child sessions
+  return their artifact as their **final reply message**, which the orchestrator pulls
+  from the child's transcript (`session_store_sql`, source `local`, `turns` table, most
+  recent `assistant_response`) after `get_session` reports it complete. The orchestrator
+  embeds a fresh live GitHub snapshot and all context in the kickoff prompt up front,
+  ships the artifact from one phase into the next phase's kickoff prompt, and does not rely
+  on `send_session_message` for delivery — a single nudge may be attempted if a child goes
+  silent, but if no artifact is retrievable the orchestrator escalates to Logan with the
+  child's partial transcript.
 - **Review failures are routed by class, not lumped together.** An *application failure*
   means the approved payload did not land correctly — a transient API error, a field that
   did not take, a partial write. The approved content is still valid, so the writer may be
@@ -322,6 +339,10 @@ Notes on the flow:
 Because subagent invocations are stateless and context-isolated, every hand-off must be
 fully self-contained. These shapes are the interface between phases and should be
 specified once in the shared skill so independently-invoked agents agree on them.
+Delivery is **pull-based**: when a subagent runs as a tracked child session, its final
+reply message is the artifact and the orchestrator retrieves it via `session_store_sql`
+(snapshot-through transcript read); when it runs in-process, the returned text is the
+artifact. Subagents never deliver artifacts with a messaging tool.
 
 **Evidence Brief** (explorer → shaper)
 - `subject` — the idea, gap, or issue under investigation
@@ -339,7 +360,10 @@ specified once in the shared skill so independently-invoked agents agree on them
 - `workflow` — `blocked; no live GitHub state was established`
 
 This is a terminal status for the current workflow, not an Evidence Brief. It MUST NOT be
-passed to the next phase or converted into any other artifact contract.
+passed to the next phase or converted into any other artifact contract. When a subagent is
+dispatched as a tracked child session, a blocked report is returned the same way as any
+other artifact — as the child's final reply message, pulled by the orchestrator — so the
+orchestrator can distinguish a blocked child from a silent one.
 
 **Issue Proposal** (shaper → gate → writer)
 - `recommendation` — create | update | close | defer | **no-op**, with the decisive tradeoff
@@ -372,7 +396,7 @@ passed to the next phase or converted into any other artifact contract.
 | --- | --- |
 | **Copilot CLI** | Full delegation end-to-end, including the write. `backlog-maintainer` dispatches every phase — `backlog-explorer`, `backlog-shaper`, `backlog-prioritizer`, and, immediately after Logan's per-item approval, `issue-writer` — via the in-process `agent` tool, then `issue-reviewer`. Logan can still invoke any subagent manually if he wants to intervene mid-cycle. |
 | **VS Code** | Same full delegation as CLI. `issue-writer` is now included in the orchestrator's `agents:` list (previously omitted); a `handoffs:` transition to `issue-writer` remains available as a manual alternative for Logan, but is no longer the only path. |
-| **Copilot App (this repo's session-based workspace)** | Full delegation, dispatched as **tracked child sessions** rather than in-process subagent calls: `backlog-maintainer` calls `create_session` with `kickoff.agent` set to each phase's exact custom-agent name, including `Issue Writer` right after approval. Logan sees every phase as its own named session in the sidebar and can inspect or message it directly via `get_session`/`send_session_message`. This is the surface where delegation is most observable, which is why it is preferred whenever those tools are present. |
+| **Copilot App (this repo's session-based workspace)** | Full delegation, dispatched as **tracked child sessions** rather than in-process subagent calls: `backlog-maintainer` calls `create_session` with `kickoff.agent` set to each phase's exact custom-agent name, including `Issue Writer` right after approval. Logan sees every phase as its own named session in the sidebar and can inspect it directly. **Because children may lack `github/*` tools and messaging, the orchestrator embeds a fresh live GitHub snapshot (its own verified preflight output) in every kickoff prompt, and retrieves each phase's artifact from the child's transcript (`session_store_sql`, source `local`) after the child completes — pull, not push.** `get_session` is used to poll for completion; `send_session_message` is used only as a single nudge when a child goes silent, and is never assumed to deliver artifacts. This is the surface where delegation is most observable, which is why it is preferred whenever those tools are present. |
 | **Plain github.com chat / any surface with no subagent-dispatch tool at all** | No subagent dispatch. The cycle degrades to the human invoking each agent in order via `/agent`, passing the artifact from the previous phase. This is now the rare exception, not the default path for the App. |
 
 To keep that degradation possible, **every subagent stays `user-invocable: true`.** The
@@ -407,5 +431,12 @@ so agents invoked independently still produce and consume compatible shapes.
    to the orchestrator. This design intentionally keeps the pipeline strictly linear
    (each phase reports to the orchestrator, which dispatches the next) rather than letting
    e.g. `issue-reviewer` message `issue-writer` directly, so failure routing stays
-   auditable through the orchestrator's Step 5 logic. Revisit only if a concrete case
-   shows the orchestrator hop adds real latency without adding safety.
+   auditable through the orchestrator's Step 5 logic.
+   **Resolved (v0.3.x, pull-based handoff):** child sessions cannot be assumed to carry
+   `github/*` tools, a messaging tool, or a working `send_session_message` delivery path.
+   The design therefore does not rely on session-to-session messaging at all: the
+   orchestrator embeds a fresh live GitHub snapshot plus all phase context in each kickoff
+   prompt, children return the artifact as their final reply, and the orchestrator pulls
+   it from the child's transcript via `session_store_sql`. Sibling messaging remains out of
+   scope; revisit only if a concrete case shows the orchestrator hop adds real latency
+   without adding safety.

--- a/docs/agents/backlog-maintainer.md
+++ b/docs/agents/backlog-maintainer.md
@@ -95,11 +95,15 @@ GitHub response — including an empty result — is the only valid preflight.
 
 **Orchestrator-supplied snapshot relief.** Because tracked child sessions may be granted
 fewer tools than their frontmatter declares, the orchestrator performs its own live
-preflight and **embeds a fresh, verbatim snapshot of the live GitHub state in each child's
-kickoff prompt**, explicitly labelled as live. A subagent that receives such a snapshot
-MUST treat it as satisfying the preflight — it counts as live state, and the subagent must
-not re-query or block. Without a supplied snapshot, the preflight is mandatory and no
-fallback is permitted.
+preflight (a capability check only, using the smallest accepted limit) and then makes a
+**separate, complete fetch** of the GitHub state each phase actually needs — the full open
+issue list at the largest accepted page size, plus closed issues and/or pull requests when
+the phase must check for duplicates or already-completed work. The orchestrator embeds
+that complete, phase-specific result as a **fresh, verbatim snapshot** in each child's
+kickoff prompt, explicitly labelled as live and complete. A subagent that receives such a
+snapshot MUST treat it as satisfying the preflight — it counts as live state, and the
+subagent must not re-query or block. Without a supplied snapshot, the preflight is
+mandatory and no fallback is permitted.
 
 The preflight is a capability check, not a local repository check. If the tool is
 unavailable or the call fails, the agent MUST stop and return a blocked report with:


### PR DESCRIPTION
## Summary

Tracked Copilot App child sessions may load with fewer tools than their \	ools:\ frontmatter declares — in practice, no \github/*\ and no \send_session_message\ — so the previous push-based handoff (child messages its artifact back to the root session) silently produced nothing. This was observed live: the \acklog-explorer\ child produced a complete Evidence Brief that never reached the root session.

## Fix — pull-based handoff

1. The orchestrator (\acklog-maintainer\) performs its own live \github/list_issues\ preflight and embeds a **fresh verbatim GitHub snapshot in each child's \kickoff.prompt\**, so children never need \github/*\ at runtime and cannot silently fall back to stale local state.
2. Every subagent's **final reply message is the artifact** (Evidence Brief / Issue Proposal / Sequenced Plan / Write Receipt / Review Verdict / blocked report). Subagents never attempt messaging.
3. The orchestrator **pulls** the artifact from the child's transcript via \session_store_sql\ (source \local\) after \get_session\ shows completion; one \send_session_message\ nudge on silence, then escalate to Logan.
4. All five subagent files gain a \session_store_sql\-independent terminal-reply contract and snapshot relief in their preflights. The design doc and the \shape-backlog-idea\ skill are updated in lockstep (skill stays the single source for artifact contracts).

## Files

- \.github/agents/backlog-maintainer.agent.md\ — orchestrator handoff protocol
- \.github/agents/{backlog-explorer,backlog-shaper,backlog-prioritizer,issue-writer,issue-reviewer}.agent.md\ — terminal-reply contracts + snapshot relief
- \.github/skills/shape-backlog-idea/SKILL.md\ — hand-off contracts updated
- \docs/agents/backlog-maintainer.md\ — design of record updated; open question #4 resolved