### PR TITLE
fix: harden delivery orchestration publication flow

### DIFF
--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Delivery Manager
-description: Coordinates delivery of one accepted issue through implementation evidence, SHA-bound review phases, and explicit human publication and deployment gates. It never edits, builds, publishes, deploys, or makes backlog decisions.
+description: Coordinates delivery of one accepted issue through implementation evidence, SHA-bound review phases, explicit human publication and deployment gates, and a post-delivery critical-orchestration self-improvement loop. It never edits product code, builds, publishes, deploys, or makes backlog decisions.
 tools: ["read", "search", "create_session", "get_session", "session_store_sql", "send_session_message", "list_sessions_and_chats"]
 user-invocable: true
 ---
@@ -27,3 +27,16 @@ exact proposal and wait for approve, edit, defer, reject, or cancel. Do not rout
 Release without green same-SHA evidence and a valid Approval Record; do not route to
 Deployment without a `published` Release Receipt and a separate valid Approval Record.
 A failed or blocked publication remains recoverable and must never be reported as a PR.
+
+After every delivery reaches a terminal state, perform the post-delivery retrospective
+specified in the design of record. Check for artifact loss, SHA/branch confusion,
+skipped gates, false publication/deployment claims, unauthorized routing, or an
+unrecoverable failure. Record either `no orchestration incident` or a Critical
+Orchestration Incident Record with exact evidence and affected phase. For a critical
+incident, preserve all original receipts, freeze the affected state, and create one
+isolated Feature Orchestration Maintainer session. The maintainer may change only
+orchestration guidance and deterministic validation fixtures, must return a
+commit-bound Remediation Receipt, and must not publish, deploy, broaden permissions,
+or change product scope. Never silently rewrite agent definitions yourself; report the
+remediation commit, validation, approval needs, and residual risk separately from the
+original delivery outcome.

--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -21,6 +21,9 @@ current surface cannot verify creation of a new child worktree at an arbitrary r
 SHA, so stop for the documented manual snapshot fallback instead of reusing the
 Developer branch for Review, Test, or QA.
 
-Use child final replies as artifacts and pull them from the transcript. At each gate,
-present the exact proposal and wait for approve, edit, defer, reject, or cancel. Do not
-route to Release or Deployment without a valid, uninvalidated Approval Record.
+Use child final replies as artifacts and pull them from the transcript, recording each
+child session, branch, SHA, and provenance before progressing. At each gate, present the
+exact proposal and wait for approve, edit, defer, reject, or cancel. Do not route to
+Release without green same-SHA evidence and a valid Approval Record; do not route to
+Deployment without a `published` Release Receipt and a separate valid Approval Record.
+A failed or blocked publication remains recoverable and must never be reported as a PR.

--- a/.github/agents/feature-deployment-manager.agent.md
+++ b/.github/agents/feature-deployment-manager.agent.md
@@ -14,7 +14,9 @@ Independently validate the Approval Record and require separate verification tha
 executing identity is authorized for the named mechanism and environment. Approval is
 not authorization. If either proof is absent, return a blocked Deployment Proposal.
 
-When both are valid, execute only the named mechanism for the exact approved SHA and
+When both are valid, require a published Release Receipt whose remote ref resolves to
+the exact approved SHA, then execute only the named mechanism for that SHA and
 environment, log exact commands, and return a Deployment Receipt with URL and status.
+A blocked or publication-failed release is never deployable.
 Never edit code, create or merge a PR, substitute a SHA/environment/mechanism, retry
 silently, inject credentials, or run unrelated commands.

--- a/.github/agents/feature-developer.agent.md
+++ b/.github/agents/feature-developer.agent.md
@@ -18,4 +18,7 @@ security posture, user behavior, or delivery risk.
 Execution is a behavioral boundary: log exact commands; do not run `git push`, `gh`,
 deployment, Azure, SWA, or Terraform-apply commands; do not use or discover credentials.
 Commit the implementation before hand-off and return an Implementation Receipt for that
