### PR TITLE
fix(agents): let developer create draft PRs

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -16,6 +16,12 @@ autonomously use the existing `git push` and `gh pr create` workflow to push the
 branch and create exactly one draft pull request before Reviewer runs. This draft pull
 request is pre-review and is not contingent on a later Reviewer pass.
 
+Publication gate: generic `execute` alone is not a publication capability. Before attempting
+this workflow, verify scoped GitHub authentication with `gh auth status` and remote write
+access with `git push --dry-run origin HEAD`. If either check cannot be verified, do not
+attempt `git push` or `gh pr create`; report the blocked publication outcome and the manual
+fallback in the Developer Result.
+
 Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other
 agent. If the permitted draft pull request is attempted, record its URL and outcome in the
 Developer Result.

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Developer
-description: Implements one approved Execution Plan and returns a complete Developer Result for the Orchestrator. It may create one plan-authorized draft PR before review, but does not create sessions, publish, deploy, or review its own work.
+description: Implements one approved Execution Plan and returns a complete Developer Result for the Orchestrator. It may autonomously create one draft PR before review, but does not create sessions, publish, deploy, or review its own work.
 tools: ["read", "search", "edit", "execute"]
 user-invocable: false
 ---
@@ -11,11 +11,10 @@ Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md) 
 instructions and specs selected by the supplied Execution Plan.
 
 Implement only that plan. Use existing repository commands for focused validation and
-commit the completed local change. Only when the user expressly requests a pull request
-and the approved Execution Plan includes it, use the existing `git push` and `gh pr
-create` workflow to push the completed branch and create exactly one draft pull request
-before Reviewer runs. This draft pull request is pre-review and is not contingent on a
-later Reviewer pass. Otherwise, do not push or create a pull request.
+commit the completed local change. During the approved implementation, Developer may
+autonomously use the existing `git push` and `gh pr create` workflow to push the completed
+branch and create exactly one draft pull request before Reviewer runs. This draft pull
+request is pre-review and is not contingent on a later Reviewer pass.
 
 Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other
 agent. If the permitted draft pull request is attempted, record its URL and outcome in the

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Developer
-description: Implements one approved Execution Plan and returns a complete Developer Result for the Orchestrator. It does not create sessions, publish, deploy, or review its own work.
+description: Implements one approved Execution Plan and returns a complete Developer Result for the Orchestrator. It may create one plan-authorized draft PR before review, but does not create sessions, publish, deploy, or review its own work.
 tools: ["read", "search", "edit", "execute"]
 user-invocable: false
 ---
@@ -11,8 +11,15 @@ Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md) 
 instructions and specs selected by the supplied Execution Plan.
 
 Implement only that plan. Use existing repository commands for focused validation and
-commit the completed local change. Do not create a session, push, create a pull request,
-publish, deploy, expand scope, or invoke another agent.
+commit the completed local change. Only when the user expressly requests a pull request
+and the approved Execution Plan includes it, use the existing `git push` and `gh pr
+create` workflow to push the completed branch and create exactly one draft pull request
+before Reviewer runs. This draft pull request is pre-review and is not contingent on a
+later Reviewer pass. Otherwise, do not push or create a pull request.
+
+Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other
+agent. If the permitted draft pull request is attempted, record its URL and outcome in the
+Developer Result.
 
 Your final response must be one **Developer Result** containing `status` (`complete` or
 `blocked`), the plan target and scope implemented, changed paths, local commit SHA when

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Orchestrator
-description: Plans one backlog item and runs the basic in-process Developer then Reviewer workflow. It owns the returned-result handoff and never creates child sessions.
-tools: ["read", "search", "agent", "github/*"]
+description: Plans one backlog item, runs the in-process Developer then Reviewer workflow, and can create a PR only after an approved review and explicit user request.
+tools: ["read", "search", "agent", "execute", "github/*"]
 agents: ["developer", "reviewer"]
 user-invocable: true
 ---
