### PR TITLE
feat(agents): dispatch per-issue subsessions from backlog triage

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: Developer
-description: Implements one approved Execution Plan and returns a complete Developer Result for the Orchestrator. It may autonomously create one draft PR before review, but does not create sessions, publish, deploy, or review its own work.
+description: Implements one approved Execution Plan and returns a complete Developer Result. It does not create the PR until the Reviewer passes the change, and does not create sessions, publish, deploy, or review its own work.
 tools: ["read", "search", "edit", "execute"]
 user-invocable: false
 ---
@@ -11,23 +11,22 @@ Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md) 
 instructions and specs selected by the supplied Execution Plan.
 
 Implement only that plan. Use existing repository commands for focused validation and
-commit the completed local change. During the approved implementation, Developer may
-autonomously use the existing `git push` and `gh pr create` workflow to push the completed
-branch and create exactly one draft pull request before Reviewer runs. This draft pull
-request is pre-review and is not contingent on a later Reviewer pass.
+commit the completed local change. Do not create a pull request before review: the review
+gate is mandatory, and the PR is created only after Reviewer passes the change.
 
-Publication gate: generic `execute` alone is not a publication capability. Before attempting
-this workflow, verify scoped GitHub authentication with `gh auth status` and remote write
-access with `git push --dry-run origin HEAD`. If either check cannot be verified, do not
-attempt `git push` or `gh pr create`; report the blocked publication outcome and the manual
-fallback in the Developer Result.
+Publication gate: generic `execute` alone is not a publication capability. When the
+subsession directs you to finalize, verify scoped GitHub authentication with `gh auth
+status` and remote write access with `git push --dry-run origin HEAD`, then use the
+existing `git push` and `gh pr create` workflow to push the completed branch and create
+exactly one pull request. If either check cannot be verified, do not attempt `git push`
+or `gh pr create`; report the blocked publication outcome and the manual fallback in the
+Developer Result.
 
 Do not create a session, publish, deploy, expand scope, or invoke Reviewer or any other
-agent. If the permitted draft pull request is attempted, record its URL and outcome in the
+agent. If the post-review pull request is attempted, record its URL and outcome in the
 Developer Result.
 
 Your final response must be one **Developer Result** containing `status` (`complete` or
 `blocked`), the plan target and scope implemented, changed paths, local commit SHA when
 available, commands and outcomes, plus limitations or blockers. Do not send messages or
-attempt to transport the result elsewhere: the Orchestrator receives this response
-directly.
+attempt to transport the result elsewhere: the subsession receives this response directly.

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -14,6 +14,12 @@ Implement only that plan. Use existing repository commands for focused validatio
 commit the completed local change. Do not create a pull request before review: the review
 gate is mandatory, and the PR is created only after Reviewer passes the change.
 
+Finalization gate: once Reviewer passes, finalize by running the existing quality gates
+and preparing PR metadata only; do not edit the reviewed code. Push the exact commit
+Reviewer assessed. If finalization surfaces a code change that is still needed, report
+`blocked` instead of editing and pushing: the subsession must route it back through the
+bounded repair pass and a fresh Reviewer pass before any push.
+
 Publication gate: generic `execute` alone is not a publication capability. When the
 subsession directs you to finalize, verify scoped GitHub authentication with `gh auth
 status` and remote write access with `git push --dry-run origin HEAD`, then use the

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -15,8 +15,9 @@ result instead of inferring the backlog from old context. Do not write GitHub st
 Select the high-priority issues and return a prioritized shortlist to the host, so the
 host can dispatch one isolated subsession per issue. Do not research, plan, build,
 review, or publish any issue yourself. Do not create or follow up on a subsession: the
-host owns dispatch via `create_session`, and a subsession owns all research and planning
-for its issue.
+host (the root session that invoked you, not any file in this repository) owns dispatch
+via its native `create_session` capability, which you do not have, and a subsession owns
+all research and planning for its issue.
 
 Never create a child session or use session messaging, transcript retrieval, startup
 acknowledgements, worktree identity, or SHA matching as a handoff mechanism. Do not edit,

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,8 +1,7 @@
 ---
 name: Orchestrator