-single SHA. A new commit invalidates prior Review, Test, QA, and Debugging results.
+single SHA, including the local branch/ref, parent/base SHA, changed paths, session ID,
+and exact commit evidence. The receipt is a release hand-off, not publication; the
+Developer never pushes or creates a PR. A new commit invalidates prior Review, Test, QA,
+and Debugging results.

--- a/.github/agents/feature-orchestration-maintainer.agent.md
+++ b/.github/agents/feature-orchestration-maintainer.agent.md
@@ -1,0 +1,30 @@
+---
+name: Feature Orchestration Maintainer
+description: Investigates and fixes one confirmed critical delivery-orchestration defect after a completed process. It changes only orchestration guidance and validation artifacts and returns a commit-bound remediation receipt.
+tools: ["read", "search", "edit", "execute"]
+user-invocable: false
+---
+
+# Feature Orchestration Maintainer
+
+Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md)
+and the applicable agent-definition instructions.
+
+Run only from an isolated maintenance session with a Critical Orchestration Incident
+Record supplied by the Feature Delivery Manager. Reconstruct the failure from the
+original receipts and exact errors before changing anything. Confirm that the defect is
+orchestration-critical: artifact loss, SHA/branch confusion, skipped gate,
+misrepresented publication/deployment, unauthorized routing, or unrecoverable failure.
+
+Change only the smallest relevant files under `docs/agents/`, `.github/agents/`,
+`.github/instructions/`, and deterministic validation fixtures. Do not change product
+source, accepted issue scope, credentials, GitHub state, branches outside the
+maintenance session, PRs, deployments, or approval records. Do not broaden tools or
+permissions as a workaround. Log exact validation commands, commit the fix, and return
+a Remediation Receipt containing the incident ID, changed paths, commit SHA, evidence,
+validation results, residual risk, and whether the original failure was re-tested.
+
+A remediation commit is not publication or deployment. If the proposed fix changes
+role ownership, permissions, approval policy, or artifact schemas, mark the receipt
+`needs-approval` and stop after local validation; the Delivery Manager must present the
+change for the normal human gates.

--- a/.github/agents/feature-release-manager.agent.md
+++ b/.github/agents/feature-release-manager.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Release Manager
-description: Validates an approved, SHA-bound pull-request proposal. Publication is blocked until exact live GitHub MCP read/write tool names are verified and minimally allowlisted.
+description: Owns publication of one approved, SHA-bound pull-request proposal. This configuration is currently blocked because no verified release write mechanism is exposed.
 tools: ["read", "search"]
 user-invocable: false
 ---
@@ -10,10 +10,20 @@ user-invocable: false
 Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md).
 
 Independently validate the Approval Record: repository, source branch and SHA, base,
-exact title/body, approval proof, and invalidation conditions. Refuse any mismatch,
-missing proof, or changed commit.
+exact title/body, approval proof, and invalidation conditions. Also verify local branch
+reachability and record whether the remote ref is absent, present at the approved SHA,
+or present at a conflicting SHA. Refuse any mismatch, missing proof, changed commit, or
+remote conflict.
 
-This target configuration intentionally has no verified GitHub write tool. Return a
-blocked Release Proposal naming the missing verified tool configuration; do not use
-shell, `gh`, a wildcard `github/*`, or another agent as a substitute. Never edit code,
-merge, alter the approved payload, or deploy.
+This target configuration intentionally has no verified GitHub write mechanism. Return a
+blocked Release Proposal with status `blocked`, preserve the Implementation Receipt,
+and name the human operator as the manual owner of this exact sequence: push the
+approved source branch/ref, verify the remote ref resolves to the approved SHA, then
+create/update the exact PR payload. The operator must return a Release Receipt or a
+`publication-failed` receipt with the verbatim error and recovery action. Do not pretend
+that a local commit or a failed PR command is publication. Never edit code, merge,
+alter the approved payload, deploy, use a wildcard `github/*`, or silently retry.
+
+When a future verified release mechanism is allowlisted, it must retain the same
+push → remote-SHA verification → PR order and exact-payload checks; update this
+frontmatter and the capability table before enabling it.

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -1,8 +1,8 @@
 ---
 spec: feature-delivery-manager agent system