@@ -12,7 +12,8 @@ Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md).
 
 Keep every run to one backlog item and one Execution Plan. Read the live backlog when
 needed; if the GitHub read is unavailable, return a blocked result instead of inferring
-the backlog from old context. Do not write GitHub state.
+the backlog from old context. Do not write GitHub state except for the narrowly authorized
+post-review push and pull-request creation below.
 
 Return the Execution Plan first unless the user explicitly requests implementation. For
 implementation, call `developer` in-process with the complete plan. Require its complete
@@ -22,5 +23,10 @@ with the plan, to `reviewer` in a second in-process call. Require its complete t
 
 Never create a child session or use session messaging, transcript retrieval, startup
 acknowledgements, worktree identity, or SHA matching as a handoff mechanism. Do not edit,
-execute, publish, deploy, create a pull request, or repair review findings. Stop after
-the Review Result, including `needs-changes` or `blocked`.
+publish, deploy, or repair review findings.
+
+Only when the returned Review Result has `status: pass` **and** the user explicitly
+requests a pull request, use `execute` solely for the existing `git push` and `gh pr
+create` workflow to push the reviewed branch and create that one pull request. Do not use
+`execute` for any other purpose. If either condition is absent, report the Review Result
+and stop; always stop after the permitted push/pull-request attempt.

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Orchestrator
-description: Plans one backlog item, runs the in-process Developer then Reviewer workflow, and can create a PR only after an approved review and explicit user request.
-tools: ["read", "search", "agent", "execute", "github/*"]
+description: Plans one backlog item, runs the in-process Developer then Reviewer workflow, and reports the result without writing GitHub state.
+tools: ["read", "search", "agent", "github/*"]
 agents: ["developer", "reviewer"]
 user-invocable: true
 ---
@@ -12,8 +12,7 @@ Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md).
 
 Keep every run to one backlog item and one Execution Plan. Read the live backlog when
 needed; if the GitHub read is unavailable, return a blocked result instead of inferring
-the backlog from old context. Do not write GitHub state except for the narrowly authorized
-post-review push and pull-request creation below.
+the backlog from old context. Do not write GitHub state.
 
 Return the Execution Plan first unless the user explicitly requests implementation. For
 implementation, call `developer` in-process with the complete plan. Require its complete
@@ -23,10 +22,5 @@ with the plan, to `reviewer` in a second in-process call. Require its complete t
 
 Never create a child session or use session messaging, transcript retrieval, startup
 acknowledgements, worktree identity, or SHA matching as a handoff mechanism. Do not edit,
-publish, deploy, or repair review findings.
-
-Only when the returned Review Result has `status: pass` **and** the user explicitly
-requests a pull request, use `execute` solely for the existing `git push` and `gh pr
-create` workflow to push the reviewed branch and create that one pull request. Do not use
-`execute` for any other purpose. If either condition is absent, report the Review Result
-and stop; always stop after the permitted push/pull-request attempt.
+execute, push, create a pull request, publish, deploy, or repair review findings. Stop
+after the Review Result, including `needs-changes` or `blocked`.

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -20,6 +20,11 @@ terminal **Developer Result** in the returned tool output. Pass that result verb
 with the plan, to `reviewer` in a second in-process call. Require its complete terminal
 **Review Result** and report it verbatim in substance.
 
+When a requested step needs a capability that Orchestrator does not have, delegate it to
+Developer or Reviewer only when it is within that role's documented contract. Do not
+attempt the step yourself or treat unavailable credentials as a reason to expand a role's
+tools. Report the request as blocked when neither subagent can own it.
+
 Never create a child session or use session messaging, transcript retrieval, startup
 acknowledgements, worktree identity, or SHA matching as a handoff mechanism. Do not edit,
 execute, push, create a pull request, publish, deploy, or repair review findings. Stop

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,6 +1,6 @@
 ---
 spec: simple delivery workflow
-version: 1.0.0
+version: 1.0.1
 status: current-design
 verified: 2026-08-11
 ---
@@ -23,7 +23,7 @@ result from a branch, diff, status message, or partial output.
 
 | Role | Owns | May do | Must not do |
 | --- | --- | --- | --- |
-| Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process | Edit code, execute commands, create sessions, write GitHub state, publish, deploy, or fix review findings |
+| Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process; only after a `pass` Review Result and an explicit user request, use scoped execution for the existing `git push` and `gh pr create` workflow to push the reviewed branch and create one PR | Edit code, execute commands other than that limited post-review workflow, create sessions, write GitHub state other than that push/PR, publish, deploy, or fix review findings |
 | Developer | Implement one approved execution plan | Read/search/edit/execute and commit local code | Expand scope, create sessions, push, create a PR, publish, deploy, or invoke Reviewer |
 | Reviewer | Independently assess the Developer's result | Read/search/execute scoped checks | Edit, commit, push, create sessions, publish, deploy, or invoke Developer |
 
@@ -36,6 +36,7 @@ flowchart LR
     D --> R[Developer Result]
     R --> V[Reviewer]
     V --> O[Review Result]
+    O -->|Review pass + explicit user request| G[Push reviewed branch and create PR]
 ```
 
 1. The Orchestrator reads the live backlog when the request needs it. If that read is
@@ -46,12 +47,20 @@ flowchart LR
    explicitly approves the plan. The entire plan is included in the invocation.
 4. Developer's final response is a **Developer Result**. The Orchestrator passes that
    result verbatim with the plan to Reviewer in the next in-process invocation.
-5. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
+5. Reviewer's final response is a **Review Result**. Unless that result has `status:
+   pass` and the user explicitly requests a pull request, the Orchestrator reports it and
    stops. A `needs-changes` result never triggers an automatic repair loop.
+6. Only with both conditions in step 5 may the Orchestrator use scoped execution solely
+   for the existing `git push` and `gh pr create` workflow to push the reviewed branch and
+   create one pull request. It does not edit or repair the change, make any other GitHub
+   state change, or invoke another agent. It then reports the Review Result and push/PR
+   outcome in its terminal response and stops.
 
 ## Handoff contracts
 
-The terminal response is the sole artifact for each handoff.
+The terminal response is the sole artifact for each delegated-agent handoff. The optional
+post-review push/PR step uses the returned Review Result directly; it creates no further
+agent handoff or session.
 
 ### Developer Result
 

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,6 +1,6 @@
 ---
 spec: simple delivery workflow
-version: 1.0.4
+version: 1.0.5
 status: current-design
 verified: 2026-08-12
 ---
@@ -42,17 +42,23 @@ flowchart LR
    unavailable, it reports the blockage; it does not invent or use a stale backlog.
 2. It selects one item only and returns an **Execution Plan** with: target, objective,
    in-scope work, out-of-scope work, likely paths, and existing checks to run.
-3. The Orchestrator invokes Developer only after the user requests implementation or
+3. When a requested step needs a capability that Orchestrator does not have, it delegates
+   only to the subagent whose documented contract owns that step: Developer for approved
+   implementation and its bounded draft-PR path, or Reviewer for independent assessment of
+   a Developer Result. Orchestrator does not attempt the step, expand a role's tools, or
+   use an unavailable credential as a substitute. If neither subagent can own the step,
+   Orchestrator reports it as blocked.
+4. The Orchestrator invokes Developer only after the user requests implementation or
    explicitly approves the plan. The entire plan is included in the invocation.
-4. During approved implementation, Developer may autonomously use its existing `execute`
+5. During approved implementation, Developer may autonomously use its existing `execute`
    capability for the `git push` and `gh pr create` workflow to push the completed branch
    and create exactly one draft pull request. This occurs before Reviewer runs: the draft
    PR is explicitly pre-review, not contingent on a later Reviewer pass, and does not alter
    Reviewer's independent review. Developer records the PR URL and outcome in its Developer
    Result. This path is subject to the publication capability gate below.
-5. Developer's final response is a **Developer Result**. The Orchestrator passes that
+6. Developer's final response is a **Developer Result**. The Orchestrator passes that
    result verbatim with the plan to Reviewer in the next in-process invocation.
-6. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
+7. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
    stops. A `needs-changes` result never triggers an automatic repair loop. No agent
    changes the draft PR after review in this simple workflow.
 

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,8 +1,8 @@
 ---
 spec: simple delivery workflow
-version: 1.0.1
+version: 1.0.2
 status: current-design
-verified: 2026-08-11
+verified: 2026-08-12
 ---
 
 # Simple Delivery Workflow
@@ -23,8 +23,8 @@ result from a branch, diff, status message, or partial output.
 
 | Role | Owns | May do | Must not do |
 | --- | --- | --- | --- |
-| Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process; only after a `pass` Review Result and an explicit user request, use scoped execution for the existing `git push` and `gh pr create` workflow to push the reviewed branch and create one PR | Edit code, execute commands other than that limited post-review workflow, create sessions, write GitHub state other than that push/PR, publish, deploy, or fix review findings |
-| Developer | Implement one approved execution plan | Read/search/edit/execute and commit local code | Expand scope, create sessions, push, create a PR, publish, deploy, or invoke Reviewer |
+| Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process | Edit code, execute commands, create sessions, write GitHub state, push, create a PR, publish, deploy, or fix review findings |
+| Developer | Implement one approved execution plan and, when authorized, create one pre-review draft PR | Read/search/edit/execute and commit local code; only when the user expressly requests a pull request and the approved Execution Plan includes it, use the existing `git push` and `gh pr create` workflow to push the completed branch and create exactly one draft PR | Expand scope, create sessions, publish, deploy, invoke Reviewer, or create any PR other than that explicitly requested, plan-authorized draft PR |
 | Reviewer | Independently assess the Developer's result | Read/search/execute scoped checks | Edit, commit, push, create sessions, publish, deploy, or invoke Developer |
 
 ## Flow
@@ -33,10 +33,9 @@ result from a branch, diff, status message, or partial output.
 flowchart LR
     B[Read backlog] --> P[Execution Plan]
     P -->|User requests implementation| D[Developer]
-    D --> R[Developer Result]
+    D -->|Optional explicit-request, plan-authorized draft PR| R[Developer Result]
     R --> V[Reviewer]
     V --> O[Review Result]
-    O -->|Review pass + explicit user request| G[Push reviewed branch and create PR]
 ```
 
 1. The Orchestrator reads the live backlog when the request needs it. If that read is