-description: Plans one backlog item, runs the in-process Developer then Reviewer workflow, and reports the result without writing GitHub state.
-tools: ["read", "search", "agent", "github/*"]
-agents: ["developer", "reviewer"]
+description: Reads the live backlog, selects the high-priority issues, and reports a prioritized shortlist for the host to dispatch one subsession per issue. It never researches, plans, builds, reviews, or publishes.
+tools: ["read", "search", "github/*"]
 user-invocable: true
 ---
 
@@ -10,22 +9,16 @@ user-invocable: true
 
 Follow [`docs/agents/simple-delivery.md`](../../docs/agents/simple-delivery.md).
 
-Keep every run to one backlog item and one Execution Plan. Read the live backlog when
-needed; if the GitHub read is unavailable, return a blocked result instead of inferring
-the backlog from old context. Do not write GitHub state.
+Read the live backlog when needed; if the GitHub read is unavailable, return a blocked
+result instead of inferring the backlog from old context. Do not write GitHub state.
 
-Return the Execution Plan first unless the user explicitly requests implementation. For
-implementation, call `developer` in-process with the complete plan. Require its complete
-terminal **Developer Result** in the returned tool output. Pass that result verbatim,
-with the plan, to `reviewer` in a second in-process call. Require its complete terminal
-**Review Result** and report it verbatim in substance.
-
-When a requested step needs a capability that Orchestrator does not have, delegate it to
-Developer or Reviewer only when it is within that role's documented contract. Do not
-attempt the step yourself or treat unavailable credentials as a reason to expand a role's
-tools. Report the request as blocked when neither subagent can own it.
+Select the high-priority issues and return a prioritized shortlist to the host, so the
+host can dispatch one isolated subsession per issue. Do not research, plan, build,
+review, or publish any issue yourself. Do not create or follow up on a subsession: the
+host owns dispatch via `create_session`, and a subsession owns all research and planning
+for its issue.
 
 Never create a child session or use session messaging, transcript retrieval, startup
 acknowledgements, worktree identity, or SHA matching as a handoff mechanism. Do not edit,
 execute, push, create a pull request, publish, deploy, or repair review findings. Stop
-after the Review Result, including `needs-changes` or `blocked`.
+after you report the shortlist.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -17,5 +17,5 @@ deploy. Report only real, actionable findings; leave the working tree untouched.
 Your final response must be one **Review Result** containing `status` (`pass`,
 `needs-changes`, or `blocked`), the reviewed target and Developer Result reference,
 findings with file/path evidence, commands and outcomes, plus limitations or blockers.
-Do not send messages or attempt to transport the result elsewhere: the Orchestrator
+Do not send messages or attempt to transport the result elsewhere: the subsession
 receives this response directly.

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -1,72 +1,101 @@
 ---
 spec: simple delivery workflow
-version: 1.0.5
+version: 1.1.0
 status: current-design
 verified: 2026-08-12
 ---
 
 # Simple Delivery Workflow
 
-This is the entire active agent workflow: **Orchestrator -> Developer -> Reviewer**.
-It deliberately does not use child sessions, `create_session`, `get_session`,
-`send_session_message`, transcript queries, shared worktrees, startup acknowledgements,
-or cross-session artifacts.
+The active agent workflow is **triage/dispatch -> per-issue delivery**. The Orchestrator
+reads the live backlog, selects the high-priority issues, and reports a shortlist to the
+host. The host then dispatches one isolated subsession per shortlisted issue; that
+subsession owns all research and planning for its issue and drives the build -> review ->
+finalize -> PR pipeline.
+
+This deliberately does not use transcript queries, shared worktrees, startup
+acknowledgements, or cross-session artifacts between the Orchestrator and a subsession.
+The Orchestrator never researches, plans, builds, reviews, or publishes, and never follows
+up on a subsession it dispatched.
 
 ## Why this is small
 
-The host's in-process `agent` invocation returns the delegated agent's final response
-to the caller. That returned response is the handoff. The Orchestrator MUST stop if it
-cannot obtain a complete returned response; it MUST NOT create a session or infer the
-result from a branch, diff, status message, or partial output.
+Triaging the backlog and delivering one issue are different concerns. The Orchestrator
+only needs read access to the repository and the live backlog to produce a prioritized
+shortlist. Each issue's research, planning, and implementation belong to an isolated
+subsession, so work scales to many issues without one agent carrying every context. The
+host's `create_session` invocation is the handoff: the dispatcher stops after reporting
+the shortlist, and a subsession finishes with a pull request or a blocked report.
 
 ## Roles
 