-version: 0.1.0
+version: 0.2.0
 status: design
-verified: 2026-08-10
+verified: 2026-08-11
 ---
 
 # Feature Delivery Manager - Design
@@ -32,7 +32,7 @@ implication.
 | Session messages | Observed, but child delivery and child tool inheritance are not guaranteed. | Include all inputs in a kickoff prompt. Retrieve the terminal artifact from the transcript. Use one message only to request a missing artifact. |
 | In-process subagents | Documented for VS Code/CLI (`agent` plus an `agents` list); not verified in this App session. | App sessions are the primary route. On a surface without tracked sessions, use a documented in-process subagent only if it can preserve the phase boundary; otherwise stop and name the next manual role. |
 | Live GitHub MCP read/write names | **Configuration mismatch.** `.github/mcp.json` configures a `github` server with `tools: ["*"]`, but this session exposes GitHub-oriented built-ins and `gh`, not a discoverable `github/*` MCP toolset. | Do not add `github/*` to new frontmatter. Use no GitHub tools for read-only roles. Release Manager is a human-invocable, approval-refusing placeholder until a human verifies exact PR read/write MCP names and replaces wildcard access with its minimal allowlist. |
-| Pull-request write operation | Observed only as the App's `create_pull_request` and `update_pull_request` built-ins, not as a configurable custom-agent tool name. | Do not claim an agent-file allowlist can expose it. A human performs the approved action manually until a verified MCP name is available. |
+| Pull-request write operation | Observed as the App's `create_pull_request` and `update_pull_request` built-ins; no verified configurable custom-agent name is exposed in this App session. | The Release Manager owns publication. Until a verified agent-accessible write mechanism exists, the human performs the approved release operation as the named manual fallback and records its receipt; never attribute a built-in action to a child agent. |
 | Generic command execution | Available on Developer, Test Engineer, QA Engineer, and Deployment Manager target roles; it can run arbitrary Git, GitHub, or deployment commands. No scoped sandbox or isolated credentials was verified. | Boundaries for execution-bearing roles are behavioral, not structural: use isolated worktrees, no credential injection, exact-command logging, and no `git push`, `gh`, `swa deploy`, Azure, or Terraform-apply command outside the approved role and gate. Residual risk remains. |
 | Credentials | `gh` is available in the environment, but token scope, Azure/SWA credentials, executing identity, and session credential isolation are unverified. | Never add tokens to files, prompts, or artifacts. Do not attempt credential discovery. Approval is not authorization: deployment remains blocked until a human either performs it in an authorized surface or verifies the executing identity and named mechanism out of band. |
 
@@ -61,7 +61,7 @@ shell access as an undocumented replacement.
 | Test Engineer | Run deterministic checks and return raw evidence for one receipt SHA | Read/search/execute; behavioral execution boundary | Edit, treat a failure as acceptable, publish, deploy |
 | QA Engineer | Check observable journeys, responsive behavior, a11y, themes, reduced motion, and SSR/prerender when relevant | Read/search/execute/browser; behavioral execution boundary | Edit, downgrade defects, publish, deploy |
 | Debugging Specialist | Diagnose a reproducible Review, Test, or QA failure on one receipt SHA and return evidence and a remediation hypothesis | Read/search/execute; behavioral execution boundary | Edit, publish, deploy, or choose a scope-changing fix |