@@ -45,22 +44,25 @@ flowchart LR
    in-scope work, out-of-scope work, likely paths, and existing checks to run.
 3. The Orchestrator invokes Developer only after the user requests implementation or
    explicitly approves the plan. The entire plan is included in the invocation.
-4. Developer's final response is a **Developer Result**. The Orchestrator passes that
+4. Only when the user expressly requests a pull request and the approved Execution Plan
+   includes it, Developer may use its existing `execute` capability for the `git push` and
+   `gh pr create` workflow to push the completed branch and create exactly one draft pull
+   request. This occurs before Reviewer runs: the draft PR is explicitly pre-review, not
+   contingent on a later Reviewer pass, and does not alter Reviewer's independent review.
+   Developer records the PR URL and outcome in its Developer Result. Otherwise, Developer
+   does not push or create a PR. If the authorized command attempt fails, Developer records
+   the outcome and does not substitute another tool or role.
+5. Developer's final response is a **Developer Result**. The Orchestrator passes that
    result verbatim with the plan to Reviewer in the next in-process invocation.
-5. Reviewer's final response is a **Review Result**. Unless that result has `status:
-   pass` and the user explicitly requests a pull request, the Orchestrator reports it and
-   stops. A `needs-changes` result never triggers an automatic repair loop.
-6. Only with both conditions in step 5 may the Orchestrator use scoped execution solely
-   for the existing `git push` and `gh pr create` workflow to push the reviewed branch and
-   create one pull request. It does not edit or repair the change, make any other GitHub
-   state change, or invoke another agent. It then reports the Review Result and push/PR
-   outcome in its terminal response and stops.
+6. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
+   stops. A `needs-changes` result never triggers an automatic repair loop. No agent
+   changes the draft PR after review in this simple workflow.
 
 ## Handoff contracts
 
 The terminal response is the sole artifact for each delegated-agent handoff. The optional
-post-review push/PR step uses the returned Review Result directly; it creates no further
-agent handoff or session.
+pre-review draft PR is performed by Developer before its terminal response; it creates no
+further agent handoff or session.
 
 ### Developer Result
 
@@ -69,6 +71,7 @@ agent handoff or session.
 - changed paths
 - local commit SHA, if committed
 - commands run and outcomes
+- PR URL and outcome, if the permitted draft PR was attempted
 - limitations or blockers
 
 ### Review Result

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,6 +1,6 @@
 ---
 spec: simple delivery workflow
-version: 1.0.2
+version: 1.0.3
 status: current-design
 verified: 2026-08-12
 ---
@@ -24,7 +24,7 @@ result from a branch, diff, status message, or partial output.
 | Role | Owns | May do | Must not do |
 | --- | --- | --- | --- |
 | Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process | Edit code, execute commands, create sessions, write GitHub state, push, create a PR, publish, deploy, or fix review findings |
-| Developer | Implement one approved execution plan and, when authorized, create one pre-review draft PR | Read/search/edit/execute and commit local code; only when the user expressly requests a pull request and the approved Execution Plan includes it, use the existing `git push` and `gh pr create` workflow to push the completed branch and create exactly one draft PR | Expand scope, create sessions, publish, deploy, invoke Reviewer, or create any PR other than that explicitly requested, plan-authorized draft PR |
+| Developer | Implement one approved execution plan and autonomously create one pre-review draft PR | Read/search/edit/execute and commit local code; during approved implementation, use the existing `git push` and `gh pr create` workflow to push the completed branch and create exactly one draft PR | Expand scope, create sessions, publish, deploy, invoke Reviewer, or create more than one draft PR |
 | Reviewer | Independently assess the Developer's result | Read/search/execute scoped checks | Edit, commit, push, create sessions, publish, deploy, or invoke Developer |
 
 ## Flow
@@ -33,7 +33,7 @@ result from a branch, diff, status message, or partial output.
 flowchart LR
     B[Read backlog] --> P[Execution Plan]
     P -->|User requests implementation| D[Developer]
-    D -->|Optional explicit-request, plan-authorized draft PR| R[Developer Result]
+    D -->|Optional autonomous draft PR| R[Developer Result]
     R --> V[Reviewer]
     V --> O[Review Result]
 ```
