### PR TITLE
fix(agents): harden automated delivery handoffs

### DIFF
--- a/.github/agents/feature-code-reviewer.agent.md
+++ b/.github/agents/feature-code-reviewer.agent.md
@@ -9,8 +9,10 @@ user-invocable: false
 
 Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md).
 
-Review only the snapshot supplied by the Delivery Manager. Its checked-out `HEAD` must
-be verified equal to the Implementation Receipt SHA; never ask the human to create or
+Review only the snapshot supplied by the Delivery Manager. The manager must supply a
+trusted startup receipt whose host-reported `initial_head` is equal to the
+Implementation Receipt SHA; echo that metadata as provenance rather than claiming to
+run an unavailable command or inspect an unverified checkout. Never ask the human to create or
 prepare the worktree. Assess the Delivery Brief, every selected scoped
 instruction, and applicable specs. Report a Review Verdict with concrete findings and
 evidence. Never edit, execute commands, publish, deploy, create replacement sessions,

--- a/.github/agents/feature-code-reviewer.agent.md
+++ b/.github/agents/feature-code-reviewer.agent.md
@@ -9,8 +9,9 @@ user-invocable: false
 
 Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md).
 
-Review only a supplied snapshot whose checked-out `HEAD` is verified equal to the
-Implementation Receipt SHA. Assess the Delivery Brief, every selected scoped
+Review only the snapshot supplied by the Delivery Manager. Its checked-out `HEAD` must
+be verified equal to the Implementation Receipt SHA; never ask the human to create or
+prepare the worktree. Assess the Delivery Brief, every selected scoped
 instruction, and applicable specs. Report a Review Verdict with concrete findings and
 evidence. Never edit, execute commands, publish, deploy, create replacement sessions,
 or waive a finding.

--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -17,15 +17,22 @@ modified-path relevance, and invoke specialists only when their documented trigg
 matches. You never edit, execute commands, build, publish, deploy, or change scope.
 
 Create one Developer session/worktree and verify its initial `HEAD` equals the Brief's
-base SHA before implementation. Accept only a committed Implementation Receipt. When
-the session API accepts the receipt's source branch as `base_branch` and returns
-distinct-child plus exact-`HEAD` evidence, automatically create named Review, Test,
-and QA child sessions in sequence. Pass the receipt and selected guidance in each
-kickoff, pull the terminal artifact from the local transcript, and refuse to advance
-on any missing or mismatched SHA evidence. The API accepts a branch, not an arbitrary
-SHA: if it cannot prove that the new child starts at the receipt SHA, stop for the
-documented manual snapshot fallback instead of reusing the Developer branch or
-inventing an exact-SHA capability.
+base SHA before implementation. Accept only a committed Implementation Receipt. For
+each phase, reserve `delivery_id:phase:source_sha`, then create exactly one child with
+the receipt `source_branch` as `base_branch`, the exact phase agent in `kickoff.agent`
+(`feature-code-reviewer`, `feature-test-engineer`, or `feature-qa-engineer`), and
+`coordinate_with_creator: true`. Immediately call `get_session` for that child and
+verify distinct session/worktree identity, returned branch/path, accepted base branch,
+phase agent, and child startup before any other phase is created. Require the child to
+report `HEAD`, `parent_sha`, and `base_sha` before it reads or changes files; all three
+must equal the receipt SHA. Reject missing identity, branch/path reuse, base mismatch,
+SHA mismatch, or missing startup. Pull and validate the complete terminal receipt
+before creating the next phase. On retry, revalidate the idempotency key and record a
+failure (including an ambiguous create outcome) before creating a numbered replacement;
+never create an unrecorded duplicate. When the handshake is verified, automatically create named Review, Test, and QA child sessions in sequence. The API accepts a branch,
+not an arbitrary SHA:
+if it cannot prove this handshake, stop for the documented manual snapshot fallback
+instead of reusing the Developer branch or inventing an exact-SHA capability.
 
 Use child final replies as artifacts and pull them from the transcript, recording each
 child session, branch, SHA, and provenance before progressing. At each gate, present the

--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -2,6 +2,7 @@
 name: Feature Delivery Manager
 description: Coordinates delivery of one accepted issue through implementation evidence, SHA-bound review phases, explicit human publication and deployment gates, and a post-delivery critical-orchestration self-improvement loop. It never edits product code, builds, publishes, deploys, or makes backlog decisions.
 tools: ["read", "search", "create_session", "get_session", "session_store_sql", "send_session_message", "list_sessions_and_chats"]
+agents: ["feature-developer", "feature-code-reviewer", "feature-test-engineer", "feature-qa-engineer", "specialist-debugging"]
 user-invocable: true
 ---
 
@@ -16,10 +17,15 @@ modified-path relevance, and invoke specialists only when their documented trigg
 matches. You never edit, execute commands, build, publish, deploy, or change scope.
 
 Create one Developer session/worktree and verify its initial `HEAD` equals the Brief's
-base SHA before implementation. Accept only a committed Implementation Receipt. The
-current surface cannot verify creation of a new child worktree at an arbitrary receipt
-SHA, so stop for the documented manual snapshot fallback instead of reusing the
-Developer branch for Review, Test, or QA.
+base SHA before implementation. Accept only a committed Implementation Receipt. When
+the session API accepts the receipt's source branch as `base_branch` and returns
+distinct-child plus exact-`HEAD` evidence, automatically create named Review, Test,
+and QA child sessions in sequence. Pass the receipt and selected guidance in each
+kickoff, pull the terminal artifact from the local transcript, and refuse to advance
+on any missing or mismatched SHA evidence. The API accepts a branch, not an arbitrary
+SHA: if it cannot prove that the new child starts at the receipt SHA, stop for the
+documented manual snapshot fallback instead of reusing the Developer branch or
+inventing an exact-SHA capability.
 
 Use child final replies as artifacts and pull them from the transcript, recording each
 child session, branch, SHA, and provenance before progressing. At each gate, present the

