### PR TITLE
fix: inject VITE_DEPLOYMENT_ENVIRONMENT during build

### DIFF
--- a/.github/workflows/reusable-deploy-static-web-app.yml
+++ b/.github/workflows/reusable-deploy-static-web-app.yml
@@ -88,6 +88,7 @@ jobs:
           VITE_GITHUB_REPOSITORY_URL: "${{ inputs.repository_url }}"
           VITE_COMMIT_HASH: "${{ inputs.commit_hash }}"
           VITE_APPINSIGHTS_CONNECTION_STRING: "${{ steps.get-secrets.outputs.application_insights_connection_string }}"
+          VITE_DEPLOYMENT_ENVIRONMENT: "${{ inputs.github_environment_name }}"
 
       - name: Deploy to Azure Static Web Apps
         id: deploy


### PR DESCRIPTION
Closes #352

Injects the deployment environment name (Production/Preview) into the build step's env as VITE_DEPLOYMENT_ENVIRONMENT so App.tsx can read it at runtime.