-| Release Manager | Create or update an exact approved PR after independent Approval Record validation | Read/search only until exact GitHub MCP names are verified; publication automation is blocked | Edit code, merge, change PR payload, or use an unverified GitHub tool |
+| Release Manager | Publish the exact approved source SHA and create or update its PR after independent Approval Record validation | Owns release preflight and push → remote-SHA verification → PR sequencing. Uses only a verified release mechanism; otherwise emits a blocked receipt with the named human fallback | Edit code, merge, change payload, substitute refs, or silently retry |
 | Deployment Manager | Execute the exact approved SHA, environment, and named mechanism | Execute only after independent Approval Record validation; behavioral boundary | Edit code, create or merge a PR, substitute a SHA, target, or mechanism |
 
 The eight on-demand specialists are **React**, **Frontend**, **Accessibility**,
@@ -114,25 +114,34 @@ host behavior rather than merely the fixture's glob interpretation.
    Before implementation, the Developer reports its initial `HEAD`; the manager records
    equality with the Delivery Brief's base SHA. A mismatch blocks the cycle and requires
    a human-created branch at that SHA. The Developer is its sole mutable owner.
-2. The Developer commits before hand-off and returns an Implementation Receipt. Its
-   branch and SHA, never uncommitted files, are the input to later work.
+2. The Developer commits before hand-off and returns an Implementation Receipt containing
+   the local branch, exact SHA, parent/base SHA, changed paths, and session ID. The commit
+   is the input to later work; uncommitted files are never an artifact.
 3. Every Review, Test, QA, and Debugging phase needs a fresh distinct child
    branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. The
-   manager records that equality.
-4. The current App cannot create that exact SHA snapshot automatically. It must stop
-   and request the documented manual snapshot instead of checking out the live branch
-   or assuming detached-SHA support.
+   manager records the phase session ID, branch, and equality evidence.
+4. The current App cannot create that exact SHA snapshot automatically. The manager must
+   stop and request a human-created branch at the receipt SHA, then a fresh named session
+   on that branch. The fallback record includes branch, SHA, session ID, and `HEAD`
+   command output; a live Developer branch or detached checkout is not a substitute.
 5. A Developer commit invalidates every Review, Test, QA, and Debugging artifact for an
    older SHA. Recreate snapshots and receipts from the new receipt.
 6. The manager alone creates and tracks sessions. Children do not route siblings,
    create replacements, or rely on shared memory. A terminal artifact is pulled from
-   its transcript.
+   its transcript and its provenance is recorded.
+7. Before release, the Release Manager verifies that the exact local branch contains the
+   receipt SHA and that the approved source branch is not already mapped to a different
+   remote SHA. Publication is push the exact branch/ref, verify the remote ref resolves
+   to the receipt SHA, then create/update the PR. A local commit is never treated as
+   published.
 
 ## Artifacts and gates
 
 Every artifact includes `delivery_id`, issue number/URL, source branch, source commit
-SHA, input references, status (`pass`, `fail`, `blocked`, or `needs-approval`),
-timestamp, and session ID where applicable.
+SHA, input references, status (`pass`, `fail`, `blocked`, `needs-approval`,
+`awaiting-publication`, `publication-failed`, or `published`), timestamp, and session ID
+where applicable. Release artifacts also include remote name/ref, remote-SHA status,
+operation attempt number, exact command/tool outcome, and a recovery reference.
 
 | Artifact | Required contents |
 | --- | --- |
@@ -142,20 +151,34 @@ timestamp, and session ID where applicable.
 | Implementation Receipt | Changed paths, committed branch/SHA, commands/results, limits, and referenced brief/guidance |
 | Review Verdict / Test Receipt / QA Verdict | Source SHA, status, selected instructions/specs assessed, evidence, and actionable remediation |
 | Approval Record | Exact action; repository; source branch/SHA; exact PR payload or environment/mechanism; invalidation rules; and a verbatim human approval quote or unambiguous approval-message reference |