@@ -44,14 +44,13 @@ flowchart LR
    in-scope work, out-of-scope work, likely paths, and existing checks to run.
 3. The Orchestrator invokes Developer only after the user requests implementation or
    explicitly approves the plan. The entire plan is included in the invocation.
-4. Only when the user expressly requests a pull request and the approved Execution Plan
-   includes it, Developer may use its existing `execute` capability for the `git push` and
-   `gh pr create` workflow to push the completed branch and create exactly one draft pull
-   request. This occurs before Reviewer runs: the draft PR is explicitly pre-review, not
-   contingent on a later Reviewer pass, and does not alter Reviewer's independent review.
-   Developer records the PR URL and outcome in its Developer Result. Otherwise, Developer
-   does not push or create a PR. If the authorized command attempt fails, Developer records
-   the outcome and does not substitute another tool or role.
+4. During approved implementation, Developer may autonomously use its existing `execute`
+   capability for the `git push` and `gh pr create` workflow to push the completed branch
+   and create exactly one draft pull request. This occurs before Reviewer runs: the draft
+   PR is explicitly pre-review, not contingent on a later Reviewer pass, and does not alter
+   Reviewer's independent review. Developer records the PR URL and outcome in its Developer
+   Result. If the command attempt fails, Developer records the outcome and does not
+   substitute another tool or role.
 5. Developer's final response is a **Developer Result**. The Orchestrator passes that
    result verbatim with the plan to Reviewer in the next in-process invocation.
 6. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