-| Role | Owns | May do | Must not do |
-| --- | --- | --- | --- |
-| Orchestrator | Choose one backlog item, create one execution plan, route the two calls, and report the result | Read/search the repository and live backlog; invoke Developer and Reviewer in-process | Edit code, execute commands, create sessions, write GitHub state, push, create a PR, publish, deploy, or fix review findings |
-| Developer | Implement one approved execution plan and autonomously create one pre-review draft PR | Read/search/edit/execute and commit local code; during approved implementation, use the existing `git push` and `gh pr create` workflow to push the completed branch and create exactly one draft PR | Expand scope, create sessions, publish, deploy, invoke Reviewer, or create more than one draft PR |
-| Reviewer | Independently assess the Developer's result | Read/search/execute scoped checks | Edit, commit, push, create sessions, publish, deploy, or invoke Developer |
+| Layer | Role | Owns | May do | Must not do |
+| --- | --- | --- | --- | --- |
+| Dispatch | Orchestrator | Read the backlog, select the high-priority issues, and report the shortlist | Read/search the repository and live backlog; read GitHub issues; produce a prioritized shortlist for the host to dispatch | Edit code, execute commands, create sessions itself, write GitHub state, push, create a PR, publish, deploy, research or plan an issue, or fix review findings |
+| Delivery | Subsession | Research its issue, produce one Execution Plan, and coordinate build -> review -> finalize -> PR | Read/search the repository; invoke Developer and Reviewer in-process; direct Developer to create the PR after review passes | Expand scope, create sessions, publish, deploy, or skip the review gate |
+| Delivery | Developer | Implement one approved Execution Plan; after review passes, finalize and create exactly one PR | Read/search/edit/execute and commit local code; use the existing `git push` and `gh pr create` workflow to push the completed branch and create exactly one PR after Reviewer passes it | Expand scope, create sessions, publish, deploy, invoke Reviewer, or create a PR before review |
+| Delivery | Reviewer | Independently assess the Developer's result | Read/search/execute scoped checks | Edit, commit, push, create sessions, publish, deploy, or invoke Developer |
 
 ## Flow
 
 ```mermaid
 flowchart LR
-    B[Read backlog] --> P[Execution Plan]
-    P -->|User requests implementation| D[Developer]
-    D -->|Optional autonomous draft PR| R[Developer Result]
+    B[Read backlog] --> O[Orchestrator]
+    O -->|shortlist| H[Host]
+    H -->|create_session per issue| S[Subsession]
+    S -->|research + plan| P[Execution Plan]
+    P -->|build| D[Developer]
+    D --> R[Developer Result]
     R --> V[Reviewer]
-    V --> O[Review Result]
+    V -->|pass| S
+    S -->|finalize| F[Finalized result]
+    F -->|post-review PR| PR[Pull Request]
 ```
 
 1. The Orchestrator reads the live backlog when the request needs it. If that read is
    unavailable, it reports the blockage; it does not invent or use a stale backlog.