-| Release or Deployment Proposal/Receipt | Approval Record reference, one SHA, approved payload/environment/mechanism, and resulting PR or deployment URL/status |
+| Release Proposal/Receipt | Approval Record reference, one SHA, approved repository/base/head/title/body, local and remote ref evidence, push/PR attempt outcome, and resulting PR URL/status or a durable failure plus named recovery action |
+| Deployment Proposal/Receipt | Approval Record reference, one SHA, approved environment/mechanism, authorization evidence, and resulting deployment URL/status or a durable failure plus named recovery action |
 
 After green Review, Test, and QA receipts for the same SHA, the manager presents a PR
 proposal with repository, source branch/SHA, base, exact title, and exact body. The
 human may approve, edit, defer, reject, or cancel. Edit invalidates the proposal;
-defer pauses; reject/cancel ends it. PR approval never authorizes deployment.
+defer pauses; reject/cancel ends it. PR approval never authorizes deployment. Approval
+moves the delivery to `awaiting-publication`; it does not imply that a local branch is
+visible on GitHub.
 
-A separate Deployment Proposal names the repository, SHA, `preview` or `production`
-environment, and mechanism. The same five human actions apply. A new commit, changed
-PR title/body/base/head, changed environment/mechanism, or scope change invalidates the
-relevant Approval Record. Release and Deployment Managers independently refuse to act
-without a valid record. Deployment also requires independently verified authorization
-for its executing identity and named mechanism. Neither role retries, merges,
-substitutes targets, or injects tokens.
+The Release Manager validates the record and performs the exact release mechanism. The
+required order is: local SHA/branch preflight, push exact source ref, remote SHA
+verification, PR create/update, and release receipt. If any step fails, the manager
+records `publication-failed` with the verbatim error, preserved Implementation Receipt,
+attempt number, current remote-ref evidence, and one safe recovery action. A retry is a
+new release attempt against the same still-valid Approval Record only after preflight;
+changed SHA, payload, base/head, or target requires new approval. If no verified release
+mechanism is available, the Release Manager emits the same blocked receipt and names
+the human operator as the manual owner of the exact push/remote-verification/PR
+sequence.
+
+A separate Deployment Proposal names the repository, published SHA, `preview` or
+`production` environment, and mechanism. The same five human actions apply. A new
+commit, changed PR title/body/base/head, changed environment/mechanism, or scope change
+invalidates the relevant Approval Record. Deployment requires a published release
+receipt, independent authorization for its executing identity and named mechanism, and
+its own receipt. Neither role merges, substitutes targets, or injects tokens; retries
+must be explicit and recorded.
 
 ## Flow and failure routing
 
@@ -172,28 +195,51 @@ flowchart TD
     B --> D
     R -->|finding or failure| D
     R -->|same-SHA passes| P{Human PR decision}