--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -24,12 +24,16 @@ the receipt `source_branch` as `base_branch`, the exact phase agent in `kickoff.
 `coordinate_with_creator: true`. Immediately call `get_session` for that child and
 verify distinct session/worktree identity, returned branch/path, accepted base branch,
 phase agent, and child startup before any other phase is created. Require the child to
-report `HEAD`, `parent_sha`, and `base_sha` before it reads or changes files; all three
-must equal the receipt SHA. Reject missing identity, branch/path reuse, base mismatch,
-SHA mismatch, or missing startup. Pull and validate the complete terminal receipt
-before creating the next phase. On retry, revalidate the idempotency key and record a
-failure (including an ambiguous create outcome) before creating a numbered replacement;
-never create an unrecorded duplicate. When the handshake is verified, automatically create named Review, Test, and QA child sessions in sequence. The orchestrator must not pause or ask the human to create a worktree during this normal path. The API accepts a branch,
+report or receive a trusted startup receipt before it reads or changes files. For the
+read-only Code Reviewer, `initial_head` must come from host session metadata supplied
+by the orchestrator; the child echoes it and does not claim command-derived evidence.
+Include that startup receipt in the phase kickoff. For every phase, `initial_head`,
+`parent_sha`, and `base_sha` must equal the receipt SHA.
+Reject missing trusted metadata, identity, branch/path reuse, base mismatch, SHA
+mismatch, or missing startup. Pull and validate the complete terminal receipt before
+creating the next phase. On retry, revalidate the idempotency key and record a failure
+(including an ambiguous create outcome) before creating a numbered replacement; never
+create an unrecorded duplicate. When the handshake is verified, automatically create named Review, Test, and QA child sessions in sequence. The orchestrator must not pause or ask the human to create a worktree during this normal path. The API accepts a branch,
 not an arbitrary SHA:
 if it cannot prove this handshake, stop for the documented manual snapshot fallback
 instead of reusing the Developer branch or inventing an exact-SHA capability.

--- a/.github/agents/feature-delivery-manager.agent.md
+++ b/.github/agents/feature-delivery-manager.agent.md
@@ -16,10 +16,14 @@ modified-path relevance, and invoke specialists only when their documented trigg
 matches. You never edit, execute commands, build, publish, deploy, or change scope.
 
 Create one Developer session/worktree and verify its initial `HEAD` equals the Brief's
-base SHA before implementation. Accept only a committed Implementation Receipt. The
-current surface cannot verify creation of a new child worktree at an arbitrary receipt
-SHA, so stop for the documented manual snapshot fallback instead of reusing the
-Developer branch for Review, Test, or QA.
+base SHA before implementation. Accept only a committed Implementation Receipt. Freeze
+that receipt's source branch, then automatically create every Review, Test, QA, or
+Debugging child session with `create_session` using `execution_location: "local"` and
+`base_branch` set to the receipt branch. Include the receipt SHA and phase inputs in the
+kickoff prompt. Require each child to report its initial `HEAD` and proceed only when it
+equals the receipt SHA. The orchestrator must dispatch these sessions itself and must not
+pause or ask the human to create a worktree during the normal path. Use the documented
+manual fallback only when branch resolution, child creation, or SHA equality fails.
 
 Use child final replies as artifacts and pull them from the transcript, recording each
 child session, branch, SHA, and provenance before progressing. At each gate, present the

--- a/.github/agents/feature-developer.agent.md
+++ b/.github/agents/feature-developer.agent.md
@@ -19,6 +19,7 @@ Execution is a behavioral boundary: log exact commands; do not run `git push`, `
 deployment, Azure, SWA, or Terraform-apply commands; do not use or discover credentials.
 Commit the implementation before hand-off and return an Implementation Receipt for that
 single SHA, including the local branch/ref, parent/base SHA, changed paths, session ID,
-and exact commit evidence. The receipt is a release hand-off, not publication; the
-Developer never pushes or creates a PR. A new commit invalidates prior Review, Test, QA,
-and Debugging results.
+and exact commit evidence. Treat the committed branch as frozen after the receipt so the
+manager can create downstream phase worktrees from that branch. The receipt is a release
+hand-off, not publication; the Developer never pushes or creates a PR. A new commit
+invalidates prior Review, Test, QA, and Debugging results.

--- a/.github/agents/feature-qa-engineer.agent.md
+++ b/.github/agents/feature-qa-engineer.agent.md
@@ -10,7 +10,8 @@ user-invocable: false
 Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md)
 and the Delivery Brief's selected instructions and specs.
 
-Work only from a snapshot with `HEAD` verified equal to the Implementation Receipt SHA.
+Work only from the snapshot supplied by the Delivery Manager, with `HEAD` verified equal
+to the Implementation Receipt SHA. Do not ask the human to create or prepare a worktree.
 Assess relevant journeys, viewport behavior, keyboard and accessibility behavior, themes,
 reduced motion, and SSR/prerender output. Use existing automated browser checks where
 available; if an interactive browser check is required but unavailable, report it as a

--- a/.github/agents/feature-test-engineer.agent.md
+++ b/.github/agents/feature-test-engineer.agent.md
@@ -10,8 +10,9 @@ user-invocable: false
 Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-delivery-manager.md)
 and the Delivery Brief's selected instructions and specs.
 
-Run only from a supplied snapshot whose `HEAD` equals the Implementation Receipt SHA.
-Use `validate-app` for application changes that require the project quality gate;
+Run only from the snapshot supplied by the Delivery Manager, whose `HEAD` must equal the
+Implementation Receipt SHA. Do not ask the human to create or prepare a worktree. Use
+`validate-app` for application changes that require the project quality gate;
 otherwise choose the smallest deterministic checks that cover the changed behavior.
 Return exact commands, raw outcomes, and any intentionally inapplicable checks in a
 Test Receipt. A failure is a failure; do not edit to repair it or downgrade it.