-2. It selects one item only and returns an **Execution Plan** with: target, objective,
-   in-scope work, out-of-scope work, likely paths, and existing checks to run.
-3. When a requested step needs a capability that Orchestrator does not have, it delegates
-   only to the subagent whose documented contract owns that step: Developer for approved
-   implementation and its bounded draft-PR path, or Reviewer for independent assessment of
-   a Developer Result. Orchestrator does not attempt the step, expand a role's tools, or
-   use an unavailable credential as a substitute. If neither subagent can own the step,
-   Orchestrator reports it as blocked.
-4. The Orchestrator invokes Developer only after the user requests implementation or
-   explicitly approves the plan. The entire plan is included in the invocation.
-5. During approved implementation, Developer may autonomously use its existing `execute`
-   capability for the `git push` and `gh pr create` workflow to push the completed branch
-   and create exactly one draft pull request. This occurs before Reviewer runs: the draft
-   PR is explicitly pre-review, not contingent on a later Reviewer pass, and does not alter
-   Reviewer's independent review. Developer records the PR URL and outcome in its Developer
-   Result. This path is subject to the publication capability gate below.
-6. Developer's final response is a **Developer Result**. The Orchestrator passes that
-   result verbatim with the plan to Reviewer in the next in-process invocation.
-7. Reviewer's final response is a **Review Result**. The Orchestrator reports it and
-   stops. A `needs-changes` result never triggers an automatic repair loop. No agent
-   changes the draft PR after review in this simple workflow.
+2. It selects the high-priority issues and returns a prioritized shortlist to the host.
+   It does not research, plan, build, review, or publish, and it does not create or follow
+   up on a subsession.
+3. The host dispatches one isolated subsession per shortlisted issue, passing the issue
+   and the path to this contract.
+4. The subsession researches the repository and returns an **Execution Plan** with:
+   target, objective, in-scope work, out-of-scope work, likely paths, and existing checks
+   to run.
+5. The subsession invokes Developer in-process with the complete plan. Developer implements
+   it, commits the completed local change, and returns a **Developer Result**.
+6. Developer does not create a pull request before review. The review gate is mandatory.
+7. The subsession invokes Reviewer in-process with the Developer Result and the plan.
+   Reviewer runs the smallest existing checks that cover the change and returns a
+   **Review Result**.
+8. If the Review Result is `needs-changes`, the subsession routes the actionable findings
+   back to Developer once for a bounded repair pass, then re-invokes Reviewer. This repair
+   loop is bounded: it never exceeds one additional Developer + Reviewer pass. If the result
+   is still `needs-changes` or is `blocked`, the subsession stops and reports a blocked
+   outcome with no pull request.
+9. If the Review Result is `pass`, the subsession directs Developer to finalize: refine
+   details and run the existing quality gates, then use the existing `git push` and
+   `gh pr create` workflow to push the completed branch and create **exactly one** pull
+   request. Developer records the PR URL and outcome in its Developer Result.
+10. The subsession finishes with a pull request or a blocked report. It does not report back
+    to the Orchestrator through any cross-session mechanism.
 
 ## Handoff contracts
 
-The terminal response is the sole artifact for each delegated-agent handoff. The optional
-pre-review draft PR is performed by Developer before its terminal response; it creates no
-further agent handoff or session.
+The host's `create_session` invocation is the sole handoff from the Orchestrator layer to
+a subsession. Inside a subsession, the terminal response is the sole artifact for each
+delegated-agent handoff (Developer Result, Review Result). The only post-review
+publication artifact is the single pull request Developer creates in step 9.
+
+## Review gate and repair loop
+
+- The subsession does not direct Developer to finalize or create a PR until Reviewer
+  returns `pass`.
+- A `needs-changes` result triggers at most one bounded Developer + Reviewer repair pass
+  (step 8). A second `needs-changes` or a `blocked` result stops the subsession with no
+  pull request. This is not an unbounded automatic repair loop.
+- Reviewer independently verifies the quality gates named in the plan and reports only
+  real, actionable findings with file/path evidence.
 
 ## Publication capability
 
@@ -78,7 +107,7 @@ further agent handoff or session.
 - **Failure routing and manual fallback:** If either check is unavailable or fails, Developer
   does not attempt `git push` or `gh pr create`. Its Developer Result records publication as
   blocked and directs the user to authenticate, push the committed branch, and create the
-  draft PR manually. Developer does not substitute another tool or role.
+  pull request manually. Developer does not substitute another tool or role.
 
 ### Developer Result
 
@@ -87,7 +116,7 @@ further agent handoff or session.
 - changed paths
 - local commit SHA, if committed
 - commands run and outcomes
-- PR URL and outcome, if the autonomous draft PR was attempted
+- PR URL and outcome, if the post-review pull request was attempted
 - limitations or blockers
 
 ### Review Result
@@ -98,11 +127,11 @@ further agent handoff or session.
 - commands run and outcomes
 - limitations or blockers
 
-If either response is missing a status or the required fields, the Orchestrator reports
+If either response is missing a status or the required fields, the subsession reports
 `blocked: incomplete delegated result` and stops.
 
 ## Manual fallback
 