-    P -->|approved record| L[Release Manager]
-    L --> Q{Human deployment decision}
+    P -->|approved record| L[Release Manager: preflight]
+    L --> U{Verified release mechanism?}
+    U -->|no| H[Named human push + remote verify + PR fallback]
+    U -->|yes| W[Push exact ref + verify remote SHA]
+    H --> Z{Release receipt?}
+    W --> Z{PR create/update}
+    Z -->|published| Q{Human deployment decision}
+    Z -->|failed| F2[publication-failed receipt + recovery]
     Q -->|approved record| X[Deployment Manager]
 ```
 
 Any failed required check, unresolved high-confidence finding, missing exact-SHA
-snapshot, missing tool, or invalid approval blocks publication. The manager reports
-the blocker and next manual role; it never skips a phase or changes scope to force a
-green result.
+snapshot, missing tool, invalid approval, missing remote ref, or remote SHA mismatch
+blocks publication. The manager reports the blocker and next manual role; it never skips
+a phase or changes scope to force a green result. A failed PR attempt is not a published
+state and never authorizes deployment.
+
+## Failed delivery fixture: issue #373
+
+This is preserved evidence for orchestration testing, not an active delivery. The
+Developer committed `176778cd5e0a12396ca1b98da956360f5aab1a32` on local branch
+`lfarci-super-robot`, but the branch was never pushed to GitHub. The subsequent
+`gh pr create --repo lfarci/loganfarci.com --base main --head lfarci-super-robot ...`
+failed because GitHub had no head ref: `Head sha can't be blank, Base sha can't be
+blank, No commits between main and lfarci-super-robot, Head ref must be a branch`.
+The root cause was not the commit or issue content; it was an incomplete publication
+handoff and an unowned push/remote-verification step. Recovery must retain the
+Implementation Receipt, verify the local SHA, publish the exact branch through the
+Release Manager or its named human fallback, verify the remote SHA, and only then
+retry PR creation under the same or a newly validated Approval Record.
 
 ## Residual risk and release conditions
 
 Tool allowlists do not structurally prevent arbitrary shell-based mutation on roles
 with `execute`. Until the host provides scoped execution and isolated credentials,
-every execution-bearing role must log exact commands, use a fresh isolated worktree,
-avoid credentials, and follow its no-publish/no-deploy behavioral rule. This residual
-risk is explicit and does not weaken approval gates.
+execution-bearing roles must log exact commands, use a fresh isolated worktree, avoid
+credentials, and follow their role-specific boundary. Release publication is limited to
+the exact approved push/remote-verification/PR sequence; deployment remains separately
+gated. This residual risk is explicit and does not weaken approval gates.
 
 Before enabling automated release work, a human must verify the exact live GitHub MCP
 read/write names, replace `.github/mcp.json` wildcard access with only the required
-tools, and update this capability table and the affected agent frontmatter. Before
-enabling automated snapshot phases, a human must verify a supported branch-at-SHA
-worktree creation path. Before enabling automated deployment, a human must verify the
-executing identity and named mechanism without exposing credentials. Until then, manual
-fallback is the only safe path for those phases.
+release tools, and update this capability table and the Release Manager frontmatter.
+Until then, the named human fallback owns the approved release sequence; the wildcard
+configuration is not evidence that a child agent can use GitHub publication tools. Before enabling
+automated snapshot phases, a human must verify a supported branch-at-SHA worktree
+creation path. Before enabling automated deployment, a human must verify the executing
+identity and named mechanism without exposing credentials.

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -61,6 +61,7 @@ shell access as an undocumented replacement.
 | Test Engineer | Run deterministic checks and return raw evidence for one receipt SHA | Read/search/execute; behavioral execution boundary | Edit, treat a failure as acceptable, publish, deploy |
 | QA Engineer | Check observable journeys, responsive behavior, a11y, themes, reduced motion, and SSR/prerender when relevant | Read/search/execute/browser; behavioral execution boundary | Edit, downgrade defects, publish, deploy |
 | Debugging Specialist | Diagnose a reproducible Review, Test, or QA failure on one receipt SHA and return evidence and a remediation hypothesis | Read/search/execute; behavioral execution boundary | Edit, publish, deploy, or choose a scope-changing fix |
+| Orchestration Maintainer | Investigate and fix a confirmed critical delivery-orchestration defect after a completed process | Owns only orchestration docs, agent definitions, validation fixtures, and tests in an isolated maintenance session; returns a commit-bound remediation receipt | Change product scope/code, bypass approvals, publish, deploy, or silently alter policy |
 | Release Manager | Publish the exact approved source SHA and create or update its PR after independent Approval Record validation | Owns release preflight and push → remote-SHA verification → PR sequencing. Uses only a verified release mechanism; otherwise emits a blocked receipt with the named human fallback | Edit code, merge, change payload, substitute refs, or silently retry |
 | Deployment Manager | Execute the exact approved SHA, environment, and named mechanism | Execute only after independent Approval Record validation; behavioral boundary | Edit code, create or merge a PR, substitute a SHA, target, or mechanism |
 
@@ -179,6 +180,38 @@ invalidates the relevant Approval Record. Deployment requires a published releas
 receipt, independent authorization for its executing identity and named mechanism, and
 its own receipt. Neither role merges, substitutes targets, or injects tokens; retries
 must be explicit and recorded.
+
+## Post-delivery critical-incident self-improvement
+
+After every completed delivery, the manager performs a short retrospective over the
+Delivery Brief, all phase artifacts, release/deployment receipts, and failure records.
+This is mandatory even when the delivery succeeds. A **critical orchestration issue** is
+any defect that can lose an artifact, misidentify a SHA/branch, skip a required gate,
+misrepresent publication/deployment, route work to an unauthorized role, or make a
+failure unrecoverable. Product defects and ordinary implementation failures remain in
+their normal delivery path and do not trigger policy self-modification.
+
+When a critical issue is found, the manager MUST:
+
+1. freeze the affected delivery state and preserve the original receipts and exact error;
+2. produce a Critical Orchestration Incident Record with delivery ID, phase, evidence,
+   impact, root-cause hypothesis, confidence, affected rules/files, and a safe recovery;
+3. investigate the orchestration definitions and validation fixtures before proposing a
+   fix; never infer a platform capability or silently widen permissions;
+4. create an isolated Orchestration Maintainer session to implement only the smallest
+   documentation/configuration/fixture fix, run targeted validation, and return a
+   commit-bound Remediation Receipt;
+5. re-run the failed gate against the corrected contract when possible, or record why it
+   cannot be reproduced; and
+6. report the remediation commit and residual risk to the human. The manager MUST NOT
+   merge, publish, deploy, change the accepted product scope, or mark the original
+   delivery successful because the orchestration fix landed.
+
+The self-improvement loop is idempotent: one incident ID gets one remediation attempt
+until a human explicitly requests another iteration. A fix that changes role tools,
+approval policy, publication/deployment ownership, or artifact schemas is itself
+release-blocking documentation/configuration work and requires the normal review and
+human publication gates.
 
 ## Flow and failure routing
 

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -1,0 +1,48 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const designPath = join(repositoryRoot, "docs", "agents", "feature-delivery-manager.md");
+const releaseAgentPath = join(repositoryRoot, ".github", "agents", "feature-release-manager.agent.md");
+
+const design = await readFile(designPath, "utf8");
+const releaseAgent = await readFile(releaseAgentPath, "utf8");
+
+const failures = [];
+function assert(condition, message) {
+    if (!condition) failures.push(message);
+}
+
+const failedDeliveryFixture = {
+    deliveryId: "issue-373-failed-publication",
+    sourceBranch: "lfarci-super-robot",
+    sourceSha: "176778cd5e0a12396ca1b98da956360f5aab1a32",
+    localCommit: true,
+    remoteRef: false,
+    prAttempted: true,
+    prCreated: false,
+};
+
+assert(failedDeliveryFixture.localCommit, "failed-delivery fixture must preserve the local commit");
+assert(!failedDeliveryFixture.remoteRef, "failed-delivery fixture must model an absent remote ref");
+assert(failedDeliveryFixture.prAttempted, "fixture must preserve the failed PR attempt");
+assert(!failedDeliveryFixture.prCreated, "fixture validation must not claim a PR was created");
+assert(design.includes("A local commit is never treated as"), "design must distinguish local commits from publication");
+assert(design.includes("push exact source ref"), "design must require pushing the exact source ref");
+assert(design.includes("remote-SHA verification") || design.includes("verify the remote ref resolves"), "design must require remote SHA verification");
+assert(design.includes("publication-failed"), "design must define a durable publication-failed state");
+assert(design.includes("preserved Implementation Receipt"), "failed publication must preserve the implementation receipt");
+assert(design.indexOf("push exact source ref") < design.indexOf("PR create/update"), "PR creation must follow push");
+assert(design.indexOf("remote SHA verification") < design.indexOf("PR create/update"), "PR creation must follow remote verification");
+assert(/Deployment requires a published release\s+receipt/.test(design), "deployment must require a published release receipt");
+assert(releaseAgent.includes("blocked"), "current release agent must expose its blocked capability state");
+assert(/push the\s+approved source branch\/ref/.test(releaseAgent), "manual fallback must own branch publication");
+assert(releaseAgent.includes("publication-failed"), "release agent must return recoverable failure evidence");
+assert(releaseAgent.includes("local commit or a failed PR command is publication"), "release agent must reject false publication claims");
+
+if (failures.length > 0) {
+    throw new Error(`Delivery contract validation failed:\n${failures.join("\n")}`);
+}
+
+console.log(`Validated delivery contract and ${failedDeliveryFixture.deliveryId} fixture.`);

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -5,9 +5,13 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const designPath = join(repositoryRoot, "docs", "agents", "feature-delivery-manager.md");
 const releaseAgentPath = join(repositoryRoot, ".github", "agents", "feature-release-manager.agent.md");
+const managerAgentPath = join(repositoryRoot, ".github", "agents", "feature-delivery-manager.agent.md");
+const maintainerAgentPath = join(repositoryRoot, ".github", "agents", "feature-orchestration-maintainer.agent.md");
 
 const design = await readFile(designPath, "utf8");
 const releaseAgent = await readFile(releaseAgentPath, "utf8");
+const managerAgent = await readFile(managerAgentPath, "utf8");
+const maintainerAgent = await readFile(maintainerAgentPath, "utf8");
 
 const failures = [];
 function assert(condition, message) {
@@ -40,6 +44,19 @@ assert(releaseAgent.includes("blocked"), "current release agent must expose its 
 assert(/push the\s+approved source branch\/ref/.test(releaseAgent), "manual fallback must own branch publication");
 assert(releaseAgent.includes("publication-failed"), "release agent must return recoverable failure evidence");
 assert(releaseAgent.includes("local commit or a failed PR command is publication"), "release agent must reject false publication claims");
+
+// Self-improvement contract: critical incidents are investigated after every terminal delivery,
+// while fixes remain isolated, receipt-preserving, and unable to publish or deploy themselves.
+assert(design.includes("Post-delivery critical-incident self-improvement"), "design must define a post-delivery retrospective");
+assert(design.includes("Critical Orchestration Incident Record"), "design must define a structured critical incident record");
+assert(design.includes("Remediation Receipt"), "design must define a remediation receipt");
+assert(design.includes("one incident ID gets one remediation attempt"), "self-improvement must be idempotent");
+assert(managerAgent.includes("After every delivery reaches a terminal state"), "manager must run the retrospective after every delivery");
+assert(managerAgent.includes("Feature Orchestration Maintainer session"), "manager must route critical incidents to the maintainer");
+assert(maintainerAgent.includes("user-invocable: false"), "maintainer must be an orchestrated role");
+assert(/Do not change product\s+source/.test(maintainerAgent), "maintainer must not alter product scope/code");
+assert(maintainerAgent.includes("not publication or deployment"), "maintainer must not publish or deploy");
+assert(maintainerAgent.includes("Remediation Receipt"), "maintainer must return remediation evidence");
 
 if (failures.length > 0) {
     throw new Error(`Delivery contract validation failed:\n${failures.join("\n")}`);


### PR DESCRIPTION
## Why
The previous delivery attempt demonstrated that a local commit could be mistaken for a publishable branch, causing PR creation to fail without a durable recovery path. This change hardens the delivery orchestration contract so publication, deployment, artifacts, and failures remain SHA-bound and evidence-based.

## What changed
- Require exact source-ref publication followed by remote-SHA verification before PR creation.
- Add explicit blocked, publication-failed, and published states with recoverable receipts.
- Preserve implementation artifacts and provenance across failure and manual snapshot fallback.
- Require a published Release Receipt plus separate approval before deployment.
- Add a post-delivery critical-orchestration retrospective and isolated remediation maintainer.
- Add deterministic validation covering the preserved issue #373 failed-publication fixture.

## Validation
- `node scripts/validate-delivery-contract.mjs`
- `node scripts/validate-instruction-scopes.mjs`
- `git diff --check`

## Notes
No credentials, deployments, or issue #373 mutations were performed. Automatic publication remains conservative when no verified release mechanism is configured.