### PR TITLE
chore: hide delegated agents from picker

### DIFF
--- a/.github/agents/backlog-explorer.agent.md
+++ b/.github/agents/backlog-explorer.agent.md
@@ -2,7 +2,7 @@
 name: Backlog Explorer
 description: Read-only backlog research agent for loganfarci.com. Use to establish facts before deciding anything — what the code/site actually does, what the specs require, and what already exists in the GitHub backlog — for one specific idea (targeted) or across the whole backlog (sweep). Produces an Evidence Brief; never drafts issue prose or decides an action.
 tools: ["read", "search", "web", "github/*"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Backlog Explorer

--- a/.github/agents/backlog-prioritizer.agent.md
+++ b/.github/agents/backlog-prioritizer.agent.md
@@ -2,7 +2,7 @@
 name: Backlog Prioritizer
 description: Read-only backlog sequencing agent for loganfarci.com. Use to order a set of Issue Proposals or the live backlog by priority and surface dependencies between them. Never sets milestones or labels — sequencing is advice for a human to accept, not a GitHub write.
 tools: ["read", "search", "github/*"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Backlog Prioritizer

--- a/.github/agents/backlog-shaper.agent.md
+++ b/.github/agents/backlog-shaper.agent.md
@@ -2,7 +2,7 @@
 name: Backlog Shaper
 description: Read-only backlog judgment agent for loganfarci.com. Use to turn an Evidence Brief into a decision and a ready-to-post GitHub issue draft — create, update, close, defer, or explicitly do nothing. This is where product judgment happens; it never posts to GitHub itself.
 tools: ["read", "search", "web", "github/*"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Backlog Shaper

--- a/.github/agents/feature-code-reviewer.agent.md
+++ b/.github/agents/feature-code-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: Feature Code Reviewer
 description: Read-only reviewer for one SHA-bound Implementation Receipt. Checks accepted scope, selected instructions, and specs without editing, publishing, or deploying.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature Code Reviewer

--- a/.github/agents/feature-deployment-manager.agent.md
+++ b/.github/agents/feature-deployment-manager.agent.md
@@ -2,7 +2,7 @@
 name: Feature Deployment Manager
 description: Deploys one explicitly approved SHA to its named Azure environment only after independent approval and authorization checks. It never edits code, creates PRs, or changes targets.
 tools: ["read", "search", "execute"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature Deployment Manager

--- a/.github/agents/feature-developer.agent.md
+++ b/.github/agents/feature-developer.agent.md
@@ -2,7 +2,7 @@
 name: Feature Developer
 description: Implements one accepted Delivery Brief in its own mutable worktree and returns a committed Implementation Receipt. It does not publish, deploy, or alter scope.
 tools: ["read", "search", "edit", "execute"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature Developer

--- a/.github/agents/feature-qa-engineer.agent.md
+++ b/.github/agents/feature-qa-engineer.agent.md
@@ -2,7 +2,7 @@
 name: Feature QA Engineer
 description: Checks observable user journeys for one SHA-bound receipt, including responsive, accessibility, theme, motion, and SSR/prerender concerns when relevant. It only reports evidence.
 tools: ["read", "search", "execute"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature QA Engineer

--- a/.github/agents/feature-release-manager.agent.md
+++ b/.github/agents/feature-release-manager.agent.md
@@ -2,7 +2,7 @@
 name: Feature Release Manager
 description: Validates an approved, SHA-bound pull-request proposal. Publication is blocked until exact live GitHub MCP read/write tool names are verified and minimally allowlisted.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature Release Manager

--- a/.github/agents/feature-test-engineer.agent.md
+++ b/.github/agents/feature-test-engineer.agent.md
@@ -2,7 +2,7 @@
 name: Feature Test Engineer
 description: Runs deterministic checks for one SHA-bound receipt and returns raw Test Receipt evidence. It does not edit, publish, deploy, or accept failures.
 tools: ["read", "search", "execute"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Feature Test Engineer

--- a/.github/agents/issue-reviewer.agent.md
+++ b/.github/agents/issue-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: Issue Reviewer
 description: Read-only post-write audit agent for loganfarci.com's backlog-maintainer system. Use after issue-writer executes an approved Issue Proposal, to verify what landed on GitHub matches what was approved and meets repository conventions. Flags drift, structure problems, duplication, and missing links; never edits anything itself.
 tools: ["read", "search", "github/*"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Issue Reviewer

--- a/.github/agents/issue-writer.agent.md
+++ b/.github/agents/issue-writer.agent.md
@@ -2,7 +2,7 @@
 name: Issue Writer
 description: The only write-capable agent in the backlog-maintainer system for loganfarci.com. Executes exactly one already-approved Issue Proposal against GitHub — create, update, close, defer, or comment. Dispatched by backlog-maintainer immediately after Logan's explicit per-item approval, or invoked directly by a human — never on its own initiative, and never without proof that approval actually happened.
 tools: ["read", "search", "github/*"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Issue Writer

--- a/.github/agents/specialist-accessibility.agent.md
+++ b/.github/agents/specialist-accessibility.agent.md
@@ -2,7 +2,7 @@
 name: Accessibility Specialist
 description: Read-only WCAG advisor when a Delivery Brief triggers accessibility risk or user-interface changes.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Accessibility Specialist

--- a/.github/agents/specialist-azure.agent.md
+++ b/.github/agents/specialist-azure.agent.md
@@ -2,7 +2,7 @@
 name: Azure Specialist
 description: Read-only advisor for Azure Static Web Apps and deployment-configuration risk when a Delivery Brief triggers Azure review.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Azure Specialist

--- a/.github/agents/specialist-debugging.agent.md
+++ b/.github/agents/specialist-debugging.agent.md
@@ -2,7 +2,7 @@
 name: Debugging Specialist
 description: Diagnoses reproducible Review, Test, or QA failures for one SHA-bound receipt and returns evidence plus a remediation hypothesis. It never edits, publishes, or deploys.
 tools: ["read", "search", "execute"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Debugging Specialist

--- a/.github/agents/specialist-frontend.agent.md
+++ b/.github/agents/specialist-frontend.agent.md
@@ -2,7 +2,7 @@
 name: Frontend Specialist
 description: Read-only advisor for UI layout, interaction, responsive behavior, and visual consistency when a Delivery Brief triggers frontend review.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Frontend Specialist

--- a/.github/agents/specialist-github-actions.agent.md
+++ b/.github/agents/specialist-github-actions.agent.md
@@ -2,7 +2,7 @@
 name: GitHub Actions Specialist
 description: Read-only advisor for workflow changes, permissions, and automation risk when a Delivery Brief touches .github/workflows.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # GitHub Actions Specialist

--- a/.github/agents/specialist-react.agent.md
+++ b/.github/agents/specialist-react.agent.md
@@ -2,7 +2,7 @@
 name: React Specialist
 description: Read-only advisor for React, routing, SSR, prerender, and state risks when a Delivery Brief triggers React/SSR review.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # React Specialist

--- a/.github/agents/specialist-security.agent.md
+++ b/.github/agents/specialist-security.agent.md
@@ -2,7 +2,7 @@
 name: Security Specialist
 description: Read-only advisor for secrets, permissions, dependency, and input risks when a Delivery Brief triggers security review.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Security Specialist

--- a/.github/agents/specialist-terraform.agent.md
+++ b/.github/agents/specialist-terraform.agent.md
@@ -2,7 +2,7 @@
 name: Terraform Specialist
 description: Read-only advisor for Terraform changes and infrastructure risk when a Delivery Brief touches infra.
 tools: ["read", "search"]
-user-invocable: true
+user-invocable: false
 ---
 
 # Terraform Specialist


### PR DESCRIPTION
The agent picker exposed delegated execution and specialist roles that are intended to be orchestrated rather than started directly. This leaves the picker focused on the two workflow entry points.

- Keep Backlog Maintainer and Feature Delivery Manager user-invocable.
- Mark all 19 delegated backlog, delivery, review, release, deployment, and specialist agents as non-user-invocable.