-If in-process delegation is unavailable, the user runs Developer and Reviewer directly
-with the same Execution Plan and Developer Result. The Orchestrator does not substitute
-sessions or a different transport mechanism.
+If in-process delegation or a subsession is unavailable, the user runs the subsession
+phases directly against the same Execution Plan and Developer Result. The Orchestrator
+does not substitute sessions or a different transport mechanism.

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -81,10 +81,13 @@ flowchart LR
    loop is bounded: it never exceeds one additional Developer + Reviewer pass. If the result
    is still `needs-changes` or is `blocked`, the subsession stops and reports a blocked
    outcome with no pull request.
-9. If the Review Result is `pass`, the subsession directs Developer to finalize: refine
-   details and run the existing quality gates, then use the existing `git push` and
-   `gh pr create` workflow to push the completed branch and create **exactly one** pull
-   request. Developer records the PR URL and outcome in its Developer Result.
+9. If the Review Result is `pass`, the subsession directs Developer to finalize: run the
+   existing quality gates and prepare PR metadata (title, description) without changing the
+   reviewed code, then use the existing `git push` and `gh pr create` workflow to push that
+   exact reviewed commit and create **exactly one** pull request. Finalization never edits
+   code: if a code change still turns out to be needed, Developer reports `blocked` instead
+   of pushing, and the subsession routes it back through the bounded repair pass (step 8)
+   and a fresh Reviewer pass. Developer records the PR URL and outcome in its Developer Result.
 10. The subsession finishes with a pull request or a blocked report. It does not report back
     to the Orchestrator through any cross-session mechanism.
 
@@ -107,6 +110,10 @@ pull request Developer creates in step 9.
   pull request. This is not an unbounded automatic repair loop.
 - Reviewer independently verifies the quality gates named in the plan and reports only
   real, actionable findings with file/path evidence.
+- Finalization (step 9) never changes the reviewed code: it pushes the exact commit
+  Reviewer assessed and only adds quality-gate runs or PR metadata. A code change
+  discovered while finalizing goes back through the bounded repair pass (step 8) and a
+  fresh Reviewer pass; it never ships straight to `git push`.
 
 ## Publication capability
 

--- a/docs/agents/simple-delivery.md
+++ b/docs/agents/simple-delivery.md
@@ -18,6 +18,14 @@ acknowledgements, or cross-session artifacts between the Orchestrator and a subs
 The Orchestrator never researches, plans, builds, reviews, or publishes, and never follows
 up on a subsession it dispatched.
 