@@ -71,7 +70,7 @@ further agent handoff or session.
 - changed paths
 - local commit SHA, if committed
 - commands run and outcomes
-- PR URL and outcome, if the permitted draft PR was attempted
+- PR URL and outcome, if the autonomous draft PR was attempted
 - limitations or blockers
 
 ### Review Result

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,6 +1,6 @@
 ---
 spec: simple delivery workflow
-version: 1.0.3
+version: 1.0.4
 status: current-design
 verified: 2026-08-12
 ---
@@ -49,8 +49,7 @@ flowchart LR
    and create exactly one draft pull request. This occurs before Reviewer runs: the draft
    PR is explicitly pre-review, not contingent on a later Reviewer pass, and does not alter
    Reviewer's independent review. Developer records the PR URL and outcome in its Developer
-   Result. If the command attempt fails, Developer records the outcome and does not
-   substitute another tool or role.
+   Result. This path is subject to the publication capability gate below.
 5. Developer's final response is a **Developer Result**. The Orchestrator passes that
    result verbatim with the plan to Reviewer in the next in-process invocation.
 6. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
@@ -62,6 +61,18 @@ flowchart LR
 The terminal response is the sole artifact for each delegated-agent handoff. The optional
 pre-review draft PR is performed by Developer before its terminal response; it creates no
 further agent handoff or session.