--- a/.github/agents/specialist-debugging.agent.md
+++ b/.github/agents/specialist-debugging.agent.md
@@ -11,8 +11,10 @@ Follow [`docs/agents/feature-delivery-manager.md`](../../docs/agents/feature-del
 Every response must return Specialist Guidance using the shared artifact envelope
 defined there.
 
-Run only when supplied a reproducible Review, Test, or QA failure and a snapshot whose
-`HEAD` is verified equal to the Implementation Receipt SHA. Reproduce the reported
+Run only when supplied a reproducible Review, Test, or QA failure and the snapshot
+created and supplied by the Delivery Manager. Its `HEAD` must be verified equal to the
+Implementation Receipt SHA; do not ask the human to create or prepare a worktree.
+Reproduce the reported
 failure before expanding the investigation. Assess the selected instructions and
 applicable specs. Return Specialist Guidance with the exact commands, evidence, likely
 cause labelled as a hypothesis until proven, affected scope, verification, and blockers.

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -1,6 +1,6 @@
 ---
 spec: feature-delivery-manager agent system
-version: 0.2.0
+version: 0.3.0
 status: design
 verified: 2026-08-11
 ---
@@ -28,7 +28,8 @@ implication.
 | Path instructions under `.github/instructions/*.instructions.md` | Documented by [repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide); existing files use YAML `applyTo`. | `applyTo` accepts comma-separated glob patterns. It is verified for VS Code, Copilot cloud agent, and code review; this task does **not** assert it for the Copilot App session runtime. The App fallback is to attach the selected files to each child prompt and record that in the Delivery Brief. |
 | Copilot App tracked child sessions | Observed: `create_session`, `get_session`, `list_sessions_and_chats`, `send_session_message`, and `session_store_sql` are available. | Create a named child with `coordinate_with_creator: true`; its final response is the hand-off artifact. Pull it from the local transcript. A message is a best-effort nudge only, never an artifact transport. |
 | Child worktree isolation | Observed: each created local project session is a separate worktree and branch. | The Developer alone owns its mutable worktree. Do not share or check out that live branch in another worktree. |
-| Start a child worktree from an exact receipt SHA | **Not verified.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA, and the current surface does not expose a branch-at-SHA creation tool. | Do not automate Review, Test, or QA snapshots. Stop with the Implementation Receipt and ask a human to create a distinct branch at that SHA, then start the named phase there. Never substitute a detached checkout or a live Developer branch. |
+| Create a child from an existing branch | Observed: `create_session` accepts `base_branch` and creates a new local child worktree/branch from it. | After a Developer commit, freeze the source branch and create each phase session with `base_branch` set to the receipt branch. The phase must verify `HEAD` equals the receipt SHA before work. |
+| Start a child worktree from an arbitrary receipt SHA | **Not verified.** The current surface does not expose a branch-at-SHA creation tool. | The normal hand-off uses the frozen Developer branch, whose tip is the receipt SHA. If the branch cannot be resolved, has moved, or the child starts at another `HEAD`, stop and use the documented manual snapshot fallback. Never substitute a detached checkout or a live Developer branch. |
 | Session messages | Observed, but child delivery and child tool inheritance are not guaranteed. | Include all inputs in a kickoff prompt. Retrieve the terminal artifact from the transcript. Use one message only to request a missing artifact. |
 | In-process subagents | Documented for VS Code/CLI (`agent` plus an `agents` list); not verified in this App session. | App sessions are the primary route. On a surface without tracked sessions, use a documented in-process subagent only if it can preserve the phase boundary; otherwise stop and name the next manual role. |
 | Live GitHub MCP read/write names | **Configuration mismatch.** `.github/mcp.json` configures a `github` server with `tools: ["*"]`, but this session exposes GitHub-oriented built-ins and `gh`, not a discoverable `github/*` MCP toolset. | Do not add `github/*` to new frontmatter. Use no GitHub tools for read-only roles. Release Manager is a human-invocable, approval-refusing placeholder until a human verifies exact PR read/write MCP names and replaces wildcard access with its minimal allowlist. |
@@ -116,15 +117,21 @@ host behavior rather than merely the fixture's glob interpretation.
    equality with the Delivery Brief's base SHA. A mismatch blocks the cycle and requires
    a human-created branch at that SHA. The Developer is its sole mutable owner.
 2. The Developer commits before hand-off and returns an Implementation Receipt containing
-   the local branch, exact SHA, parent/base SHA, changed paths, and session ID. The commit
-   is the input to later work; uncommitted files are never an artifact.
+   the local branch, exact SHA, parent/base SHA, changed paths, and session ID. The manager
+   freezes that source branch for downstream hand-off. The commit is the input to later
+   work; uncommitted files are never an artifact.
 3. Every Review, Test, QA, and Debugging phase needs a fresh distinct child
-   branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. The
-   manager records the phase session ID, branch, and equality evidence.
-4. The current App cannot create that exact SHA snapshot automatically. The manager must
-   stop and request a human-created branch at the receipt SHA, then a fresh named session
-   on that branch. The fallback record includes branch, SHA, session ID, and `HEAD`
-   command output; a live Developer branch or detached checkout is not a substitute.
+   branch/worktree. The manager creates and dispatches it automatically with
+   `create_session`, using the Implementation Receipt's frozen source branch as
+   `base_branch`, and includes the receipt SHA plus all phase inputs in the kickoff prompt.
+   The phase verifies its `HEAD` equals the receipt SHA before doing work; the manager
+   records the phase session ID, branch, and equality evidence. The manager must not pause
+   for, or ask the human to create, this worktree during the normal path.
+4. If `create_session` cannot resolve the receipt branch, the source branch moved after the
+   receipt, or the child reports a different `HEAD`, stop the phase and use the manual
+   snapshot fallback. The fallback record includes branch, SHA, session ID, and `HEAD`
+   command output; a live Developer branch or detached checkout is not a substitute. This
+   fallback is exceptional failure handling, not a normal approval or user hand-off gate.
 5. A Developer commit invalidates every Review, Test, QA, and Debugging artifact for an
    older SHA. Recreate snapshots and receipts from the new receipt.
 6. The manager alone creates and tracks sessions. Children do not route siblings,
@@ -221,8 +228,8 @@ flowchart TD
     M --> S[Triggered read-only specialists]
     S --> D[Developer mutable worktree]
     D --> I[Committed Implementation Receipt]
-    I --> V{Exact SHA snapshot available?}
-    V -->|yes| R[Reviewer then Test then QA]
+    I --> V{Automatic branch handoff succeeds?}
+    V -->|yes| R[Fresh Reviewer/Test/QA worktrees]
     V -->|no| F[Manual snapshot fallback]
     R -->|reproducible failure needing diagnosis| B[Debugging Specialist]
     B --> D
@@ -272,7 +279,8 @@ Before enabling automated release work, a human must verify the exact live GitHu
 read/write names, replace `.github/mcp.json` wildcard access with only the required
 release tools, and update this capability table and the Release Manager frontmatter.
 Until then, the named human fallback owns the approved release sequence; the wildcard
-configuration is not evidence that a child agent can use GitHub publication tools. Before enabling
-automated snapshot phases, a human must verify a supported branch-at-SHA worktree
-creation path. Before enabling automated deployment, a human must verify the executing
-identity and named mechanism without exposing credentials.
+configuration is not evidence that a child agent can use GitHub publication tools. Automated
+phase hand-off is limited to `create_session(base_branch=<frozen receipt branch>)` plus
+child-reported `HEAD` equality; any branch-resolution or equality failure follows the
+manual snapshot fallback. Before enabling automated deployment, a human must verify the
+executing identity and named mechanism without exposing credentials.

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -1,6 +1,6 @@
 ---
 spec: feature-delivery-manager agent system
-version: 0.2.0
+version: 0.3.0
 status: design
 verified: 2026-08-11
 ---
@@ -28,7 +28,7 @@ implication.
 | Path instructions under `.github/instructions/*.instructions.md` | Documented by [repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide); existing files use YAML `applyTo`. | `applyTo` accepts comma-separated glob patterns. It is verified for VS Code, Copilot cloud agent, and code review; this task does **not** assert it for the Copilot App session runtime. The App fallback is to attach the selected files to each child prompt and record that in the Delivery Brief. |
 | Copilot App tracked child sessions | Observed: `create_session`, `get_session`, `list_sessions_and_chats`, `send_session_message`, and `session_store_sql` are available. | Create a named child with `coordinate_with_creator: true`; its final response is the hand-off artifact. Pull it from the local transcript. A message is a best-effort nudge only, never an artifact transport. |
 | Child worktree isolation | Observed: each created local project session is a separate worktree and branch. | The Developer alone owns its mutable worktree. Do not share or check out that live branch in another worktree. |
-| Start a child worktree from an exact receipt SHA | **Not verified.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA, and the current surface does not expose a branch-at-SHA creation tool. | Do not automate Review, Test, or QA snapshots. Stop with the Implementation Receipt and ask a human to create a distinct branch at that SHA, then start the named phase there. Never substitute a detached checkout or a live Developer branch. |
+| Start a child worktree from an exact receipt SHA | **Conditional, not verified in this maintenance session.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA. A receipt branch may be used only when the host accepts it as the base, creates a distinct child branch/worktree, and exposes evidence that the child `HEAD` equals the receipt SHA. | When all three proofs are available, automate the named child phase from the receipt branch and pull its terminal artifact. Otherwise stop with the Implementation Receipt and ask a human to create a distinct branch at that SHA. Never substitute a detached checkout, an unverified child, or a live Developer branch. |
 | Session messages | Observed, but child delivery and child tool inheritance are not guaranteed. | Include all inputs in a kickoff prompt. Retrieve the terminal artifact from the transcript. Use one message only to request a missing artifact. |
 | In-process subagents | Documented for VS Code/CLI (`agent` plus an `agents` list); not verified in this App session. | App sessions are the primary route. On a surface without tracked sessions, use a documented in-process subagent only if it can preserve the phase boundary; otherwise stop and name the next manual role. |
 | Live GitHub MCP read/write names | **Configuration mismatch.** `.github/mcp.json` configures a `github` server with `tools: ["*"]`, but this session exposes GitHub-oriented built-ins and `gh`, not a discoverable `github/*` MCP toolset. | Do not add `github/*` to new frontmatter. Use no GitHub tools for read-only roles. Release Manager is a human-invocable, approval-refusing placeholder until a human verifies exact PR read/write MCP names and replaces wildcard access with its minimal allowlist. |
@@ -119,12 +119,23 @@ host behavior rather than merely the fixture's glob interpretation.
    the local branch, exact SHA, parent/base SHA, changed paths, and session ID. The commit
    is the input to later work; uncommitted files are never an artifact.
 3. Every Review, Test, QA, and Debugging phase needs a fresh distinct child
-   branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. The
-   manager records the phase session ID, branch, and equality evidence.
-4. The current App cannot create that exact SHA snapshot automatically. The manager must
-   stop and request a human-created branch at the receipt SHA, then a fresh named session
-   on that branch. The fallback record includes branch, SHA, session ID, and `HEAD`
-   command output; a live Developer branch or detached checkout is not a substitute.
+   branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. When
+   the session surface exposes `create_session`, `get_session`, and local transcript
+   access, the manager first attempts the supported handoff: pass the receipt's
+   `source_branch` as `base_branch`, set the exact phase agent in `kickoff.agent`, and
+   set `coordinate_with_creator: true`. The manager must obtain host or terminal
+   evidence for a distinct child branch/worktree and `HEAD == source_sha` before
+   accepting the phase. The source branch is a starting ref, not permission to reuse
+   the Developer worktree.
+4. Handoff is automatic only when the platform accepts that receipt branch and
+   supplies both proofs above. The manager polls `get_session`, pulls the child's
+   final response from the local transcript, and starts the next phase only after
+   validating the complete artifact. `send_session_message` is at most one nudge and
+   never transports an artifact. If any API, base-branch acceptance, distinct-worktree
+   proof, or SHA-equality proof is unavailable, stop with the Implementation Receipt
+   and ask a human to create a distinct branch at that SHA. The fallback record includes
+   branch, SHA, session ID, and `HEAD` command output; a live Developer branch or
+   detached checkout is not a substitute.
 5. A Developer commit invalidates every Review, Test, QA, and Debugging artifact for an
    older SHA. Recreate snapshots and receipts from the new receipt.
 6. The manager alone creates and tracks sessions. Children do not route siblings,
@@ -222,8 +233,8 @@ flowchart TD
     S --> D[Developer mutable worktree]
     D --> I[Committed Implementation Receipt]
     I --> V{Exact SHA snapshot available?}
-    V -->|yes| R[Reviewer then Test then QA]
-    V -->|no| F[Manual snapshot fallback]
+    V -->|verified receipt-branch handoff| R[Automated Reviewer then Test then QA children]
+    V -->|not verified| F[Manual snapshot fallback]
     R -->|reproducible failure needing diagnosis| B[Debugging Specialist]
     B --> D
     R -->|finding or failure| D

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -1,6 +1,6 @@
 ---
 spec: feature-delivery-manager agent system
-version: 0.4.0
+version: 0.5.0
 status: design
 verified: 2026-08-11
 ---
@@ -28,7 +28,8 @@ implication.
 | Path instructions under `.github/instructions/*.instructions.md` | Documented by [repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide); existing files use YAML `applyTo`. | `applyTo` accepts comma-separated glob patterns. It is verified for VS Code, Copilot cloud agent, and code review; this task does **not** assert it for the Copilot App session runtime. The App fallback is to attach the selected files to each child prompt and record that in the Delivery Brief. |
 | Copilot App tracked child sessions | Observed: `create_session`, `get_session`, `list_sessions_and_chats`, `send_session_message`, and `session_store_sql` are available. | Create a named child with `coordinate_with_creator: true`; its final response is the hand-off artifact. Pull it from the local transcript. A message is a best-effort nudge only, never an artifact transport. |
 | Child worktree isolation | Observed: each created local project session is a separate worktree and branch. | The Developer alone owns its mutable worktree. Do not share or check out that live branch in another worktree. |
-| Start and verify a child worktree from an exact receipt SHA | **Conditional, not verified in this maintenance session.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA. A receipt branch may be used only when the host accepts it as the base, immediately returns a distinct session/worktree identity, reports the returned branch/path and child startup through `get_session`, and the child reports `HEAD`, `parent_sha`, and `base_sha` equal to the receipt SHA before work. | During the normal path, automatically create the named child phase from the receipt branch and pull its terminal artifact; do not pause or ask the human to create a worktree. If any handshake proof is unavailable or fails, stop with the Implementation Receipt and use the exceptional manual branch-at-SHA fallback. Never substitute a detached checkout, an unverified child, or a live Developer branch. |
+| Trusted child startup `HEAD` metadata | **Not verified.** The observed `get_session` surface reports session/worktree identity and branch/path, but does not expose an immutable initial `HEAD` field. | Automated phases are allowed only when the host supplies `initial_head` as trusted session metadata before child work starts. The manager records it and includes it in the startup receipt; a read-only child may echo it but must not claim command-derived evidence. If absent, use the manual branch-at-SHA fallback. Never infer a SHA from a branch name or transcript text. |
+| Start and verify a child worktree from an exact receipt SHA | **Conditional, not verified in this maintenance session.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA. A receipt branch may be used only when the host accepts it as the base, immediately returns a distinct session/worktree identity, reports the returned branch/path and startup through `get_session`, and supplies trusted `initial_head` metadata equal to the receipt SHA before work. | During the normal path, automatically create the named child phase from the receipt branch and pull its terminal artifact; do not pause or ask the human to create a worktree. If any handshake proof is unavailable or fails, stop with the Implementation Receipt and use the exceptional manual branch-at-SHA fallback. Never substitute a detached checkout, an unverified child, or a live Developer branch. |
 | Idempotent phase-session retry | **Not verified.** `session_store_sql` is observed, but atomic idempotency reservation and durable create outcomes are not verified in this maintenance session. | Reserve `delivery_id:phase:source_sha` before `create_session`; reuse and revalidate an existing attempt, or create a numbered retry only after recording the prior failure (including an ambiguous timeout). Never blindly call `create_session` twice. |
 | Session messages | Observed, but child delivery and child tool inheritance are not guaranteed. | Include all inputs in a kickoff prompt. Retrieve the terminal artifact from the transcript. Use one message only to request a missing artifact. |
 | In-process subagents | Documented for VS Code/CLI (`agent` plus an `agents` list); not verified in this App session. | App sessions are the primary route. On a surface without tracked sessions, use a documented in-process subagent only if it can preserve the phase boundary; otherwise stop and name the next manual role. |
@@ -130,13 +131,16 @@ host behavior rather than merely the fixture's glob interpretation.
      worktree path, returned branch, accepted base branch, exact phase agent, and
      startup state are present, with distinct child branch/worktree isolation evidence,
      and distinct from the manager, Developer, and every prior phase;
-   * require the child startup receipt before it reads or changes files. It must report
-     its session ID, worktree ID/path, branch, `HEAD`, `parent_sha`, and `base_sha`.
-     `HEAD == parent_sha == base_sha == source_sha`, the branch must equal the returned
-     branch, and the returned base branch must equal the receipt branch; and
+   * require trusted host session metadata containing `initial_head` before the child
+     reads or changes files. The manager records a startup receipt with its session ID,
+     worktree ID/path, branch, `initial_head`, `parent_sha`, and `base_sha`.
+     `initial_head == parent_sha == base_sha == source_sha`, the branch must equal the
+     returned branch, and the returned base branch must equal the receipt branch. The
+     Code Reviewer receives and echoes this trusted metadata; it must not claim to
+     obtain `HEAD` by command because it has no execution tool; and
    * record the startup receipt before accepting the phase. A missing identity, reused
-     branch/path, missing startup, base-branch mismatch, or any SHA mismatch rejects
-     the handoff.
+     branch/path, missing startup or trusted `initial_head`, base-branch mismatch, or
+     any SHA mismatch rejects the handoff.
    The source branch is a starting ref, not permission to reuse the Developer worktree.
 4. The manager polls `get_session`, pulls the child's final response from the local
    transcript, and validates a complete terminal receipt (including the startup

--- a/docs/agents/feature-delivery-manager.md
+++ b/docs/agents/feature-delivery-manager.md
@@ -1,6 +1,6 @@
 ---
 spec: feature-delivery-manager agent system
-version: 0.3.0
+version: 0.4.0
 status: design
 verified: 2026-08-11
 ---
@@ -28,7 +28,8 @@ implication.
 | Path instructions under `.github/instructions/*.instructions.md` | Documented by [repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide); existing files use YAML `applyTo`. | `applyTo` accepts comma-separated glob patterns. It is verified for VS Code, Copilot cloud agent, and code review; this task does **not** assert it for the Copilot App session runtime. The App fallback is to attach the selected files to each child prompt and record that in the Delivery Brief. |
 | Copilot App tracked child sessions | Observed: `create_session`, `get_session`, `list_sessions_and_chats`, `send_session_message`, and `session_store_sql` are available. | Create a named child with `coordinate_with_creator: true`; its final response is the hand-off artifact. Pull it from the local transcript. A message is a best-effort nudge only, never an artifact transport. |
 | Child worktree isolation | Observed: each created local project session is a separate worktree and branch. | The Developer alone owns its mutable worktree. Do not share or check out that live branch in another worktree. |
-| Start a child worktree from an exact receipt SHA | **Conditional, not verified in this maintenance session.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA. A receipt branch may be used only when the host accepts it as the base, creates a distinct child branch/worktree, and exposes evidence that the child `HEAD` equals the receipt SHA. | When all three proofs are available, automate the named child phase from the receipt branch and pull its terminal artifact. Otherwise stop with the Implementation Receipt and ask a human to create a distinct branch at that SHA. Never substitute a detached checkout, an unverified child, or a live Developer branch. |
+| Start and verify a child worktree from an exact receipt SHA | **Conditional, not verified in this maintenance session.** `create_session` accepts an existing `base_branch`, not an arbitrary commit SHA. A receipt branch may be used only when the host accepts it as the base, immediately returns a distinct session/worktree identity, reports the returned branch/path and child startup through `get_session`, and the child reports `HEAD`, `parent_sha`, and `base_sha` equal to the receipt SHA before work. | When every handshake proof is available, automate the named child phase from the receipt branch and pull its terminal artifact. Otherwise stop with the Implementation Receipt and ask a human to create a distinct branch at that SHA. Never substitute a detached checkout, an unverified child, or a live Developer branch. |
+| Idempotent phase-session retry | **Not verified.** `session_store_sql` is observed, but atomic idempotency reservation and durable create outcomes are not verified in this maintenance session. | Reserve `delivery_id:phase:source_sha` before `create_session`; reuse and revalidate an existing attempt, or create a numbered retry only after recording the prior failure (including an ambiguous timeout). Never blindly call `create_session` twice. |
 | Session messages | Observed, but child delivery and child tool inheritance are not guaranteed. | Include all inputs in a kickoff prompt. Retrieve the terminal artifact from the transcript. Use one message only to request a missing artifact. |
 | In-process subagents | Documented for VS Code/CLI (`agent` plus an `agents` list); not verified in this App session. | App sessions are the primary route. On a surface without tracked sessions, use a documented in-process subagent only if it can preserve the phase boundary; otherwise stop and name the next manual role. |
 | Live GitHub MCP read/write names | **Configuration mismatch.** `.github/mcp.json` configures a `github` server with `tools: ["*"]`, but this session exposes GitHub-oriented built-ins and `gh`, not a discoverable `github/*` MCP toolset. | Do not add `github/*` to new frontmatter. Use no GitHub tools for read-only roles. Release Manager is a human-invocable, approval-refusing placeholder until a human verifies exact PR read/write MCP names and replaces wildcard access with its minimal allowlist. |
@@ -119,29 +120,45 @@ host behavior rather than merely the fixture's glob interpretation.
    the local branch, exact SHA, parent/base SHA, changed paths, and session ID. The commit
    is the input to later work; uncommitted files are never an artifact.
 3. Every Review, Test, QA, and Debugging phase needs a fresh distinct child
-   branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. When
-   the session surface exposes `create_session`, `get_session`, and local transcript
-   access, the manager first attempts the supported handoff: pass the receipt's
-   `source_branch` as `base_branch`, set the exact phase agent in `kickoff.agent`, and
-   set `coordinate_with_creator: true`. The manager must obtain host or terminal
-   evidence for a distinct child branch/worktree and `HEAD == source_sha` before
-   accepting the phase. The source branch is a starting ref, not permission to reuse
-   the Developer worktree.
-4. Handoff is automatic only when the platform accepts that receipt branch and
-   supplies both proofs above. The manager polls `get_session`, pulls the child's
-   final response from the local transcript, and starts the next phase only after
-   validating the complete artifact. `send_session_message` is at most one nudge and
-   never transports an artifact. If any API, base-branch acceptance, distinct-worktree
-   proof, or SHA-equality proof is unavailable, stop with the Implementation Receipt
-   and ask a human to create a distinct branch at that SHA. The fallback record includes
-   branch, SHA, session ID, and `HEAD` command output; a live Developer branch or
-   detached checkout is not a substitute.
-5. A Developer commit invalidates every Review, Test, QA, and Debugging artifact for an
+   branch/worktree whose `HEAD` equals the receipt SHA before the phase starts. The
+   manager uses this explicit session handoff handshake:
+   * reserve the idempotency key `delivery_id:phase:source_sha` in the session ledger;
+   * call `create_session` once with the receipt's `source_branch` as `base_branch`,
+     the exact phase agent in `kickoff.agent`, and `coordinate_with_creator: true`;
+   * immediately call `get_session` for the returned child ID, before sending another
+     message or creating any other phase, and verify the child session ID, worktree ID,
+     worktree path, returned branch, accepted base branch, exact phase agent, and
+     startup state are present, with distinct child branch/worktree isolation evidence,
+     and distinct from the manager, Developer, and every prior phase;
+   * require the child startup receipt before it reads or changes files. It must report
+     its session ID, worktree ID/path, branch, `HEAD`, `parent_sha`, and `base_sha`.
+     `HEAD == parent_sha == base_sha == source_sha`, the branch must equal the returned
+     branch, and the returned base branch must equal the receipt branch; and
+   * record the startup receipt before accepting the phase. A missing identity, reused
+     branch/path, missing startup, base-branch mismatch, or any SHA mismatch rejects
+     the handoff.
+   The source branch is a starting ref, not permission to reuse the Developer worktree.
+4. The manager polls `get_session`, pulls the child's final response from the local
+   transcript, and validates a complete terminal receipt (including the startup
+   receipt, phase, session identity, source SHA, branch/path, status, and evidence)
+   before creating the next phase. `send_session_message` is at most one nudge and
+   never transports an artifact. A failed or incomplete child is recorded against the
+   idempotency key and blocks the next phase. On retry, first look up and revalidate
+   that key; an unknown or ambiguous create outcome is a failure that must be recorded
+   before a numbered replacement attempt can be created. Never create duplicate phase
+   sessions on an unrecorded retry.
+5. Handoff is automatic only when the platform accepts that receipt branch and supplies
+   every proof above. If any API, base-branch acceptance, identity, startup,
+   distinct-worktree, or SHA-equality proof is unavailable, stop with the Implementation
+   Receipt and ask a human to create a distinct branch at that SHA. The fallback record
+   includes branch, SHA, session ID, and `HEAD` command output; a live Developer branch
+   or detached checkout is not a substitute.
+6. A Developer commit invalidates every Review, Test, QA, and Debugging artifact for an
    older SHA. Recreate snapshots and receipts from the new receipt.
-6. The manager alone creates and tracks sessions. Children do not route siblings,
+7. The manager alone creates and tracks sessions. Children do not route siblings,
    create replacements, or rely on shared memory. A terminal artifact is pulled from
    its transcript and its provenance is recorded.
-7. Before release, the Release Manager verifies that the exact local branch contains the
+8. Before release, the Release Manager verifies that the exact local branch contains the
    receipt SHA and that the approved source branch is not already mapped to a different
    remote SHA. Publication is push the exact branch/ref, verify the remote ref resolves
    to the receipt SHA, then create/update the PR. A local commit is never treated as
@@ -233,7 +250,7 @@ flowchart TD
     S --> D[Developer mutable worktree]
     D --> I[Committed Implementation Receipt]
     I --> V{Exact SHA snapshot available?}
-    V -->|verified receipt-branch handoff| R[Automated Reviewer then Test then QA children]
+    V -->|verified session handoff handshake| R[One phase child at a time]
     V -->|not verified| F[Manual snapshot fallback]
     R -->|reproducible failure needing diagnosis| B[Debugging Specialist]
     B --> D
@@ -285,5 +302,7 @@ release tools, and update this capability table and the Release Manager frontmat
 Until then, the named human fallback owns the approved release sequence; the wildcard
 configuration is not evidence that a child agent can use GitHub publication tools. Before enabling
 automated snapshot phases, a human must verify a supported branch-at-SHA worktree
-creation path. Before enabling automated deployment, a human must verify the executing
-identity and named mechanism without exposing credentials.
+creation path, the `get_session` identity/branch/path/startup fields, and a durable
+idempotency reservation or equivalent create-outcome lookup. Before enabling automated
+deployment, a human must verify the executing identity and named mechanism without
+exposing credentials.

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -6,11 +6,13 @@ const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const designPath = join(repositoryRoot, "docs", "agents", "feature-delivery-manager.md");
 const releaseAgentPath = join(repositoryRoot, ".github", "agents", "feature-release-manager.agent.md");
 const managerAgentPath = join(repositoryRoot, ".github", "agents", "feature-delivery-manager.agent.md");
+const reviewerAgentPath = join(repositoryRoot, ".github", "agents", "feature-code-reviewer.agent.md");
 const maintainerAgentPath = join(repositoryRoot, ".github", "agents", "feature-orchestration-maintainer.agent.md");
 
 const design = await readFile(designPath, "utf8");
 const releaseAgent = await readFile(releaseAgentPath, "utf8");
 const managerAgent = await readFile(managerAgentPath, "utf8");
+const reviewerAgent = await readFile(reviewerAgentPath, "utf8");
 const maintainerAgent = await readFile(maintainerAgentPath, "utf8");
 
 const failures = [];
@@ -61,6 +63,7 @@ const handoffFixture = {
         baseBranch: "lfarci-reflect-skip-link-spec",
         phaseAgent: "feature-code-reviewer",
         startup: "started",
+        initialHead: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
     },
     startupReceipt: {
         sessionId: "review-373",
@@ -70,6 +73,7 @@ const handoffFixture = {
         headSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
         parentSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
         baseSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+        headShaSource: "host-session-metadata",
         status: "ready-before-work",
     },
     terminalReceipt: {
@@ -133,6 +137,7 @@ function supportsAutomatedHandoff(fixture) {
         && returned.baseBranch === fixture.sourceBranch
         && returned.phaseAgent === fixture.phaseAgent
         && returned.startup === "started"
+        && returned.initialHead === fixture.sourceSha
         && startup.sessionId === returned.sessionId
         && startup.worktreeId === returned.worktreeId
         && startup.worktreePath === returned.worktreePath
@@ -140,6 +145,7 @@ function supportsAutomatedHandoff(fixture) {
         && startup.headSha === fixture.sourceSha
         && startup.parentSha === fixture.sourceSha
         && startup.baseSha === fixture.sourceSha
+        && startup.headShaSource === "host-session-metadata"
         && startup.status === "ready-before-work"
         && terminal.complete
         && terminal.sessionId === returned.sessionId
@@ -164,6 +170,10 @@ assert(!failedDeliveryFixture.remoteRef, "failed-delivery fixture must model an 
 assert(failedDeliveryFixture.prAttempted, "fixture must preserve the failed PR attempt");
 assert(!failedDeliveryFixture.prCreated, "fixture validation must not claim a PR was created");
 assert(supportsAutomatedHandoff(handoffFixture), "safe fixture must model a verified exact-SHA child handoff");
+assert(reviewerAgent.includes('tools: ["read", "search"]'), "code reviewer must remain read-only");
+assert(reviewerAgent.includes("trusted startup receipt") && reviewerAgent.includes("initial_head"), "code reviewer must use trusted startup metadata");
+assert(design.includes("Trusted child startup `HEAD` metadata"), "design must define trusted startup HEAD metadata");
+assert(design.includes("must not claim command-derived evidence"), "design must forbid unverifiable reviewer HEAD evidence");
 assert(supportsRecordedRetry(handoffFixture), "safe fixture must model a recorded idempotent retry");
 assert(!supportsAutomatedHandoff({
     ...handoffFixture,

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -28,10 +28,44 @@ const failedDeliveryFixture = {
     prCreated: false,
 };
 
+const handoffFixture = {
+    deliveryId: "issue-373-automated-handoff",
+    sourceBranch: "lfarci-reflect-skip-link-spec",
+    sourceSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+    requiredApis: ["create_session", "get_session", "session_store_sql"],
+    availableApis: ["create_session", "get_session", "session_store_sql"],
+    receiptBranchAccepted: true,
+    childWorktreeDistinct: true,
+    childHeadSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+};
+
+function supportsAutomatedHandoff(fixture) {
+    return fixture.sourceBranch.length > 0
+        && fixture.requiredApis.every((api) => fixture.availableApis.includes(api))
+        && fixture.receiptBranchAccepted
+        && fixture.childWorktreeDistinct
+        && fixture.childHeadSha === fixture.sourceSha;
+}
+
 assert(failedDeliveryFixture.localCommit, "failed-delivery fixture must preserve the local commit");
 assert(!failedDeliveryFixture.remoteRef, "failed-delivery fixture must model an absent remote ref");
 assert(failedDeliveryFixture.prAttempted, "fixture must preserve the failed PR attempt");
 assert(!failedDeliveryFixture.prCreated, "fixture validation must not claim a PR was created");
+assert(supportsAutomatedHandoff(handoffFixture), "issue #373 fixture must model a verified exact-SHA child handoff");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    availableApis: ["create_session", "get_session"],
+}), "a missing transcript API must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    childHeadSha: "unverified",
+}), "a child SHA mismatch must select the manual fallback");
+assert(design.includes("base_branch"), "design must name the supported branch-based session input");
+assert(design.includes("distinct child branch/worktree"), "design must require child-worktree isolation evidence");
+assert(design.includes("terminal artifact"), "design must define pull-based child artifact handoff");
+assert(managerAgent.includes("automatically create named Review, Test"), "manager must route supported phase handoffs automatically");
+assert(managerAgent.includes("manual snapshot fallback"), "manager must retain the exact-SHA manual fallback");
+assert(managerAgent.includes('agents: ["feature-developer", "feature-code-reviewer", "feature-test-engineer", "feature-qa-engineer", "specialist-debugging"]'), "manager must allowlist delivery child agents");
 assert(design.includes("A local commit is never treated as"), "design must distinguish local commits from publication");
 assert(design.includes("push exact source ref"), "design must require pushing the exact source ref");
 assert(design.includes("remote-SHA verification") || design.includes("verify the remote ref resolves"), "design must require remote SHA verification");
@@ -62,4 +96,4 @@ if (failures.length > 0) {
     throw new Error(`Delivery contract validation failed:\n${failures.join("\n")}`);
 }
 
-console.log(`Validated delivery contract and ${failedDeliveryFixture.deliveryId} fixture.`);
+console.log(`Validated delivery contract and ${failedDeliveryFixture.deliveryId} plus ${handoffFixture.deliveryId} fixtures.`);

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -29,37 +29,214 @@ const failedDeliveryFixture = {
 };
 
 const handoffFixture = {
-    deliveryId: "issue-373-automated-handoff",
+    deliveryId: "issue-373-safe-session-handoff",
     sourceBranch: "lfarci-reflect-skip-link-spec",
     sourceSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
     requiredApis: ["create_session", "get_session", "session_store_sql"],
     availableApis: ["create_session", "get_session", "session_store_sql"],
-    receiptBranchAccepted: true,
-    childWorktreeDistinct: true,
-    childHeadSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+    managerSessionId: "manager-373",
+    developerSessionId: "developer-373",
+    developerWorktreeId: "worktree-developer-373",
+    developerWorktreePath: "C:/worktrees/developer-373",
+    developerBranch: "lfarci-reflect-skip-link-spec",
+    previousPhaseSessionIds: [],
+    previousWorktreeIds: [],
+    previousWorktreePaths: [],
+    previousPhaseBranches: [],
+    phase: "Review",
+    phaseAgent: "feature-code-reviewer",
+    idempotencyKey: "issue-373-safe-session-handoff:Review:07e89aa83c16d285ba43ac8b262e5f17a7354367",
+    createSession: {
+        calls: 1,
+        baseBranch: "lfarci-reflect-skip-link-spec",
+        kickoffAgent: "feature-code-reviewer",
+        coordinateWithCreator: true,
+        returnedSessionId: "review-373",
+    },
+    getSession: {
+        sessionId: "review-373",
+        worktreeId: "worktree-review-373",
+        worktreePath: "C:/worktrees/review-373",
+        branch: "review/issue-373",
+        baseBranch: "lfarci-reflect-skip-link-spec",
+        phaseAgent: "feature-code-reviewer",
+        startup: "started",
+    },
+    startupReceipt: {
+        sessionId: "review-373",
+        worktreeId: "worktree-review-373",
+        worktreePath: "C:/worktrees/review-373",
+        branch: "review/issue-373",
+        headSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+        parentSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+        baseSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+        status: "ready-before-work",
+    },
+    terminalReceipt: {
+        complete: true,
+        sessionId: "review-373",
+        sourceSha: "07e89aa83c16d285ba43ac8b262e5f17a7354367",
+        status: "pass",
+    },
+    retry: {
+        calls: 2,
+        retryOf: "review-373",
+        attempt: 2,
+        failureRecorded: true,
+        ambiguousOutcomeHandled: true,
+        failure: {
+            status: "fail",
+            error: "create_session timeout after reservation",
+        },
+    },
 };
 
 function supportsAutomatedHandoff(fixture) {
+    const created = fixture.createSession;
+    const returned = fixture.getSession;
+    const startup = fixture.startupReceipt;
+    const terminal = fixture.terminalReceipt;
+    const identities = [
+        fixture.managerSessionId,
+        fixture.developerSessionId,
+        ...((fixture.previousPhaseSessionIds) || []),
+    ];
+    const worktreePaths = [
+        fixture.developerWorktreePath,
+        ...((fixture.previousWorktreePaths) || []),
+    ];
+    const worktreeIds = [
+        fixture.developerWorktreeId,
+        ...((fixture.previousWorktreeIds) || []),
+    ];
+    const branches = [
+        fixture.developerBranch,
+        ...((fixture.previousPhaseBranches) || []),
+    ];
     return fixture.sourceBranch.length > 0
         && fixture.requiredApis.every((api) => fixture.availableApis.includes(api))
-        && fixture.receiptBranchAccepted
-        && fixture.childWorktreeDistinct
-        && fixture.childHeadSha === fixture.sourceSha;
+        && typeof fixture.idempotencyKey === "string"
+        && created.calls === 1
+        && created.baseBranch === fixture.sourceBranch
+        && created.kickoffAgent === fixture.phaseAgent
+        && created.coordinateWithCreator === true
+        && typeof created.returnedSessionId === "string"
+        && returned.sessionId === created.returnedSessionId
+        && !identities.includes(returned.sessionId)
+        && typeof returned.worktreeId === "string"
+        && !worktreeIds.includes(returned.worktreeId)
+        && typeof returned.worktreePath === "string"
+        && returned.worktreePath.length > 0
+        && !worktreePaths.includes(returned.worktreePath)
+        && typeof returned.branch === "string"
+        && !branches.includes(returned.branch)
+        && returned.baseBranch === fixture.sourceBranch
+        && returned.phaseAgent === fixture.phaseAgent
+        && returned.startup === "started"
+        && startup.sessionId === returned.sessionId
+        && startup.worktreeId === returned.worktreeId
+        && startup.worktreePath === returned.worktreePath
+        && startup.branch === returned.branch
+        && startup.headSha === fixture.sourceSha
+        && startup.parentSha === fixture.sourceSha
+        && startup.baseSha === fixture.sourceSha
+        && startup.status === "ready-before-work"
+        && terminal.complete
+        && terminal.sessionId === returned.sessionId
+        && terminal.sourceSha === fixture.sourceSha
+        && terminal.status === "pass";
+}
+
+function supportsRecordedRetry(fixture) {
+    return fixture.idempotencyKey
+        && fixture.retry
+        && fixture.retry.calls === 2
+        && fixture.retry.retryOf === fixture.createSession.returnedSessionId
+        && fixture.retry.attempt === 2
+        && fixture.retry.failureRecorded === true
+        && fixture.retry.ambiguousOutcomeHandled === true
+        && fixture.retry.failure.status === "fail"
+        && fixture.retry.failure.error.length > 0;
 }
 
 assert(failedDeliveryFixture.localCommit, "failed-delivery fixture must preserve the local commit");
 assert(!failedDeliveryFixture.remoteRef, "failed-delivery fixture must model an absent remote ref");
 assert(failedDeliveryFixture.prAttempted, "fixture must preserve the failed PR attempt");
 assert(!failedDeliveryFixture.prCreated, "fixture validation must not claim a PR was created");
-assert(supportsAutomatedHandoff(handoffFixture), "issue #373 fixture must model a verified exact-SHA child handoff");
+assert(supportsAutomatedHandoff(handoffFixture), "safe fixture must model a verified exact-SHA child handoff");
+assert(supportsRecordedRetry(handoffFixture), "safe fixture must model a recorded idempotent retry");
 assert(!supportsAutomatedHandoff({
     ...handoffFixture,
     availableApis: ["create_session", "get_session"],
 }), "a missing transcript API must select the manual fallback");
 assert(!supportsAutomatedHandoff({
     ...handoffFixture,
-    childHeadSha: "unverified",
+    startupReceipt: {
+        ...handoffFixture.startupReceipt,
+        headSha: "unverified",
+    },
 }), "a child SHA mismatch must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        sessionId: handoffFixture.developerSessionId,
+    },
+}), "a reused session identity must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        worktreeId: "",
+    },
+}), "a missing worktree identity must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        branch: handoffFixture.sourceBranch,
+    },
+}), "a reused branch must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        worktreePath: "C:/worktrees/developer-373",
+    },
+    developerWorktreePath: "C:/worktrees/developer-373",
+}), "a reused worktree path must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        baseBranch: "main",
+    },
+}), "a returned base-branch mismatch must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    getSession: {
+        ...handoffFixture.getSession,
+        startup: "unknown",
+    },
+}), "missing child startup must select the manual fallback");
+assert(!supportsAutomatedHandoff({
+    ...handoffFixture,
+    terminalReceipt: {
+        ...handoffFixture.terminalReceipt,
+        complete: false,
+    },
+}), "an incomplete terminal receipt must block the next phase");
+assert(!supportsRecordedRetry({
+    ...handoffFixture,
+    retry: {
+        calls: 2,
+        retryOf: handoffFixture.createSession.returnedSessionId,
+        attempt: 2,
+        failureRecorded: false,
+        ambiguousOutcomeHandled: false,
+        failure: null,
+    },
+}), "an unrecorded retry must not create a duplicate phase session");
 assert(design.includes("base_branch"), "design must name the supported branch-based session input");
 assert(design.includes("distinct child branch/worktree"), "design must require child-worktree isolation evidence");
 assert(design.includes("terminal artifact"), "design must define pull-based child artifact handoff");


### PR DESCRIPTION
## Why
The delivery flow previously stopped after implementation and required a human to create an exact-SHA review worktree. That made normal Review, Test, QA, and Debugging handoffs unnecessarily manual and left room for unsafe branch or worktree reuse.

## What changed
- Automatically dispatch downstream local sessions from the frozen Implementation Receipt branch.
- Add a strict handoff handshake that verifies distinct session/worktree identity, branch and path provenance, startup `HEAD`, and exact receipt-SHA equality before work begins.
- Require phase agents to use the snapshot supplied by the Delivery Manager and never ask the human to prepare a worktree during the normal path.
- Gate each phase on a complete terminal receipt and prevent unsafe duplicate retries.
- Preserve the exceptional manual exact-SHA fallback whenever the platform cannot provide the required evidence.
- Add deterministic contract fixtures covering safe handoffs and rejection paths.
- Align Developer, Reviewer, Test, QA, and Debugging agent documentation with the orchestration contract.

## Validation
- `node scripts/validate-delivery-contract.mjs`
- `node scripts/validate-instruction-scopes.mjs`
- `git diff --check`

This is orchestration-only; no product code, GitHub publication logic, deployment behavior, or credentials were changed.