+**What "the host" is:** the host is the root Copilot CLI/agent session that invoked the
+Orchestrator (a user's interactive session or a workflow run), not a component defined by
+any file in this repository. `create_session` is a native capability of that host runtime,
+unavailable to the Orchestrator, Developer, and Reviewer themselves. This repository
+therefore does not, and cannot, implement or automate the dispatch step: after reading the
+Orchestrator's shortlist, the host manually invokes `create_session` once per shortlisted
+issue. That external dependency is intentional, not a missing piece of this workflow.
+
 ## Why this is small
 
 Triaging the backlog and delivering one issue are different concerns. The Orchestrator
@@ -83,9 +91,12 @@ flowchart LR
 ## Handoff contracts
 
 The host's `create_session` invocation is the sole handoff from the Orchestrator layer to
-a subsession. Inside a subsession, the terminal response is the sole artifact for each
-delegated-agent handoff (Developer Result, Review Result). The only post-review
-publication artifact is the single pull request Developer creates in step 9.
+a subsession. That invocation is made manually by the host runtime after it reads the
+Orchestrator's shortlist; it is not, and cannot be, triggered by an in-repo automation or
+by any `.agent.md` file, because custom agents have no access to `create_session`. Inside a
+subsession, the terminal response is the sole artifact for each delegated-agent handoff
+(Developer Result, Review Result). The only post-review publication artifact is the single
+pull request Developer creates in step 9.
 
 ## Review gate and repair loop
 

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -62,8 +62,9 @@ assert(
     "orchestrator must be triage/dispatch-only and never own an issue's delivery",
 );
 assert(
-    files.orchestrator.includes("the\nhost owns dispatch via `create_session`"),
-    "orchestrator must leave dispatch to the host's create_session",
+    files.orchestrator.includes("the\nhost (the root session that invoked you, not any file in this repository) owns dispatch\nvia its native `create_session` capability, which you do not have")
+        && files.orchestrator.includes("Never create a child session"),
+    "orchestrator must leave dispatch to the host's create_session and clarify the host is external",
 );
 
 assert(frontmatterValue(files.developer, "name") === "Developer", "developer name must be Developer");
@@ -119,6 +120,12 @@ assert(
     files.design.includes("host dispatches one isolated subsession per shortlisted issue")
         && files.design.includes("`create_session` invocation is the sole handoff"),
     "design must use host create_session as the sole dispatch handoff",
+);
+assert(
+    files.design.includes("the host is the root Copilot CLI/agent session that invoked the\nOrchestrator")
+        && files.design.includes("not a component defined by\nany file in this repository")
+        && files.design.includes("That external dependency is intentional, not a missing piece of this workflow."),
+    "design must clarify the host is an external runtime, not an in-repo automation gap",
 );
 assert(
     files.design.includes("Developer | Implement one approved Execution Plan; after review passes, finalize and create exactly one PR")

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -82,6 +82,12 @@ assert(
     "developer PR path must be one post-review PR through the existing workflow",
 );
 assert(
+    files.developer.includes("Finalization gate: once Reviewer passes, finalize by running the existing quality gates")
+        && files.developer.includes("do not edit the reviewed code. Push the exact commit")
+        && files.developer.includes("the subsession must route it back through the\nbounded repair pass and a fresh Reviewer pass before any push."),
+    "developer finalization must not edit reviewed code and must route needed code changes back through repair + re-review",
+);
+assert(
     files.developer.includes("generic `execute` alone is not a publication capability")
         && files.developer.includes("`gh auth\nstatus`")
         && files.developer.includes("`git push --dry-run origin HEAD`")
@@ -138,6 +144,11 @@ assert(
         && files.design.includes("**exactly one** pull")
         && files.design.includes("Developer records the PR URL and outcome in its Developer Result"),
     "design must require the review gate before the single PR",
+);
+assert(
+    files.design.includes("Finalization never edits\n   code: if a code change still turns out to be needed, Developer reports `blocked` instead")
+        && files.design.includes("Finalization (step 9) never changes the reviewed code: it pushes the exact commit"),
+    "design must freeze finalization to the reviewed commit and route needed code changes back through repair + re-review",
 );
 assert(
     files.design.includes("## Publication capability")

--- a/scripts/validate-delivery-contract.mjs
+++ b/scripts/validate-delivery-contract.mjs
@@ -46,9 +46,10 @@ const developerTools = tools(files.developer);
 const reviewerTools = tools(files.reviewer);
 
 assert(frontmatterValue(files.orchestrator, "name") === "Orchestrator", "orchestrator name must be Orchestrator");
-assert(orchestratorTools.join(",") === "read,search,agent,github/*", "orchestrator must use only read/search/agent/GitHub tools");
+assert(orchestratorTools.join(",") === "read,search,github/*", "orchestrator must use only read/search/GitHub tools");
 assert(!orchestratorTools.includes("edit") && !orchestratorTools.includes("execute"), "orchestrator must not edit or execute");
-assert(frontmatterValue(files.orchestrator, "agents") === "[\"developer\", \"reviewer\"]", "orchestrator must delegate only to Developer and Reviewer");
+assert(!orchestratorTools.includes("agent"), "orchestrator must not invoke in-process agents");
+assert(frontmatterValue(files.orchestrator, "agents") === "", "orchestrator must not delegate to in-process agents");
 assert(files.orchestrator.includes("Do not write GitHub state."), "orchestrator must prohibit GitHub state writes");
 assert(
     files.orchestrator.includes("Do not edit,\nexecute, push, create a pull request, publish, deploy, or repair review findings."),
@@ -56,30 +57,34 @@ assert(
 );
 assert(!files.orchestrator.includes("git push") && !files.orchestrator.includes("gh pr create"), "orchestrator must not own the PR workflow");
 assert(
-    files.orchestrator.includes("delegate it to\nDeveloper or Reviewer only when it is within that role's documented contract")
-        && files.orchestrator.includes("Report the request as blocked when neither subagent can own it."),
-    "orchestrator must delegate unavailable capabilities only to the owning subagent or report a block",
+    files.orchestrator.includes("Do not research, plan, build,\nreview, or publish any issue yourself.")
+        && files.orchestrator.includes("Do not create or follow up on a subsession: the"),
+    "orchestrator must be triage/dispatch-only and never own an issue's delivery",
+);
+assert(
+    files.orchestrator.includes("the\nhost owns dispatch via `create_session`"),
+    "orchestrator must leave dispatch to the host's create_session",
 );
 
 assert(frontmatterValue(files.developer, "name") === "Developer", "developer name must be Developer");
 assert(developerTools.join(",") === "read,search,edit,execute", "developer must have the minimal implementation toolset");
 assert(files.developer.includes("Developer Result"), "developer must return a Developer Result");
 assert(
-    files.developer.includes("During the approved implementation, Developer may")
-        && files.developer.includes("autonomously use the existing `git push` and `gh pr"),
-    "developer PR path must be autonomous during approved implementation",
+    files.developer.includes("Do not create a pull request before review")
+        && files.developer.includes("the review\ngate is mandatory"),
+    "developer must never create a pre-review PR",
 );
 assert(
-    files.developer.includes("`git push` and `gh pr create` workflow")
-        && files.developer.includes("exactly one draft pull request")
-        && files.developer.includes("before Reviewer runs"),
-    "developer PR path must be limited to one pre-review draft PR through the existing workflow",
+    files.developer.includes("When the\nsubsession directs you to finalize")
+        && files.developer.includes("`git push` and `gh pr create` workflow")
+        && files.developer.includes("exactly one pull request"),
+    "developer PR path must be one post-review PR through the existing workflow",
 );
 assert(
     files.developer.includes("generic `execute` alone is not a publication capability")
-        && files.developer.includes("`gh auth status`")
+        && files.developer.includes("`gh auth\nstatus`")
         && files.developer.includes("`git push --dry-run origin HEAD`")
-        && files.developer.includes("manual\nfallback in the Developer Result"),
+        && files.developer.includes("manual fallback in the\nDeveloper Result"),
     "developer PR path must verify publication credentials and provide the manual fallback",
 );
 assert(
@@ -97,35 +102,35 @@ assert(
     agentIds.length === 3 && ["orchestrator", "developer", "reviewer"].every((agent) => agentIds.includes(agent)),
     "only the three simple-workflow agents may exist",
 );
-assert(files.design.includes("Orchestrator -> Developer -> Reviewer"), "design must define the three-role workflow");
-assert(files.design.includes("does not use child sessions"), "design must reject child-session handoffs");
-assert(files.design.includes("returned response is the handoff"), "design must define direct result handoff");
-assert(files.design.includes("needs-changes") && files.design.includes("automatic repair loop"), "design must stop instead of auto-repairing review findings");
+assert(files.design.includes("triage/dispatch -> per-issue delivery"), "design must define the dispatch + per-issue workflow");
+assert(files.design.includes("dispatches one isolated subsession per shortlisted issue"), "design must dispatch one subsession per issue");
+assert(files.design.includes("The Orchestrator never researches, plans, builds, reviews, or publishes"), "design must keep Orchestrator triage-only");
 assert(
-    files.design.includes("Orchestrator | Choose one backlog item")
-        && files.design.includes("execute commands, create sessions, write GitHub state, push, create a PR"),
-    "design must keep the Orchestrator read/delegate/report-only",
+    files.design.includes("Subsession | Research its issue, produce one Execution Plan"),
+    "design must give the subsession research and planning",
+);
+assert(files.design.includes("needs-changes") && files.design.includes("bounded"), "design must bound the repair loop");
+assert(
+    files.design.includes("Orchestrator | Read the backlog, select the high-priority issues")
+        && files.design.includes("execute commands, create sessions itself, write GitHub state, push, create a PR"),
+    "design must keep the Orchestrator read/report-only",
 );
 assert(
-    files.design.includes("When a requested step needs a capability that Orchestrator does not have")
-        && files.design.includes("only to the subagent whose documented contract owns that step")
-        && files.design.includes("If neither subagent can own the step,\n   Orchestrator reports it as blocked."),
-    "design must route unavailable Orchestrator capabilities to the owning subagent or report a block",
+    files.design.includes("host dispatches one isolated subsession per shortlisted issue")
+        && files.design.includes("`create_session` invocation is the sole handoff"),
+    "design must use host create_session as the sole dispatch handoff",
 );
 assert(
-    files.design.includes("Developer | Implement one approved execution plan and autonomously create one pre-review draft PR")
-        && files.design.includes("During approved implementation, Developer may autonomously")
-        && files.design.includes("exactly one draft PR"),
-    "design must allocate the bounded autonomous draft PR path to Developer",
+    files.design.includes("Developer | Implement one approved Execution Plan; after review passes, finalize and create exactly one PR")
+        && files.design.includes("create a PR before review"),
+    "design must allocate the post-review PR to Developer",
 );
 assert(
-    files.design.includes("This occurs before Reviewer runs: the draft")
-        && files.design.includes("PR is explicitly pre-review")
-        && files.design.includes("does not alter")
-        && files.design.includes("Reviewer's independent review")
-        && files.design.includes("No agent")
-        && files.design.includes("changes the draft PR after review"),
-    "design must preserve the pre-review draft PR and independent Reviewer flow",
+    files.design.includes("Developer does not create a pull request before review")
+        && files.design.includes("review gate is mandatory")
+        && files.design.includes("**exactly one** pull")
+        && files.design.includes("Developer records the PR URL and outcome in its Developer Result"),
+    "design must require the review gate before the single PR",
 );
 assert(
     files.design.includes("## Publication capability")
@@ -140,4 +145,4 @@ if (failures.length > 0) {
     throw new Error(`Delivery contract validation failed:\n${failures.join("\n")}`);
 }
 
-console.log("Validated the Orchestrator -> Developer -> Reviewer workflow.");
+console.log("Validated the dispatch + per-issue delivery workflow.");


### PR DESCRIPTION
## Why

The delivery workflow was a single `Orchestrator -> Developer -> Reviewer` chain where the Orchestrator planned one backlog item, ran both subagents in-process, and never used child sessions. That couples triage (reading the backlog) with per-issue research, planning, and implementation, so work doesn't scale to multiple issues and the Orchestrator carries every issue's context.

This change splits the two concerns: a lightweight Orchestrator that only triages the backlog, and one isolated subsession per shortlisted issue that owns all research/planning for that issue.

## What changed

**Docs (`docs/agents/simple-delivery.md`, v1.0.5 -> v1.1.0)**
- Orchestrator is now triage/dispatch-only: it reads the live backlog, selects high-priority issues, and reports a prioritized shortlist to the host. It no longer researches, plans, builds, reviews, or publishes.
- The host dispatches one isolated subsession per shortlisted issue via `create_session`; that is the sole dispatch handoff. A subsession owns research + planning (produces the Execution Plan), then runs build -> review -> finalize -> PR.
- PR timing changed: Developer no longer creates a pre-review draft PR. The review gate is mandatory and Developer creates exactly one PR after Reviewer passes the change, subject to the publication gate.

**Agent definitions**
- `orchestrator.agent.md`: now `read`/`search`/`github/*` only, dropped the `agent` tool and dev/reviewer delegation; prohibits edit, execute, session creation, and follow-up.
- `developer.agent.md`: PR is now post-review + finalize (not a pre-review draft); preserved the publication capability gate (`gh auth status` + `git push --dry-run origin HEAD`) and the Developer Result contract.
- `reviewer.agent.md`: role unchanged; handoff target wording updated to "subsession."

**Validation**
- `scripts/validate-delivery-contract.mjs` rewritten to assert the new dispatch + per-issue contract. Output: `Validated the dispatch + per-issue delivery workflow.`

## Notes for reviewers

- Added a bounded repair loop: a `needs-changes` review triggers at most one additional Developer + Reviewer pass before the subsession stops with a blocked outcome.
- Custom agents cannot call `create_session` themselves, so dispatch correctly lives with the host (the main session), matching the design.
- All agent files remain on verified frontmatter tools only; no wildcard toolsets.