+
+## Publication capability
+
+- **Status:** Conditional. Generic `execute` is behavioral control only and does not itself
+  establish an authenticated publication capability.
+- **Runtime evidence:** Immediately before publication, Developer runs `gh auth status` to
+  verify scoped GitHub authentication and `git push --dry-run origin HEAD` to verify
+  authenticated remote write access. Both must succeed.
+- **Failure routing and manual fallback:** If either check is unavailable or fails, Developer
+  does not attempt `git push` or `gh pr create`. Its Developer Result records publication as
+  blocked and directs the user to authenticate, push the committed branch, and create the
+  draft PR manually. Developer does not substitute another tool or role.
 
 ### Developer Result
 

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -60,12 +60,12 @@ assert(frontmatterValue(files.developer, "name") === "Developer", "developer nam
 assert(developerTools.join(",") === "read,search,edit,execute", "developer must have the minimal implementation toolset");
 assert(files.developer.includes("Developer Result"), "developer must return a Developer Result");
 assert(
-    files.developer.includes("user expressly requests a pull request")
-        && files.developer.includes("approved Execution Plan includes it"),
-    "developer PR path must require an explicit user request and plan authorization",
+    files.developer.includes("During the approved implementation, Developer may")
+        && files.developer.includes("autonomously use the existing `git push` and `gh pr"),
+    "developer PR path must be autonomous during approved implementation",
 );
 assert(
-    files.developer.includes("`git push` and `gh pr\ncreate` workflow")
+    files.developer.includes("`git push` and `gh pr create` workflow")
         && files.developer.includes("exactly one draft pull request")
         && files.developer.includes("before Reviewer runs"),
     "developer PR path must be limited to one pre-review draft PR through the existing workflow",
@@ -95,15 +95,18 @@ assert(
     "design must keep the Orchestrator read/delegate/report-only",
 );
 assert(
-    files.design.includes("Developer | Implement one approved execution plan and, when authorized, create one pre-review draft PR")
-        && files.design.includes("user expressly requests a pull request and the approved Execution Plan includes it")
+    files.design.includes("Developer | Implement one approved execution plan and autonomously create one pre-review draft PR")
+        && files.design.includes("During approved implementation, Developer may autonomously")
         && files.design.includes("exactly one draft PR"),
-    "design must allocate the bounded explicit-request, plan-authorized draft PR path to Developer",
+    "design must allocate the bounded autonomous draft PR path to Developer",
 );
 assert(
-    files.design.includes("This occurs before Reviewer runs: the draft PR is explicitly pre-review")
-        && files.design.includes("does not alter Reviewer's independent review")
-        && files.design.includes("No agent\n   changes the draft PR after review"),
+    files.design.includes("This occurs before Reviewer runs: the draft")
+        && files.design.includes("PR is explicitly pre-review")
+        && files.design.includes("does not alter")
+        && files.design.includes("Reviewer's independent review")
+        && files.design.includes("No agent")
+        && files.design.includes("changes the draft PR after review"),
     "design must preserve the pre-review draft PR and independent Reviewer flow",
 );
 

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -13,7 +13,9 @@ const paths = {
 const entries = await Promise.all(
     Object.entries(paths).map(async ([key, file]) => [key, await readFile(file, "utf8")]),
 );
-const files = Object.fromEntries(entries);
+const files = Object.fromEntries(
+    entries.map(([key, text]) => [key, text.replaceAll("\r\n", "\n")]),
+);
 const failures = [];
 
 function assert(condition, message) {
@@ -47,10 +49,32 @@ assert(frontmatterValue(files.orchestrator, "name") === "Orchestrator", "orchest
 assert(orchestratorTools.join(",") === "read,search,agent,github/*", "orchestrator must use only read/search/agent/GitHub tools");
 assert(!orchestratorTools.includes("edit") && !orchestratorTools.includes("execute"), "orchestrator must not edit or execute");
 assert(frontmatterValue(files.orchestrator, "agents") === "[\"developer\", \"reviewer\"]", "orchestrator must delegate only to Developer and Reviewer");
+assert(files.orchestrator.includes("Do not write GitHub state."), "orchestrator must prohibit GitHub state writes");
+assert(
+    files.orchestrator.includes("Do not edit,\nexecute, push, create a pull request, publish, deploy, or repair review findings."),
+    "orchestrator must prohibit execution, push/PR creation, publication, deployment, and review repair",
+);
+assert(!files.orchestrator.includes("git push") && !files.orchestrator.includes("gh pr create"), "orchestrator must not own the PR workflow");
 
 assert(frontmatterValue(files.developer, "name") === "Developer", "developer name must be Developer");
 assert(developerTools.join(",") === "read,search,edit,execute", "developer must have the minimal implementation toolset");
 assert(files.developer.includes("Developer Result"), "developer must return a Developer Result");
+assert(
+    files.developer.includes("user expressly requests a pull request")
+        && files.developer.includes("approved Execution Plan includes it"),
+    "developer PR path must require an explicit user request and plan authorization",
+);
+assert(
+    files.developer.includes("`git push` and `gh pr\ncreate` workflow")
+        && files.developer.includes("exactly one draft pull request")
+        && files.developer.includes("before Reviewer runs"),
+    "developer PR path must be limited to one pre-review draft PR through the existing workflow",
+);
+assert(
+    files.developer.includes("Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other\nagent."),
+    "developer must continue to prohibit sessions, publication, deployment, scope expansion, and Reviewer invocation",
+);
+assert(files.developer.includes("record its URL and outcome in the\nDeveloper Result"), "developer must report a permitted PR outcome");
 
 assert(frontmatterValue(files.reviewer, "name") === "Reviewer", "reviewer name must be Reviewer");
 assert(reviewerTools.join(",") === "read,search,execute", "reviewer must have the minimal read-only validation toolset");
@@ -65,6 +89,23 @@ assert(files.design.includes("Orchestrator -> Developer -> Reviewer"), "design m
 assert(files.design.includes("does not use child sessions"), "design must reject child-session handoffs");
 assert(files.design.includes("returned response is the handoff"), "design must define direct result handoff");
 assert(files.design.includes("needs-changes") && files.design.includes("automatic repair loop"), "design must stop instead of auto-repairing review findings");
+assert(
+    files.design.includes("Orchestrator | Choose one backlog item")
+        && files.design.includes("execute commands, create sessions, write GitHub state, push, create a PR"),
+    "design must keep the Orchestrator read/delegate/report-only",
+);
+assert(
+    files.design.includes("Developer | Implement one approved execution plan and, when authorized, create one pre-review draft PR")
+        && files.design.includes("user expressly requests a pull request and the approved Execution Plan includes it")
+        && files.design.includes("exactly one draft PR"),
+    "design must allocate the bounded explicit-request, plan-authorized draft PR path to Developer",
+);
+assert(
+    files.design.includes("This occurs before Reviewer runs: the draft PR is explicitly pre-review")
+        && files.design.includes("does not alter Reviewer's independent review")
+        && files.design.includes("No agent\n   changes the draft PR after review"),
+    "design must preserve the pre-review draft PR and independent Reviewer flow",
+);
 
 if (failures.length > 0) {
     throw new Error(`Delivery contract validation failed:\n${failures.join("\n")}`);

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -55,6 +55,11 @@ assert(
     "orchestrator must prohibit execution, push/PR creation, publication, deployment, and review repair",
 );
 assert(!files.orchestrator.includes("git push") && !files.orchestrator.includes("gh pr create"), "orchestrator must not own the PR workflow");
+assert(
+    files.orchestrator.includes("delegate it to\nDeveloper or Reviewer only when it is within that role's documented contract")
+        && files.orchestrator.includes("Report the request as blocked when neither subagent can own it."),
+    "orchestrator must delegate unavailable capabilities only to the owning subagent or report a block",
+);
 
 assert(frontmatterValue(files.developer, "name") === "Developer", "developer name must be Developer");
 assert(developerTools.join(",") === "read,search,edit,execute", "developer must have the minimal implementation toolset");
@@ -100,6 +105,12 @@ assert(
     files.design.includes("Orchestrator | Choose one backlog item")
         && files.design.includes("execute commands, create sessions, write GitHub state, push, create a PR"),
     "design must keep the Orchestrator read/delegate/report-only",
+);
+assert(
+    files.design.includes("When a requested step needs a capability that Orchestrator does not have")
+        && files.design.includes("only to the subagent whose documented contract owns that step")
+        && files.design.includes("If neither subagent can own the step,\n   Orchestrator reports it as blocked."),
+    "design must route unavailable Orchestrator capabilities to the owning subagent or report a block",
 );
 assert(
     files.design.includes("Developer | Implement one approved execution plan and autonomously create one pre-review draft PR")

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -71,6 +71,13 @@ assert(
     "developer PR path must be limited to one pre-review draft PR through the existing workflow",
 );
 assert(
+    files.developer.includes("generic `execute` alone is not a publication capability")
+        && files.developer.includes("`gh auth status`")
+        && files.developer.includes("`git push --dry-run origin HEAD`")
+        && files.developer.includes("manual\nfallback in the Developer Result"),
+    "developer PR path must verify publication credentials and provide the manual fallback",
+);
+assert(
     files.developer.includes("Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other\nagent."),
     "developer must continue to prohibit sessions, publication, deployment, scope expansion, and Reviewer invocation",
 );
@@ -108,6 +115,14 @@ assert(
         && files.design.includes("No agent")
         && files.design.includes("changes the draft PR after review"),
     "design must preserve the pre-review draft PR and independent Reviewer flow",
+);
+assert(
+    files.design.includes("## Publication capability")
+        && files.design.includes("**Status:** Conditional")
+        && files.design.includes("`gh auth status`")
+        && files.design.includes("`git push --dry-run origin HEAD`")
+        && files.design.includes("Failure routing and manual fallback"),
+    "design must record publication capability status, evidence, and manual fallback",
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
The delivery workflow blocked pull-request creation because the Orchestrator does not execute repository commands. This assigns the narrow PR lifecycle action to Developer, which already has the scoped command capability.

During an approved implementation, Developer may autonomously push the completed branch and open exactly one pre-review draft PR. Orchestrator remains read/delegation-only, and the in-process Developer -> Reviewer handoff is unchanged.

The delivery-contract validator now enforces the final tool boundaries, autonomous single-draft-PR rule, and reviewer independence.